### PR TITLE
Align navigation with registered Shell routes

### DIFF
--- a/ViewModels/LoginViewModel.cs
+++ b/ViewModels/LoginViewModel.cs
@@ -417,7 +417,7 @@ namespace YasGMP.ViewModels
 
         /// <summary>
         /// Centralized, UI-thread-safe switch to <see cref="AppShell"/> as the root and navigation
-        /// to the dashboard tab. Uses an absolute Shell route (<c>///routes/dashboard</c>) so the
+        /// to the dashboard tab. Uses the absolute Shell route (<c>//root/home/dashboard</c>) so the
         /// stack is clean and <see cref="Shell.Current"/> is guaranteed non-null afterwards.
         /// </summary>
         private static async Task SwitchToShellDashboardAsync()
@@ -427,7 +427,7 @@ namespace YasGMP.ViewModels
                 Application.Current!.MainPage = new AppShell();
                 if (Shell.Current is not null)
                 {
-                    await Shell.Current.GoToAsync("///routes/dashboard");
+                    await Shell.Current.GoToAsync("//root/home/dashboard");
                 }
             });
         }

--- a/ViewModels/MainPageViewModel.cs
+++ b/ViewModels/MainPageViewModel.cs
@@ -1,4 +1,5 @@
 using Microsoft.Maui.Controls;
+using System.Threading.Tasks;
 using System.Windows.Input;
 
 namespace YasGMP.ViewModels
@@ -33,10 +34,6 @@ namespace YasGMP.ViewModels
         public ICommand OpenValidationCommand { get; }
         /// <summary>Komanda za CAPA slučajeve.</summary>
         public ICommand OpenCapaCommand { get; }
-        /// <summary>Komanda za SOP/dokumentaciju.</summary>
-        public ICommand OpenSopCommand { get; }
-        /// <summary>Komanda za inspekcije.</summary>
-        public ICommand OpenInspectionsCommand { get; }
         /// <summary>Komanda za izvještaje (reports/dashboard).</summary>
         public ICommand OpenReportsCommand { get; }
         /// <summary>Komanda za GMP/Audit log.</summary>
@@ -56,75 +53,81 @@ namespace YasGMP.ViewModels
             OpenCalibrationsCommand = new Command(OpenCalibrations);
             OpenValidationCommand = new Command(OpenValidation);
             OpenCapaCommand = new Command(OpenCapa);
-            OpenSopCommand = new Command(OpenSop);
-            OpenInspectionsCommand = new Command(OpenInspections);
             OpenReportsCommand = new Command(OpenReports);
             OpenAuditLogCommand = new Command(OpenAuditLog);
         }
 
+        private static class Routes
+        {
+            public const string Dashboard    = "//root/home/dashboard";
+            public const string Users        = "//root/admin/users";
+            public const string Machines     = "//root/ops/machines";
+            public const string Components   = "//root/ops/components";
+            public const string Parts        = "//root/ops/parts";
+            public const string Suppliers    = "//root/ops/suppliers";
+            public const string WorkOrders   = "//root/ops/workorders";
+            public const string Calibrations = "//root/ops/calibrations";
+            public const string Validation   = "//root/quality/validation";
+            public const string Capa         = "//root/quality/capa";
+            public const string AuditLog     = "//root/quality/auditlog";
+        }
+
+        private static Task NavigateAsync(string route)
+            => Shell.Current is null ? Task.CompletedTask : Shell.Current.GoToAsync(route);
+
         /// <summary>
         /// Otvara ekran za korisnike.
         /// </summary>
-        private async void OpenUsers() => await Shell.Current.GoToAsync("//UsersPage");
+        private async void OpenUsers() => await NavigateAsync(Routes.Users);
 
         /// <summary>
         /// Otvara ekran za strojeve.
         /// </summary>
-        private async void OpenMachines() => await Shell.Current.GoToAsync("//MachinesPage");
+        private async void OpenMachines() => await NavigateAsync(Routes.Machines);
 
         /// <summary>
         /// Otvara ekran za komponente.
         /// </summary>
-        private async void OpenComponents() => await Shell.Current.GoToAsync("//ComponentsPage");
+        private async void OpenComponents() => await NavigateAsync(Routes.Components);
 
         /// <summary>
         /// Otvara ekran za dijelove (Parts).
         /// </summary>
-        private async void OpenParts() => await Shell.Current.GoToAsync("//PartsPage");
+        private async void OpenParts() => await NavigateAsync(Routes.Parts);
 
         /// <summary>
         /// Otvara ekran za dobavljače.
         /// </summary>
-        private async void OpenSuppliers() => await Shell.Current.GoToAsync("//SuppliersPage");
+        private async void OpenSuppliers() => await NavigateAsync(Routes.Suppliers);
 
         /// <summary>
         /// Otvara ekran za radne naloge.
         /// </summary>
