### PR TITLE
Refactor operations pages to use injected services

### DIFF
--- a/Common/ServiceLocator.cs
+++ b/Common/ServiceLocator.cs
@@ -1,0 +1,53 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Controls;
+
+namespace YasGMP.Common
+{
+    /// <summary>
+    /// Centralized helper for resolving services when constructor injection
+    /// is not possible (e.g., XAML-instantiated pages). Stores the root
+    /// <see cref="IServiceProvider"/> configured in <see cref="MauiProgram"/>
+    /// and falls back to <see cref="Application.Handler"/> when necessary.
+    /// </summary>
+    public static class ServiceLocator
+    {
+        private static IServiceProvider? _services;
+
+        /// <summary>
+        /// Initializes the locator with the application's root service provider.
+        /// Safe to call multiple times; the last non-null provider wins.
+        /// </summary>
+        /// <param name="provider">The MAUI app service provider.</param>
+        public static void Initialize(IServiceProvider provider)
+        {
+            _services = provider ?? throw new ArgumentNullException(nameof(provider));
+        }
+
+        /// <summary>
+        /// Gets the active <see cref="IServiceProvider"/> (locator → Application.Handler → null).
+        /// </summary>
+        private static IServiceProvider? CurrentProvider
+            => _services ?? Application.Current?.Handler?.MauiContext?.Services;
+
+        /// <summary>
+        /// Resolves a service if available, otherwise returns <c>null</c>.
+        /// </summary>
+        public static T? GetService<T>()
+        {
+            var provider = CurrentProvider;
+            return provider is null ? default : provider.GetService<T>();
+        }
+
+        /// <summary>
+        /// Resolves a required service, throwing a descriptive exception if unavailable.
+        /// </summary>
+        public static T GetRequiredService<T>() where T : notnull
+        {
+            var provider = CurrentProvider
+                ?? throw new InvalidOperationException("Service provider is not initialized. Ensure MauiProgram.CreateMauiApp() calls ServiceLocator.Initialize().");
+
+            return provider.GetRequiredService<T>();
+        }
+    }
+}

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Collections.Generic;                  // IEnumerable<>
+using YasGMP.Common;
 using YasGMP.Data;
 using YasGMP.Services;
 using YasGMP.Services.Interfaces;                  // IRBACService
@@ -171,6 +172,8 @@ namespace YasGMP
             builder.Services.AddTransient<UserViewModel>();
             builder.Services.AddTransient<UserRolePermissionViewModel>();
             builder.Services.AddTransient<MachineViewModel>(); // NEW
+            builder.Services.AddTransient<CalibrationsViewModel>();
+            builder.Services.AddTransient<PpmViewModel>();
 
             // Pages
             builder.Services.AddTransient<YasGMP.Views.LoginPage>();
@@ -179,6 +182,15 @@ namespace YasGMP
             builder.Services.AddTransient<YasGMP.Views.AdminPanelPage>();
             builder.Services.AddTransient<YasGMP.Views.UsersPage>();
             builder.Services.AddTransient<YasGMP.Views.UserRolePermissionPage>();
+            builder.Services.AddTransient<YasGMP.Views.CalibrationsPage>();
+            builder.Services.AddTransient<YasGMP.Views.MachinesPage>();
+            builder.Services.AddTransient<YasGMP.Views.PartsPage>();
+            builder.Services.AddTransient<YasGMP.Views.WorkOrdersPage>();
+            builder.Services.AddTransient<YasGMP.Views.ComponentsPage>();
+            builder.Services.AddTransient<YasGMP.Views.SuppliersPage>();
+            builder.Services.AddTransient<YasGMP.ExternalServicersPage>();
+            builder.Services.AddTransient<YasGMP.Pages.PpmPage>();
+            builder.Services.AddTransient<YasGMP.Views.ValidationPage>();
             // Debug pages (RBAC-gated in page code-behind)
             builder.Services.AddTransient<YasGMP.Views.Debug.DebugDashboardPage>();
             builder.Services.AddTransient<YasGMP.Views.Debug.LogViewerPage>();
