### PR TITLE
Add warehouse movement history preview with UI timeline

### DIFF
--- a/AppShell.xaml
+++ b/AppShell.xaml
@@ -15,6 +15,7 @@
     <ToolbarItem Text="Work Orders"  Clicked="OnToolbarGoWorkOrders" />
     <ToolbarItem Text="Machines"     Clicked="OnToolbarGoMachines" />
     <ToolbarItem Text="Parts"        Clicked="OnToolbarGoParts" />
+    <ToolbarItem Text="Warehouses"   Clicked="OnToolbarGoWarehouses" />
     <ToolbarItem Text="Suppliers"    Clicked="OnToolbarGoSuppliers" />
     <ToolbarItem Text="Components"   Clicked="OnToolbarGoComponents" />
     <ToolbarItem Text="External"     Clicked="OnToolbarGoExternal" />
@@ -53,6 +54,8 @@
                     ContentTemplate="{DataTemplate views:CalibrationsPage}" />
       <ShellContent Title="Parts"         Route="parts"
                     ContentTemplate="{DataTemplate views:PartsPage}" />
+      <ShellContent Title="Warehouses"    Route="warehouses"
+                    ContentTemplate="{DataTemplate views:WarehousePage}" />
       <ShellContent Title="Suppliers"     Route="suppliers"
                     ContentTemplate="{DataTemplate views:SuppliersPage}" />
       <ShellContent Title="Components"    Route="components"

--- a/AppShell.xaml.cs
+++ b/AppShell.xaml.cs
@@ -18,6 +18,7 @@ namespace YasGMP
             public const string WorkOrders     = "//root/ops/workorders";
             public const string Machines       = "//root/ops/machines";
             public const string Parts          = "//root/ops/parts";
+            public const string Warehouses     = "//root/ops/warehouses";
             public const string Suppliers      = "//root/ops/suppliers";
             public const string Components     = "//root/ops/components";
             public const string External       = "//root/ops/externalservicers";
@@ -95,6 +96,7 @@ namespace YasGMP
         private async void OnToolbarGoWorkOrders(object s, EventArgs e) => await GoAsync(Paths.WorkOrders);
         private async void OnToolbarGoMachines  (object s, EventArgs e) => await GoAsync(Paths.Machines);
         private async void OnToolbarGoParts     (object s, EventArgs e) => await GoAsync(Paths.Parts);
+        private async void OnToolbarGoWarehouses(object s, EventArgs e) => await GoAsync(Paths.Warehouses);
         private async void OnToolbarGoSuppliers (object s, EventArgs e) => await GoAsync(Paths.Suppliers);
         private async void OnToolbarGoComponents(object s, EventArgs e) => await GoAsync(Paths.Components);
         private async void OnToolbarGoExternal  (object s, EventArgs e) => await GoAsync(Paths.External);

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -174,6 +174,7 @@ namespace YasGMP
             builder.Services.AddTransient<MachineViewModel>(); // NEW
             builder.Services.AddTransient<CalibrationsViewModel>();
             builder.Services.AddTransient<PpmViewModel>();
+            builder.Services.AddTransient<WarehouseViewModel>();
 
             // Pages
             builder.Services.AddTransient<YasGMP.Views.LoginPage>();
@@ -185,6 +186,7 @@ namespace YasGMP
             builder.Services.AddTransient<YasGMP.Views.CalibrationsPage>();
             builder.Services.AddTransient<YasGMP.Views.MachinesPage>();
             builder.Services.AddTransient<YasGMP.Views.PartsPage>();
+            builder.Services.AddTransient<YasGMP.Views.WarehousePage>();
             builder.Services.AddTransient<YasGMP.Views.WorkOrdersPage>();
             builder.Services.AddTransient<YasGMP.Views.ComponentsPage>();
             builder.Services.AddTransient<YasGMP.Views.SuppliersPage>();

