### PR TITLE
Add change control linking workflow for documents

### DIFF
--- a/AppShell.xaml
+++ b/AppShell.xaml
@@ -72,6 +72,8 @@
                     ContentTemplate="{DataTemplate views:CapaPage}" />
       <ShellContent Title="Validation"      Route="validation"
                     ContentTemplate="{DataTemplate views:ValidationPage}" />
+      <ShellContent Title="Documents"       Route="documents"
+                    ContentTemplate="{DataTemplate views:DocumentControlPage}" />
       <ShellContent Title="Audit Dashboard" Route="auditdashboard"
                     ContentTemplate="{DataTemplate views:AuditDashboardPage}" />
       <ShellContent Title="Audit Log"       Route="auditlog"

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -175,6 +175,7 @@ namespace YasGMP
             builder.Services.AddTransient<CalibrationsViewModel>();
             builder.Services.AddTransient<PpmViewModel>();
             builder.Services.AddTransient<WarehouseViewModel>();
+            builder.Services.AddTransient<DocumentControlViewModel>();
 
             // Pages
             builder.Services.AddTransient<YasGMP.Views.LoginPage>();
@@ -190,6 +191,7 @@ namespace YasGMP
             builder.Services.AddTransient<YasGMP.Views.WorkOrdersPage>();
             builder.Services.AddTransient<YasGMP.Views.ComponentsPage>();
             builder.Services.AddTransient<YasGMP.Views.SuppliersPage>();
+            builder.Services.AddTransient<YasGMP.Views.DocumentControlPage>();
             builder.Services.AddTransient<YasGMP.ExternalServicersPage>();
             builder.Services.AddTransient<YasGMP.Pages.PpmPage>();
             builder.Services.AddTransient<YasGMP.Views.ValidationPage>();

--- a/Models/DTO/ChangeControlSummaryDto.cs
+++ b/Models/DTO/ChangeControlSummaryDto.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace YasGMP.Models.DTO
+{
+    /// <summary>
+    /// Lightweight DTO representing a change control entry used for selection dialogs.
+    /// Provides enough information for users to identify the record without loading
+    /// the entire <see cref="Models.ChangeControl"/> aggregate.
+    /// </summary>
+    public sealed class ChangeControlSummaryDto
+    {
+        /// <summary>Primary key of the change control record.</summary>
+        public int Id { get; set; }
+
+        /// <summary>Business/traceability code (e.g., CC-2024-001).</summary>
+        public string Code { get; set; } = string.Empty;
+
+        /// <summary>Human readable title/summary.</summary>
+        public string Title { get; set; } = string.Empty;
+
+        /// <summary>Current workflow status (draft, under_review, approved, implemented, closed...).</summary>
+        public string Status { get; set; } = string.Empty;
+
+        /// <summary>Optional requested date for quick context in pickers.</summary>
+        public DateTime? DateRequested { get; set; }
+    }
+}

