### PR TITLE
Fix admin and debug navigation routes

### DIFF
--- a/ViewModels/AdminViewModel.cs
+++ b/ViewModels/AdminViewModel.cs
@@ -730,7 +730,7 @@ namespace YasGMP.ViewModels
         [RelayCommand]
         public async Task OpenAuditAsync()
         {
-            await Services.SafeNavigator.GoToAsync("routes/auditlog").ConfigureAwait(false);
+            await Services.SafeNavigator.GoToAsync("//root/quality/auditlog").ConfigureAwait(false);
         }
 
         #endregion

--- a/Views/AdminPanelPage.xaml.cs
+++ b/Views/AdminPanelPage.xaml.cs
@@ -46,7 +46,7 @@ namespace YasGMP.Views
         {
             if (Shell.Current is not null)
             {
-                await Shell.Current.GoToAsync("routes/users").ConfigureAwait(false);
+                await Shell.Current.GoToAsync("//root/admin/users").ConfigureAwait(false);
             }
         }
     }

--- a/Views/Debug/DebugDashboardPage.xaml.cs
+++ b/Views/Debug/DebugDashboardPage.xaml.cs
@@ -53,12 +53,12 @@ namespace YasGMP.Views.Debug
 
         private async void OnViewLogs(object sender, EventArgs e)
         {
-            await Shell.Current.GoToAsync("routes/logviewer");
+            await Shell.Current.GoToAsync("//root/debug/logviewer");
         }
 
         private async void OnHealth(object sender, EventArgs e)
         {
-            await Shell.Current.GoToAsync("routes/health");
+            await Shell.Current.GoToAsync("//root/debug/health");
         }
 
         private void OnFlushElastic(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- update admin panel toolbar navigation to use the absolute Shell route for the Users tab
- point debug dashboard buttons at the registered log viewer and health Shell routes
- ensure the admin audit command routes to the quality audit log via SafeNavigator

## Testing
- `dotnet build` *(fails: `dotnet` CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7f7d02fc8331bf6ce722aa9b2297