--- a/Views/WarehousePage.xaml
+++ b/Views/WarehousePage.xaml
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="YasGMP.Views.WarehousePage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    Title="Skladišta – YasGMP">
+  <ScrollView>
+    <Grid Padding="24"
+          ColumnSpacing="18"
+          RowSpacing="18"
+          RowDefinitions="Auto,Auto,*"
+          ColumnDefinitions="320,*">
+
+      <Frame Grid.ColumnSpan="2"
+             BackgroundColor="{StaticResource YtSurfaceCard}"
+             BorderColor="{StaticResource YtRowBorder}"
+             Padding="12">
+        <VerticalStackLayout Spacing="4">
+          <Label Text="{Binding StatusMessage}"
+                 FontSize="14"
+                 TextColor="{StaticResource YtOnSurface}" />
+          <Label Text="{Binding GlobalLowStockSummary}"
+                 FontSize="12"
+                 TextColor="{StaticResource YtOnSurfaceDim}" />
+        </VerticalStackLayout>
+      </Frame>
+
+      <Frame Grid.Row="1"
+             Grid.Column="0"
+             BackgroundColor="{StaticResource YtSurfaceCard}"
+             BorderColor="{StaticResource YtRowBorder}"
+             Padding="14"
+             HasShadow="True"
+             CornerRadius="14">
+        <VerticalStackLayout Spacing="10">
+          <Label Text="Skladišta"
+                 FontSize="18"
+                 FontAttributes="Bold"
+                 TextColor="{StaticResource YtPrimary700}" />
+          <CollectionView ItemsSource="{Binding Warehouses}"
+                          SelectionMode="Single"
+                          SelectedItem="{Binding SelectedWarehouse}"
+                          HeightRequest="360"
+                          BackgroundColor="{StaticResource YtSurface}">
+            <CollectionView.ItemTemplate>
+              <DataTemplate>
+                <Frame Margin="0,4"
+                       Padding="10"
+                       CornerRadius="10"
+                       BorderColor="{StaticResource YtRowBorder}"
+                       BackgroundColor="{StaticResource YtSurface}">
+                  <VerticalStackLayout Spacing="4">
+                    <Label Text="{Binding Name}"
+                           FontAttributes="Bold"
+                           TextColor="{StaticResource YtOnSurface}" />
+                    <Label Text="{Binding Location}"
+                           FontSize="12"
+                           TextColor="{StaticResource YtOnSurfaceDim}" />
+                    <Label Text="{Binding Status, StringFormat='Status: {0}'}"
+                           FontSize="12"
+                           TextColor="{StaticResource YtOnSurfaceDim}" />
+                    <Label Text="{Binding Note}"
+                           FontSize="11"
+                           TextColor="{StaticResource YtOnSurfaceDim}" />
+                  </VerticalStackLayout>
+                </Frame>
+              </DataTemplate>
+            </CollectionView.ItemTemplate>
+          </CollectionView>
+        </VerticalStackLayout>
+      </Frame>
+
+      <Grid Grid.Row="1"
+            Grid.Column="1"
+            RowDefinitions="Auto,*"
+            RowSpacing="18">
+        <Frame BackgroundColor="{StaticResource YtSurfaceCard}"
+               BorderColor="{StaticResource YtRowBorder}"
+               Padding="14"
+               HasShadow="True"
+               CornerRadius="14">
+          <VerticalStackLayout Spacing="10">
+            <Label Text="Artikli i zalihe"
+                   FontSize="18"
+                   FontAttributes="Bold"
+                   TextColor="{StaticResource YtPrimary700}" />
+            <Grid ColumnDefinitions="*,Auto"
+                  ColumnSpacing="10">
+              <SearchBar Grid.Column="0"
+                         Placeholder="Pretraži artikle (šifra ili naziv)"
+                         Text="{Binding PartSearchTerm}" />
+              <StackLayout Grid.Column="1"
+                           Orientation="Horizontal"
+                           Spacing="6"
+                           VerticalOptions="Center">
+                <CheckBox IsChecked="{Binding ShowOnlyLowStock}" />
+                <Label Text="Samo niski stock"
+                       VerticalOptions="Center"
+                       FontSize="13" />
+              </StackLayout>
+            </Grid>
+            <Label Text="{Binding SelectedWarehouseLowStockSummary}"
+                   FontSize="12"
+                   TextColor="{StaticResource YtOnSurfaceDim}" />
+            <CollectionView ItemsSource="{Binding FilteredParts}"
+                            SelectionMode="Single"
+                            SelectedItem="{Binding SelectedPart}"
+                            HeightRequest="260"
+                            BackgroundColor="{StaticResource YtSurface}">
+              <CollectionView.ItemTemplate>
+                <DataTemplate>
+                  <Frame Margin="0,4"
+                         Padding="10"
+                         CornerRadius="10"
+                         BorderColor="{StaticResource YtRowBorder}"
+                         BackgroundColor="{StaticResource YtSurface}">
+                    <VerticalStackLayout Spacing="4">
+                      <Label Text="{Binding PartName}"
+                             FontAttributes="Bold"
+                             TextColor="{StaticResource YtOnSurface}" />
+                      <Label Text="{Binding PartCode, StringFormat='Šifra: {0}'}"
+                             FontSize="12"
+                             TextColor="{StaticResource YtOnSurfaceDim}" />
+                      <Label Text="{Binding WarehouseName, StringFormat='Skladište: {0}'}"
+                             FontSize="12"
+                             TextColor="{StaticResource YtOnSurfaceDim}" />
+                      <HorizontalStackLayout Spacing="10">
+                        <Label Text="{Binding Quantity, StringFormat='Količina: {0}'}"
+                               FontSize="12"
+                               TextColor="{StaticResource YtPrimary700}" />
+                        <Label Text="{Binding WarehouseMin, StringFormat='Min: {0}'}"
+                               FontSize="12"
+                               TextColor="{StaticResource YtOnSurfaceDim}" />
+                      </HorizontalStackLayout>
+                      <Frame BackgroundColor="{StaticResource YtDanger50}"
+                             Padding="4,2"
+                             CornerRadius="6"
+                             IsVisible="{Binding IsLowStock}">
+                        <Label Text="⚠ Potrebna nadopuna"
+                               FontSize="11"
+                               TextColor="{StaticResource YtDanger700}" />
+                      </Frame>
+                    </VerticalStackLayout>
+                  </Frame>
+                </DataTemplate>
+              </CollectionView.ItemTemplate>
+            </CollectionView>
+          </VerticalStackLayout>
+        </Frame>
+
+        <Frame Grid.Row="1"
+               BackgroundColor="{StaticResource YtSurfaceCard}"
+               BorderColor="{StaticResource YtRowBorder}"
+               Padding="14"
+               HasShadow="True"
+               CornerRadius="14">
+          <VerticalStackLayout Spacing="10">
+            <Grid ColumnDefinitions="*,Auto"
+                  ColumnSpacing="10"
+                  VerticalOptions="Center">
+              <Label Text="Povijest kretanja zaliha"
+                     FontSize="18"
+                     FontAttributes="Bold"
+                     TextColor="{StaticResource YtPrimary700}" />
+              <Button Text="Osvježi"
+                      Command="{Binding RefreshMovementHistoryCommand}" />
+            </Grid>
+            <ActivityIndicator IsRunning="{Binding IsMovementHistoryLoading}"
+                               IsVisible="{Binding IsMovementHistoryLoading}" />
+            <Label Text="{Binding MovementHistoryStatus}"
+                   FontSize="12"
+                   TextColor="{StaticResource YtOnSurfaceDim}" />
+            <CollectionView ItemsSource="{Binding MovementHistory}"
+                            BackgroundColor="{StaticResource YtSurface}">
+              <CollectionView.EmptyView>
+                <VerticalStackLayout Spacing="8" Padding="12">
+                  <Label Text="Nema evidentiranih transakcija za prikaz." />
+                </VerticalStackLayout>
+              </CollectionView.EmptyView>
+              <CollectionView.ItemTemplate>
+                <DataTemplate>
+                  <Frame Margin="0,4"
+                         Padding="10"
+                         CornerRadius="10"
+                         BorderColor="{StaticResource YtRowBorder}"
+                         BackgroundColor="{StaticResource YtSurface}">
+                    <VerticalStackLayout Spacing="6">
+                      <Grid ColumnDefinitions="160,*,80"
+                            ColumnSpacing="10">
+                        <Label Grid.Column="0"
+                               Text="{Binding Timestamp, StringFormat='{0:yyyy-MM-dd HH:mm}'}"
+                               FontAttributes="Bold"
+                               TextColor="{StaticResource YtOnSurface}" />
+                        <Label Grid.Column="1"
+                               Text="{Binding TransactionType}"
+                               FontSize="12"
+                               TextColor="{StaticResource YtOnSurfaceDim}" />
+                        <Label Grid.Column="2"
+                               Text="{Binding Quantity, StringFormat='Qty: {0}'}"
+                               FontSize="12"
+                               HorizontalTextAlignment="End"
+                               TextColor="{StaticResource YtPrimary700}" />
+                      </Grid>
+                      <Label Text="{Binding RelatedDocument, StringFormat='Dokument: {0}'}"
+                             FontSize="12"
+                             TextColor="{StaticResource YtOnSurfaceDim}">
+                        <Label.Triggers>
+                          <DataTrigger TargetType="Label" Binding="{Binding RelatedDocument}" Value="">
+                            <Setter Property="IsVisible" Value="False" />
+                          </DataTrigger>
+                          <DataTrigger TargetType="Label" Binding="{Binding RelatedDocument}" Value="{x:Null}">
+                            <Setter Property="IsVisible" Value="False" />
+                          </DataTrigger>
+                        </Label.Triggers>
+                      </Label>
+                      <Label Text="{Binding Note, StringFormat='Napomena: {0}'}"
+                             FontSize="12"
+                             TextColor="{StaticResource YtOnSurface}">
+                        <Label.Triggers>
+                          <DataTrigger TargetType="Label" Binding="{Binding Note}" Value="">
+                            <Setter Property="IsVisible" Value="False" />
+                          </DataTrigger>
+                          <DataTrigger TargetType="Label" Binding="{Binding Note}" Value="{x:Null}">
+                            <Setter Property="IsVisible" Value="False" />
+                          </DataTrigger>
+                        </Label.Triggers>
+                      </Label>
+                      <Label Text="{Binding PerformedById, StringFormat='Izvršio korisnik ID: {0}'}"
+                             FontSize="11"
+                             TextColor="{StaticResource YtOnSurfaceDim}">
+                        <Label.Triggers>
+                          <DataTrigger TargetType="Label" Binding="{Binding PerformedById}" Value="{x:Null}">
+                            <Setter Property="IsVisible" Value="False" />
+                          </DataTrigger>
+                        </Label.Triggers>
+                      </Label>
+                    </VerticalStackLayout>
+                  </Frame>
+                </DataTemplate>
+              </CollectionView.ItemTemplate>
+            </CollectionView>
+          </VerticalStackLayout>
+        </Frame>
+      </Grid>
+    </Grid>
+  </ScrollView>
+</ContentPage>

--- a/Views/WarehousePage.xaml.cs
+++ b/Views/WarehousePage.xaml.cs
@@ -1,0 +1,24 @@
+using System;
+using Microsoft.Maui.Controls;
+using YasGMP.Common;
+using YasGMP.ViewModels;
+
+namespace YasGMP.Views
+{
+    public partial class WarehousePage : ContentPage
+    {
+        public WarehouseViewModel ViewModel { get; }
+
+        public WarehousePage(WarehouseViewModel viewModel)
+        {
+            InitializeComponent();
+            ViewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+            BindingContext = ViewModel;
+        }
+
+        public WarehousePage()
+            : this(ServiceLocator.GetRequiredService<WarehouseViewModel>())
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a database helper that returns inventory movement rows filtered by optional warehouse and part ids
- extend the warehouse view-model with movement history state, loading logic, and audit logging hooks
- introduce a warehouses page with parts and movement timeline UI, wiring it into the shell and dependency injection

## Testing
- `dotnet build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca83617d4483319b49efcc6c3fcae6