--- a/Services/DatabaseService.ChangeControls.Extensions.cs
+++ b/Services/DatabaseService.ChangeControls.Extensions.cs
@@ -1,0 +1,52 @@
+// ==============================================================================
+// File: Services/DatabaseService.ChangeControls.Extensions.cs
+// Purpose: Query helpers for change control lookups (picker/list scenarios)
+// ==============================================================================
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using YasGMP.Models.DTO;
+
+namespace YasGMP.Services
+{
+    public static class DatabaseServiceChangeControlsExtensions
+    {
+        /// <summary>
+        /// Returns a lightweight list of change controls (id/code/title/status/date) suitable
+        /// for selection dialogs. The query only pulls essential fields to keep the dialog fast
+        /// even on large datasets.
+        /// </summary>
+        public static async Task<List<ChangeControlSummaryDto>> GetChangeControlsAsync(
+            this DatabaseService db,
+            CancellationToken token = default)
+        {
+            const string sql = @"SELECT id, code, title, status, date_requested
+FROM change_controls
+ORDER BY id DESC";
+
+            var table = await db.ExecuteSelectAsync(sql, null, token).ConfigureAwait(false);
+            var list = new List<ChangeControlSummaryDto>(table.Rows.Count);
+            foreach (DataRow row in table.Rows)
+            {
+                var dto = new ChangeControlSummaryDto
+                {
+                    Id            = row.Table.Columns.Contains("id") && row["id"] != DBNull.Value
+                                    ? Convert.ToInt32(row["id"])
+                                    : 0,
+                    Code          = row.Table.Columns.Contains("code") ? row["code"]?.ToString() ?? string.Empty : string.Empty,
+                    Title         = row.Table.Columns.Contains("title") ? row["title"]?.ToString() ?? string.Empty : string.Empty,
+                    Status        = row.Table.Columns.Contains("status") ? row["status"]?.ToString() ?? string.Empty : string.Empty,
+                    DateRequested = row.Table.Columns.Contains("date_requested") && row["date_requested"] != DBNull.Value
+                                    ? Convert.ToDateTime(row["date_requested"])
+                                    : (DateTime?)null
+                };
+                list.Add(dto);
+            }
+
+            return list;
+        }
+    }
+}

