### PR TITLE
Wire components page to view model and add export

### DIFF
--- a/Views/ComponentsPage.xaml
+++ b/Views/ComponentsPage.xaml
@@ -6,6 +6,13 @@
     xmlns:maui="http://schemas.microsoft.com/dotnet/2021/maui"
     Title="Komponente strojeva – YasGMP">
 
+  <ContentPage.ToolbarItems>
+    <ToolbarItem Text="📤 Export"
+                 Order="Primary"
+                 Priority="0"
+                 Clicked="OnExportComponentsClicked" />
+  </ContentPage.ToolbarItems>
+
   <ContentPage.Content>
     <VerticalStackLayout Padding="28,20,28,20" Spacing="18"
                          BackgroundColor="{StaticResource YtSurface}">
@@ -40,7 +47,8 @@
           </HorizontalStackLayout>
 
           <CollectionView x:Name="ComponentListView"
-                          ItemsSource="{Binding Components}"
+                          ItemsSource="{Binding FilteredComponents}"
+                          SelectedItem="{Binding SelectedComponent, Mode=TwoWay}"
                           SelectionMode="Single"
                           HeightRequest="440"
                           BackgroundColor="{StaticResource YtSurface}">


### PR DESCRIPTION
## Summary
- switch the components page to use the ComponentViewModel binding and filtered collection
- add an export toolbar action that calls the view-model export flow and opens the generated file
- enhance ComponentViewModel export logic to return the generated path and support manual data loading

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caa2a28cdc833182e51576195230de