### PR TITLE
Add StockLevels navigation to Part model

### DIFF
--- a/Models/Part.cs
+++ b/Models/Part.cs
@@ -83,6 +83,9 @@ namespace YasGMP.Models
         /// <summary>Stock movement/change history.</summary>
         public List<StockChangeLog> StockHistory { get; set; } = new();
 
+        /// <summary>Aggregated stock levels over time.</summary>
+        public List<StockLevel> StockLevels { get; set; } = new();
+
         /// <summary>Primary storage location (quick view).</summary>
         [StringLength(100)]
         [Display(Name = "Lokacija")]


### PR DESCRIPTION
## Summary
- add the StockLevels collection navigation to the Part entity so EF mappings compile

## Testing
- dotnet build *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca5d88f24c8331a9ca71636fdc80e6