@@ -206,7 +218,9 @@ namespace YasGMP
             AppDataFileLoggerProvider.WriteFrameworkLine("CFG", "info", $"ConnString (redacted): {Redact(mysqlConnStr)}");
 #endif
 
-            return builder.Build();
+            var app = builder.Build();
+            ServiceLocator.Initialize(app.Services);
+            return app;
         }
 
         /// <summary>

--- a/Views/CalibrationsPage.xaml
+++ b/Views/CalibrationsPage.xaml
@@ -3,14 +3,8 @@
     x:Class="YasGMP.Views.CalibrationsPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:vm="clr-namespace:YasGMP.ViewModels"
     Title="Kalibracije – YasGMP"
     BackgroundColor="#f5f7fa">
-
-    <!-- ViewModel Binding -->
-    <ContentPage.BindingContext>
-        <vm:CalibrationsViewModel />
-    </ContentPage.BindingContext>
 
     <ContentPage.Resources>
         <ResourceDictionary>

--- a/Views/ComponentsPage.xaml.cs
+++ b/Views/ComponentsPage.xaml.cs
@@ -15,9 +15,9 @@ using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls;
 using MySqlConnector;
+using YasGMP.Common;
 using YasGMP.Models;
 using YasGMP.Services;
-using MySqlConnector;
 
 namespace YasGMP.Views
 {
@@ -36,32 +36,22 @@ namespace YasGMP.Views
         /// Inicijalizira stranicu, rješava konekcijski string i učitava podatke.
         /// </summary>
         /// <exception cref="InvalidOperationException">Ako aplikacija nema connection string.</exception>
-        public ComponentsPage()
+        public ComponentsPage(DatabaseService dbService)
         {
             InitializeComponent();
 
-            var connStr = ResolveMySqlConnectionStringFromApp();
-            _dbService = new DatabaseService(connStr);
+            _dbService = dbService ?? throw new ArgumentNullException(nameof(dbService));
 
             BindingContext = this;
+
+            _ = LoadMachinesAsync();
             _ = LoadComponentsAsync();
         }
 
-        private static string ResolveMySqlConnectionStringFromApp()
+        /// <summary>Parameterless ctor for Shell/XAML koji koristi ServiceLocator.</summary>
+        public ComponentsPage()
+            : this(ServiceLocator.GetRequiredService<DatabaseService>())
         {
-            if (Application.Current is not App app)
-                throw new InvalidOperationException("Application.Current nije tipa App.");
-
-            var viaSection = app.AppConfig?["ConnectionStrings:MySqlDb"];
-            var viaFlat    = app.AppConfig?["MySqlDb"];
-            var conn       = !string.IsNullOrWhiteSpace(viaSection) ? viaSection
-                           : !string.IsNullOrWhiteSpace(viaFlat)    ? viaFlat
-                           : null;
-
-            if (string.IsNullOrWhiteSpace(conn))
-                throw new InvalidOperationException("MySqlDb connection string nije pronađen u konfiguraciji.");
-
-            return conn!;
         }
 
         /// <summary>

--- a/Views/ExternalServicersPage.xaml.cs
+++ b/Views/ExternalServicersPage.xaml.cs
@@ -19,6 +19,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel; // MainThread
 using Microsoft.Maui.Controls;
+using YasGMP.Common;
 using YasGMP.Models;
 using YasGMP.Services;
 using ExternalServicer = YasGMP.Models.ExternalContractor;
@@ -50,25 +51,24 @@ namespace YasGMP
         /// Inicijalizira stranicu, validira konfiguraciju i učitava podatke.
         /// </summary>
         /// <exception cref="InvalidOperationException">Ako konfiguracija ili konekcijski string nisu dostupni.</exception>
-        public ExternalServicersPage()
+        public ExternalServicersPage(DatabaseService dbService)
         {
-            InitializeComponent(); // use source-generated InitializeComponent
+            InitializeComponent();
 
-            var app = Application.Current as App ?? throw new InvalidOperationException("Application.Current nije tipa App.");
-
-            // Robusno dohvaćanje connection stringa (podrži i ravni i sekcijski ključ)
-            var connStr = app.AppConfig?["ConnectionStrings:MySqlDb"] ?? app.AppConfig?["MySqlDb"];
-            if (string.IsNullOrWhiteSpace(connStr))
-                throw new InvalidOperationException("MySqlDb connection string nije pronađen u konfiguraciji.");
-
-            _dbService = new DatabaseService(connStr);
+            _dbService = dbService ?? throw new ArgumentNullException(nameof(dbService));
 
             BindingContext = this;
 
-            // Fire-and-forget inicijalno punjenje (metode same rješavaju iznimke i UI maršaliranje)
             _ = LoadLookupsAsync();
             _ = LoadExternalServicersAsync();
         }
+
+        /// <summary>Parameterless ctor za Shell/XAML (ServiceLocator fallback).</summary>
+        public ExternalServicersPage()
+            : this(ServiceLocator.GetRequiredService<DatabaseService>())
+        {
+        }
+
 
         #region === Reflection helpers (schema tolerant) ===
 

--- a/Views/PartsPage.xaml.cs
+++ b/Views/PartsPage.xaml.cs
@@ -17,6 +17,7 @@ using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel;             // MainThread
 using Microsoft.Maui.Controls;
 using MySqlConnector;
+using YasGMP.Common;
 using YasGMP.Models;
 using YasGMP.Services;
 using ClosedXML.Excel;
@@ -48,40 +49,22 @@ namespace YasGMP.Views
         /// Inicijalizira stranicu i uÄ‚„Ă˘â‚¬ĹˇÄ‚ËĂ˘‚¬ÄąÄľĂ„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ă„Ä…Ă‹â€ˇÄ‚„Ă˘â‚¬ĹˇÄ‚â€ąĂ‚Ă„‚Ă‹Ä‚ËĂ˘‚¬ÄąË‡Ä‚‚Ă‚¬Ä‚„Ă„…Ä‚„Ă„ÄľÄ‚„Ă˘â‚¬ĹˇÄ‚ËĂ˘‚¬ÄąÄľĂ„‚Ă˘â‚¬ĹľÄ‚ËĂ˘‚¬Ă‚¦Ä‚„Ă˘â‚¬ĹˇÄ‚ËĂ˘‚¬ÄąË‡Ă„‚Ă˘â‚¬ĹˇÄ‚‚Ă‚¤itava dijelove. Sigurno dohvaÄ‚„Ă˘â‚¬ĹˇÄ‚ËĂ˘‚¬ÄąÄľĂ„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ă„Ä…Ă‹â€ˇÄ‚„Ă˘â‚¬ĹˇÄ‚â€ąĂ‚Ă„‚Ă‹Ä‚ËĂ˘‚¬ÄąË‡Ä‚‚Ă‚¬Ä‚„Ă„…Ä‚„Ă„ÄľĂ„‚Ă˘â‚¬ĹľÄ‚ËĂ˘‚¬ÄąË‡Ă„‚Ă˘â‚¬Ä…Ä‚‚Ă‚Ä‚„Ă˘â‚¬ĹˇÄ‚â€ąĂ‚Ă„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ă„Ä…Ă‹â€ˇĂ„‚Ă˘â‚¬ĹˇÄ‚‚Ă‚¬Ä‚„Ă˘â‚¬ĹˇÄ‚ËĂ˘‚¬Ă„…Ă„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ä‚â€ąĂ˘â‚¬Ë‡a konekcijski string.
         /// </summary>
         /// <exception cref="InvalidOperationException">Ako aplikacija ili konekcijski string nisu dostupni.</exception>
-        public PartsPage()
+        public PartsPage(DatabaseService dbService)
         {
             InitializeComponent();
 
-            var connStr = ResolveMySqlConnectionStringFromApp();
-            _dbService = new DatabaseService(connStr);
+            _dbService = dbService ?? throw new ArgumentNullException(nameof(dbService));
 
             BindingContext = this;
 
-            // Ne blokirati UI Ä‚„Ă˘â‚¬ĹˇÄ‚ËĂ˘‚¬ÄąÄľĂ„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ă„Ä…Ă‹â€ˇÄ‚„Ă˘â‚¬ĹˇÄ‚ËĂ˘‚¬Ă„…Ă„‚Ă˘â‚¬ĹˇÄ‚‚Ă‚Ă„‚Ă˘â‚¬ĹľÄ‚ËĂ˘‚¬ÄąË‡Ă„‚Ă˘â‚¬Ä…Ä‚‚Ă‚Ä‚„Ă˘â‚¬ĹˇÄ‚â€ąĂ‚Ă„‚Ă‹Ä‚ËĂ˘‚¬ÄąË‡Ä‚‚Ă‚¬Ä‚„Ă„…Ä‚â€ąĂ˘â‚¬Ë‡Ä‚„Ă˘â‚¬ĹˇÄ‚ËĂ˘‚¬ÄąË‡Ă„‚Ă˘â‚¬ĹˇÄ‚‚Ă‚¬Ă„‚Ă˘â‚¬ĹľÄ‚ËĂ˘‚¬ÄąË‡Ă„‚Ă˘â‚¬Ä…Ä‚‚Ă‚Ä‚„Ă˘â‚¬ĹˇÄ‚â€ąĂ‚Ă„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ă„Ä…Ă‹â€ˇĂ„‚Ă˘â‚¬ĹˇÄ‚‚Ă‚¬Ă„‚Ă˘â‚¬ĹľÄ‚„Ă˘â‚¬¦Ă„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ă„Ä…ÄąĹź metoda sama marĂ„‚Ă˘â‚¬ĹľÄ‚ËĂ˘‚¬ÄąË‡Ă„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ă„Ä…Ă„ÄľÄ‚„Ă˘â‚¬ĹˇÄ‚ËĂ˘‚¬ÄąÄľĂ„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ä‚‚Ă‚¦Ă„‚Ă˘â‚¬ĹľÄ‚ËĂ˘‚¬ÄąË‡Ă„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ä‚„Ă˘â‚¬¦Ä‚„Ă˘â‚¬ĹˇÄ‚â€ąĂ‚Ă„‚Ă‹Ä‚ËĂ˘‚¬ÄąË‡Ä‚‚Ă‚¬Ă„‚Ă˘â‚¬Ä…Ä‚ËĂ˘‚¬Ă‹â€ˇalira UI aĂ„‚Ă˘â‚¬ĹľÄ‚ËĂ˘‚¬ÄąË‡Ă„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ă„Ä…Ă„ÄľÄ‚„Ă˘â‚¬ĹˇÄ‚ËĂ˘‚¬ÄąÄľĂ„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ä‚‚Ă‚¦Ă„‚Ă˘â‚¬ĹľÄ‚ËĂ˘‚¬ÄąË‡Ă„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ă„Ä…Ă„ÄľÄ‚„Ă˘â‚¬ĹˇÄ‚ËĂ˘‚¬ÄąÄľĂ„‚Ă˘â‚¬ĹľÄ‚„Ă„Äľuriranja
+            // Ne blokirati UI – metoda sama maršalira UI ažuriranja
             _ = LoadPartsAsync();
         }
 
-        /// <summary>
-        /// Sigurno dohvaÄ‚„Ă˘â‚¬ĹˇÄ‚ËĂ˘‚¬ÄąÄľĂ„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ă„Ä…Ă‹â€ˇÄ‚„Ă˘â‚¬ĹˇÄ‚â€ąĂ‚Ă„‚Ă‹Ä‚ËĂ˘‚¬ÄąË‡Ä‚‚Ă‚¬Ä‚„Ă„…Ä‚„Ă„ÄľĂ„‚Ă˘â‚¬ĹľÄ‚ËĂ˘‚¬ÄąË‡Ă„‚Ă˘â‚¬Ä…Ä‚‚Ă‚Ä‚„Ă˘â‚¬ĹˇÄ‚â€ąĂ‚Ă„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ă„Ä…Ă‹â€ˇĂ„‚Ă˘â‚¬ĹˇÄ‚‚Ă‚¬Ä‚„Ă˘â‚¬ĹˇÄ‚ËĂ˘‚¬Ă„…Ă„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ä‚â€ąĂ˘â‚¬Ë‡a MySQL connection string iz <see cref="App.AppConfig"/> bez ovisnosti o ekstenzijama.
-        /// PokuĂ„‚Ă˘â‚¬ĹľÄ‚ËĂ˘‚¬ÄąË‡Ă„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ă„Ä…Ă„ÄľÄ‚„Ă˘â‚¬ĹˇÄ‚ËĂ˘‚¬ÄąÄľĂ„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ä‚‚Ă‚¦Ă„‚Ă˘â‚¬ĹľÄ‚ËĂ˘‚¬ÄąË‡Ă„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ä‚„Ă˘â‚¬¦Ä‚„Ă˘â‚¬ĹˇÄ‚â€ąĂ‚Ă„‚Ă‹Ä‚ËĂ˘‚¬ÄąË‡Ä‚‚Ă‚¬Ă„‚Ă˘â‚¬Ä…Ä‚ËĂ˘‚¬Ă‹â€ˇava i ravni kljuÄ‚„Ă˘â‚¬ĹˇÄ‚ËĂ˘‚¬ÄąÄľĂ„‚Ă‹Ä‚ËĂ˘â‚¬ĹˇĂ‚¬Ă„Ä…Ă‹â€ˇÄ‚„Ă˘â‚¬ĹˇÄ‚â€ąĂ‚Ă„‚Ă‹Ä‚ËĂ˘‚¬ÄąË‡Ä‚‚Ă‚¬Ä‚„Ă„…Ä‚„Ă„ÄľÄ‚„Ă˘â‚¬ĹˇÄ‚ËĂ˘‚¬ÄąÄľĂ„‚Ă˘â‚¬ĹľÄ‚ËĂ˘‚¬Ă‚¦Ä‚„Ă˘â‚¬ĹˇÄ‚ËĂ˘‚¬ÄąË‡Ă„‚Ă˘â‚¬ĹˇÄ‚‚Ă‚¤ (<c>MySqlDb</c>) i sekcijski (<c>ConnectionStrings:MySqlDb</c>).
-        /// </summary>
-        private static string ResolveMySqlConnectionStringFromApp()
+        /// <summary>Parameterless ctor for Shell/XAML; resolves dependencies via ServiceLocator.</summary>
+        public PartsPage()
+            : this(ServiceLocator.GetRequiredService<DatabaseService>())
         {
-            if (Application.Current is not App app)
-                throw new InvalidOperationException("Application.Current nije tipa App.");
-
-            var cfg = app.AppConfig;
-            var viaSection = cfg?["ConnectionStrings:MySqlDb"];
-            var viaFlat    = cfg?["MySqlDb"];
-
-            var conn = !string.IsNullOrWhiteSpace(viaSection) ? viaSection
-                     : !string.IsNullOrWhiteSpace(viaFlat)    ? viaFlat
-                     : null;
-
-            if (string.IsNullOrWhiteSpace(conn))
-                throw new InvalidOperationException("MySqlDb connection string nije pronaÄ‚â€žĂ˘â‚¬ĹˇÄ‚ËĂ˘â€šÂ¬ÄąÄľĂ„â€šĂ‹ÂÄ‚ËĂ˘â‚¬ĹˇĂ‚Â¬Ă„Ä…Ă‹â€ˇÄ‚â€žĂ˘â‚¬ĹˇÄ‚â€ąĂ‚ÂĂ„â€šĂ‹ÂÄ‚ËĂ˘â€šÂ¬ÄąË‡Ä‚â€šĂ‚Â¬Ä‚â€žĂ„â€¦Ä‚â€žĂ„ÄľĂ„â€šĂ˘â‚¬ĹľÄ‚ËĂ˘â€šÂ¬ÄąË‡Ă„â€šĂ˘â‚¬Ä…Ä‚â€šĂ‚ÂÄ‚â€žĂ˘â‚¬ĹˇÄ‚â€ąĂ‚ÂĂ„â€šĂ‹ÂÄ‚ËĂ˘â‚¬ĹˇĂ‚Â¬Ă„Ä…Ă‹â€ˇĂ„â€šĂ˘â‚¬ĹˇÄ‚â€šĂ‚Â¬Ä‚â€žĂ˘â‚¬ĹˇÄ‚ËĂ˘â€šÂ¬ÄąË‡Ă„â€šĂ˘â‚¬ĹˇÄ‚â€šĂ‚Âen u konfiguraciji.");
-
-            return conn!;
         }
 
         /// <summary>

--- a/Views/SuppliersPage.xaml.cs
+++ b/Views/SuppliersPage.xaml.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel; // MainThread
 using Microsoft.Maui.Controls;
 using MySqlConnector;
+using YasGMP.Common;
 using YasGMP.Models;
 using YasGMP.Services;
 
@@ -30,37 +31,20 @@ namespace YasGMP.Views
         /// Konstruktor — inicijalizira UI, konfiguraciju i učitava podatke.
         /// </summary>
         /// <exception cref="InvalidOperationException">Ako konekcijski string nije dostupan.</exception>
-        public SuppliersPage()
+        public SuppliersPage(DatabaseService dbService)
         {
             InitializeComponent();
 
-            var connStr = ResolveMySqlConnectionStringFromApp();
-            _dbService = new DatabaseService(connStr);
+            _dbService = dbService ?? throw new ArgumentNullException(nameof(dbService));
 
             BindingContext = this;
             _ = LoadSuppliersAsync();
         }
 
-        /// <summary>
-        /// Vraća MySQL connection string iz <see cref="App.AppConfig"/>.
-        /// Pokušava i sekcijski (<c>ConnectionStrings:MySqlDb</c>) i ravni ključ (<c>MySqlDb</c>).
-        /// </summary>
-        private static string ResolveMySqlConnectionStringFromApp()
+        /// <summary>Parameterless ctor for Shell/XAML; koristi ServiceLocator.</summary>
+        public SuppliersPage()
+            : this(ServiceLocator.GetRequiredService<DatabaseService>())
         {
-            if (Application.Current is not App app)
-                throw new InvalidOperationException("Application.Current nije tipa App.");
-
-            var cfg       = app.AppConfig;
-            var viaSection = cfg?["ConnectionStrings:MySqlDb"];
-            var viaFlat    = cfg?["MySqlDb"];
-            var conn       = !string.IsNullOrWhiteSpace(viaSection) ? viaSection
-                           : !string.IsNullOrWhiteSpace(viaFlat)    ? viaFlat
-                           : null;
-
-            if (string.IsNullOrWhiteSpace(conn))
-                throw new InvalidOperationException("MySqlDb connection string nije pronađen u konfiguraciji.");
-
-            return conn!;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add a ServiceLocator helper and register additional view-models/pages in `MauiProgram` so MAUI navigation can resolve them from DI
- update the Calibrations/Machines/Parts/WorkOrders/Components/Suppliers/External Servicers pages to accept injected `DatabaseService` (and related helpers) instead of resolving connection strings manually
- shift CalibrationsViewModel, PpmPage, and ValidationPage to use injected services so diagnostics-enabled database access is shared consistently

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca6e6a46a883319ae91b32334143ec