### PR TITLE
Handle nullable work order dates in edit dialog

### DIFF
--- a/Views/Dialogs/WorkOrderEditDialog.xaml
+++ b/Views/Dialogs/WorkOrderEditDialog.xaml
@@ -2,6 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="YasGMP.Views.Dialogs.WorkOrderEditDialog"
+             x:Name="DialogPage"
              Title="Radni nalog">
   <ScrollView>
     <VerticalStackLayout Padding="20" Spacing="10">
@@ -15,8 +16,8 @@
       <Editor Text="{Binding Description}" Placeholder="Opis" AutoSize="TextChanges" />
       <Entry Text="{Binding TaskDescription}" Placeholder="Opis zadatka (legacy)" />
       <DatePicker Date="{Binding DateOpen}" />
-      <DatePicker Date="{Binding DueDate}" />
-      <DatePicker Date="{Binding DateClose}" />
+      <DatePicker Date="{Binding Source={x:Reference DialogPage}, Path=DueDatePickerValue, Mode=TwoWay}" />
+      <DatePicker Date="{Binding Source={x:Reference DialogPage}, Path=DateClosePickerValue, Mode=TwoWay}" />
       <Entry Text="{Binding Result}" Placeholder="Rezultat/nalaz" />
       <Editor Text="{Binding Notes}" Placeholder="Napomena" AutoSize="TextChanges" />
 


### PR DESCRIPTION
## Summary
- route due/close date pickers through dialog-level bindable properties so DatePicker.Date never receives null
- keep the pickers synchronized with nullable WorkOrder fields and translate DateTime.MinValue back to null when clearing

## Testing
- Not Run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68caa036f7f08331a5bd59644e26d453