### PR TITLE
Remove unused machine preload call from ComponentsPage

### DIFF
--- a/Views/ComponentsPage.xaml.cs
+++ b/Views/ComponentsPage.xaml.cs
@@ -44,7 +44,6 @@ namespace YasGMP.Views
 
             BindingContext = this;
 
-            _ = LoadMachinesAsync();
             _ = LoadComponentsAsync();
         }
 


### PR DESCRIPTION
## Summary
- remove the LoadMachinesAsync invocation from the ComponentsPage constructor to avoid referencing the missing method

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca74c506308331a4f5a00380d805fe