### PR TITLE
Add preflight validation before linking change controls

### DIFF
--- a/Services/DatabaseService.Documents.Extensions.cs
+++ b/Services/DatabaseService.Documents.Extensions.cs
@@ -97,6 +97,22 @@ FROM documentcontrol ORDER BY id DESC";
             if (documentId <= 0) throw new ArgumentOutOfRangeException(nameof(documentId));
             if (changeControlId <= 0) throw new ArgumentOutOfRangeException(nameof(changeControlId));
 
+            var docExists = await db.ExecuteScalarAsync(
+                "SELECT 1 FROM documentcontrol WHERE id=@docId LIMIT 1",
+                new[] { new MySqlParameter("@docId", documentId) },
+                token).ConfigureAwait(false);
+
+            if (docExists == null || docExists == DBNull.Value)
+                throw new DocumentControlLinkException("Document not found. Please refresh and try again.");
+
+            var changeControlExists = await db.ExecuteScalarAsync(
+                "SELECT 1 FROM change_controls WHERE id=@ccId LIMIT 1",
+                new[] { new MySqlParameter("@ccId", changeControlId) },
+                token).ConfigureAwait(false);
+
+            if (changeControlExists == null || changeControlExists == DBNull.Value)
+                throw new DocumentControlLinkException("Change control not found. It may have been removed.");
+
             bool persisted = false;
             Exception? primaryFailure = null;
 

--- a/Services/DocumentControlLinkException.cs
+++ b/Services/DocumentControlLinkException.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace YasGMP.Services
+{
+    /// <summary>
+    /// Represents a recoverable failure when attempting to link a change control to a document.
+    /// </summary>
+    public sealed class DocumentControlLinkException : Exception
+    {
+        public DocumentControlLinkException(string message) : base(message)
+        {
+        }
+
+        public DocumentControlLinkException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/ViewModels/DocumentControlViewModel.cs
+++ b/ViewModels/DocumentControlViewModel.cs
@@ -593,6 +593,10 @@ namespace YasGMP.ViewModels
                 CancelChangeControlPicker();
                 await LoadDocumentsAsync().ConfigureAwait(false);
             }
+            catch (DocumentControlLinkException ex)
+            {
+                StatusMessage = ex.Message;
+            }
             catch (Exception ex)
             {
                 StatusMessage = $"Linking failed: {ex.Message}";


### PR DESCRIPTION
## Summary
- add change control and document existence checks before attempting to insert the link row
- introduce a dedicated DocumentControlLinkException for user friendly errors
- surface the friendly status message in DocumentControlViewModel when linking fails because records are missing

## Testing
- dotnet build *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caa9077238833185007525f516224e