-        private async void OpenWorkOrders() => await Shell.Current.GoToAsync("//WorkOrdersPage");
+        private async void OpenWorkOrders() => await NavigateAsync(Routes.WorkOrders);
 
         /// <summary>
         /// Otvara ekran za kalibracije.
         /// </summary>
-        private async void OpenCalibrations() => await Shell.Current.GoToAsync("//CalibrationsPage");
+        private async void OpenCalibrations() => await NavigateAsync(Routes.Calibrations);
 
         /// <summary>
         /// Otvara ekran za validacije/kvalifikacije (IQ/OQ/PQ/URS).
         /// </summary>
-        private async void OpenValidation() => await Shell.Current.GoToAsync("//ValidationPage");
+        private async void OpenValidation() => await NavigateAsync(Routes.Validation);
 
         /// <summary>
         /// Otvara ekran za CAPA slučajeve.
         /// </summary>
-        private async void OpenCapa() => await Shell.Current.GoToAsync("//CapaPage");
+        private async void OpenCapa() => await NavigateAsync(Routes.Capa);
 
         /// <summary>
-        /// Otvara ekran za SOP dokumente.
+        /// Otvara glavni dashboard s izvještajima.
         /// </summary>
-        private async void OpenSop() => await Shell.Current.GoToAsync("//SopPage");
-
-        /// <summary>
-        /// Otvara ekran za inspekcije.
-        /// </summary>
-        private async void OpenInspections() => await Shell.Current.GoToAsync("//InspectionsPage");
-
-        /// <summary>
-        /// Otvara ekran za izvještaje/dashboard.
-        /// </summary>
-        private async void OpenReports() => await Shell.Current.GoToAsync("//ReportsPage");
+        private async void OpenReports() => await NavigateAsync(Routes.Dashboard);
 
         /// <summary>
         /// Otvara ekran za audit/GMP log.
         /// </summary>
-        private async void OpenAuditLog() => await Shell.Current.GoToAsync("//AuditLogPage");
+        private async void OpenAuditLog() => await NavigateAsync(Routes.AuditLog);
     }
 }

--- a/Views/DashboardPage.xaml.cs
+++ b/Views/DashboardPage.xaml.cs
@@ -22,12 +22,12 @@ namespace YasGMP
     {
         private static class AppRoutes
         {
-            public const string Machines   = "routes/machines";
-            public const string Parts      = "routes/parts";
-            public const string WorkOrders = "routes/workorders";
-            public const string Capa       = "routes/capa";
-            public const string Validation = "routes/validation";
-            public const string AdminPanel = "routes/adminpanel";
+            public const string Machines   = "//root/ops/machines";
+            public const string Parts      = "//root/ops/parts";
+            public const string WorkOrders = "//root/ops/workorders";
+            public const string Capa       = "//root/quality/capa";
+            public const string Validation = "//root/quality/validation";
+            public const string AdminPanel = "//root/admin/adminpanel";
         }
 
         public User? CurrentUser { get; private set; }

--- a/Views/MainPage.xaml
+++ b/Views/MainPage.xaml
@@ -27,10 +27,11 @@
           <Button Text="Kalibracije"              Command="{Binding OpenCalibrationsCommand}"/>
           <Button Text="Korisnici"                 Command="{Binding OpenUsersCommand}"      />
           <Button Text="Audit log"                 Command="{Binding OpenAuditLogCommand}"   />
-          <Button Text="SOP / Dokumentacija"      Command="{Binding OpenSopCommand}"        />
-          <Button Text="Inspekcije"               Command="{Binding OpenInspectionsCommand}"/>
+          <Button Text="Strojevi"                  Command="{Binding OpenMachinesCommand}"   />
+          <Button Text="Komponente"                Command="{Binding OpenComponentsCommand}" />
           <Button Text="Dijelovi (Parts)"         Command="{Binding OpenPartsCommand}"      />
           <Button Text="CAPA"                      Command="{Binding OpenCapaCommand}"       />
+          <Button Text="Validacija / URS"         Command="{Binding OpenValidationCommand}" />
           <Button Text="Dobavljači i Serviseri"   Command="{Binding OpenSuppliersCommand}"  />
           <Button Text="Izvještaji / Dashboard"   Command="{Binding OpenReportsCommand}"    />
         </VerticalStackLayout>


### PR DESCRIPTION
## Summary
- route MainPageViewModel commands through the Shell's absolute //root/... paths and drop bindings to non-existent pages
- refresh the dashboard and main page buttons to target the same registered tabs
- redirect post-login navigation to the Shell dashboard route for consistency

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca64e8dc6c8331b759ba37bf04d044