--- a/Views/DocumentControlPage.xaml
+++ b/Views/DocumentControlPage.xaml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="YasGMP.Views.DocumentControlPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:conv="clr-namespace:YasGMP.Converters"
+    mc:Ignorable="d">
+
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <conv:NullToBoolConverter x:Key="NullToBoolConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
+    <Grid Padding="16" RowDefinitions="Auto,Auto,Auto,*,Auto" ColumnDefinitions="*">
+        <Label Grid.Row="0"
+               Text="Document Control"
+               FontAttributes="Bold"
+               FontSize="22"
+               TextColor="{DynamicResource YtPrimary700}" />
+
+        <SearchBar Grid.Row="1"
+                   Placeholder="Search by name, code, status or notes"
+                   Text="{Binding SearchTerm}" />
+
+        <Grid Grid.Row="2" ColumnDefinitions="*,*" ColumnSpacing="12" Margin="0,8,0,8">
+            <Picker Grid.Column="0"
+                    Title="Status"
+                    ItemsSource="{Binding AvailableStatuses}"
+                    SelectedItem="{Binding StatusFilter}" />
+            <Picker Grid.Column="1"
+                    Title="Type"
+                    ItemsSource="{Binding AvailableTypes}"
+                    SelectedItem="{Binding TypeFilter}" />
+        </Grid>
+
+        <CollectionView Grid.Row="3"
+                        ItemsSource="{Binding FilteredDocuments}"
+                        SelectedItem="{Binding SelectedDocument}"
+                        SelectionMode="Single">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Border Stroke="{DynamicResource YtPrimary200}" StrokeShape="RoundRectangle 8"
+                            BackgroundColor="{DynamicResource YtSurfaceCard}"
+                            Margin="0,0,0,8"
+                            Padding="12">
+                        <VerticalStackLayout Spacing="4">
+                            <Label Text="{Binding Name}" FontAttributes="Bold" />
+                            <Label Text="{Binding Code}" FontSize="12" TextColor="{DynamicResource YtPrimary500}" />
+                            <HorizontalStackLayout Spacing="12">
+                                <Label Text="{Binding Status, StringFormat='Status: {0}'}" FontSize="12" />
+                                <Label Text="{Binding VersionNo, StringFormat='Version: {0}'}" FontSize="12" />
+                            </HorizontalStackLayout>
+                            <Label Text="{Binding ReviewNotes}" FontSize="12" TextColor="{DynamicResource YtOnSurfaceVariant}" MaxLines="2" />
+                        </VerticalStackLayout>
+                    </Border>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+
+        <VerticalStackLayout Grid.Row="4" Spacing="8">
+            <HorizontalStackLayout Spacing="12">
+                <Button Text="Link Change Control"
+                        Command="{Binding OpenChangeControlPickerCommand}"
+                        IsEnabled="{Binding SelectedDocument, Converter={StaticResource NullToBoolConverter}}"
+                        Style="{StaticResource YtButton.Primary}" />
+                <Button Text="Refresh"
+                        Command="{Binding LoadDocumentsCommand}"
+                        Style="{StaticResource YtButton.Flat}" />
+            </HorizontalStackLayout>
+            <Label Text="{Binding StatusMessage}" TextColor="{DynamicResource YtOnSurfaceVariant}" FontSize="12" />
+        </VerticalStackLayout>
+
+        <Border Grid.RowSpan="5"
+                BackgroundColor="#66000000"
+                IsVisible="{Binding IsChangeControlPickerOpen}"
+                ZIndex="10">
+            <Border Stroke="{DynamicResource YtPrimary200}"
+                    StrokeShape="RoundRectangle 12"
+                    BackgroundColor="{DynamicResource YtSurface}"
+                    VerticalOptions="Center"
+                    HorizontalOptions="Center"
+                    Padding="20"
+                    WidthRequest="420">
+                <VerticalStackLayout Spacing="16">
+                    <Label Text="Select Change Control"
+                           FontAttributes="Bold"
+                           FontSize="18"
+                           HorizontalOptions="Center" />
+                    <CollectionView ItemsSource="{Binding AvailableChangeControls}"
+                                    SelectedItem="{Binding SelectedChangeControlForLink}"
+                                    SelectionMode="Single"
+                                    HeightRequest="240">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate>
+                                <Border Stroke="{DynamicResource YtPrimary100}" StrokeShape="RoundRectangle 6"
+                                        BackgroundColor="{DynamicResource YtSurfaceCard}"
+                                        Margin="0,0,0,8"
+                                        Padding="10">
+                                    <VerticalStackLayout Spacing="2">
+                                        <Label Text="{Binding Title}" FontAttributes="Bold" />
+                                        <Label Text="{Binding Code}" FontSize="12" TextColor="{DynamicResource YtPrimary500}" />
+                                        <Label Text="{Binding Status, StringFormat='Status: {0}'}" FontSize="12" />
+                                        <Label Text="{Binding DateRequested, StringFormat='Requested: {0:yyyy-MM-dd}'}" FontSize="12" />
+                                    </VerticalStackLayout>
+                                </Border>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                    <HorizontalStackLayout Spacing="12" HorizontalOptions="End">
+                        <Button Text="Cancel"
+                                Command="{Binding CancelChangeControlPickerCommand}"
+                                Style="{StaticResource YtButton.Flat}" />
+                        <Button Text="Link"
+                                Command="{Binding LinkChangeControlCommand}"
+                                IsEnabled="{Binding SelectedChangeControlForLink, Converter={StaticResource NullToBoolConverter}}"
+                                Style="{StaticResource YtButton.Primary}" />
+                    </HorizontalStackLayout>
+                </VerticalStackLayout>
+            </Border>
+        </Border>
+    </Grid>
+</ContentPage>

--- a/Views/DocumentControlPage.xaml.cs
+++ b/Views/DocumentControlPage.xaml.cs
@@ -1,0 +1,24 @@
+using System;
+using Microsoft.Maui.Controls;
+using YasGMP.Common;
+using YasGMP.ViewModels;
+
+namespace YasGMP.Views
+{
+    public partial class DocumentControlPage : ContentPage
+    {
+        public DocumentControlViewModel ViewModel { get; }
+
+        public DocumentControlPage(DocumentControlViewModel viewModel)
+        {
+            InitializeComponent();
+            ViewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+            BindingContext = ViewModel;
+        }
+
+        public DocumentControlPage()
+            : this(ServiceLocator.GetRequiredService<DocumentControlViewModel>())
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add change-control picker state and commands to the document control view-model
- persist document/change-control links via a dedicated table with CSV fallback and expose summaries via DatabaseService
- create a document control page with linking dialog and register it in the shell/DI so users can link change controls

## Testing
- `dotnet build` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9adfb26883318d10d852a88aa3c1