### PR TITLE
Handle component export format selection on UI thread

### DIFF
--- a/Helpers/ExportFormatPrompt.cs
+++ b/Helpers/ExportFormatPrompt.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
-using Microsoft.Maui.ApplicationModel;
-using Microsoft.Maui.Controls;
+using YasGMP.Services;
 
 namespace YasGMP.Helpers
 {
@@ -15,9 +14,13 @@ namespace YasGMP.Helpers
         {
             try
             {
-                var choice = await MainThread.InvokeOnMainThreadAsync(async () =>
-                    await (Application.Current?.MainPage)?.DisplayActionSheet(
-                        "Export format", "Cancel", null, "CSV", "XLSX", "PDF")!);
+                var choice = await SafeNavigator.ActionSheetAsync(
+                    "Export format",
+                    "Cancel",
+                    null,
+                    "CSV",
+                    "XLSX",
+                    "PDF").ConfigureAwait(false);
 
                 if (string.IsNullOrWhiteSpace(choice) || choice.Equals("Cancel", StringComparison.OrdinalIgnoreCase))
                     return "csv";

--- a/Services/SafeNavigator.cs
+++ b/Services/SafeNavigator.cs
@@ -142,6 +142,32 @@ namespace YasGMP.Services
             }
         }
 
+        /// <summary>
+        /// Displays an action sheet in a UI-thread-safe manner.
+        /// Returns the selected option or <c>null</c> if cancelled/failed.
+        /// </summary>
+        public static async Task<string?> ActionSheetAsync(string title, string cancel, string? destruction, params string[] buttons)
+        {
+            try
+            {
+                return await MainThread.InvokeOnMainThreadAsync(async () =>
+                {
+                    var page = Application.Current?.MainPage;
+                    if (page is null)
+                        return null;
+
+                    return await page.DisplayActionSheet(title, cancel, destruction, buttons).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+#if DEBUG
+                Debug.WriteLine($"[NAV WARN] ActionSheetAsync('{title}') → {ex.Message}");
+#endif
+                return null;
+            }
+        }
+
         private static async Task TryShowAlertAsync(string title, string message, string cancel)
         {
             try

--- a/ViewModels/ComponentViewModel.cs
+++ b/ViewModels/ComponentViewModel.cs
@@ -7,7 +7,6 @@ using System.Windows.Input;
 using System.Linq;
 using YasGMP.Models;
 using YasGMP.Services;
-using YasGMP.Helpers;
 using CommunityToolkit.Mvvm.Input;
 using System.Collections.Generic;
 
@@ -63,7 +62,7 @@ namespace YasGMP.ViewModels
             AddComponentCommand = new AsyncRelayCommand(AddComponentAsync, () => !IsBusy && SelectedComponent != null);
             UpdateComponentCommand = new AsyncRelayCommand(UpdateComponentAsync, () => !IsBusy && SelectedComponent != null);
             DeleteComponentCommand = new AsyncRelayCommand(DeleteComponentAsync, () => !IsBusy && SelectedComponent != null);
-            ExportComponentsCommand = new AsyncRelayCommand(ExecuteExportComponentsCommandAsync, () => !IsBusy);
+            ExportComponentsCommand = new AsyncRelayCommand<string?>(ExecuteExportComponentsCommandAsync, _ => !IsBusy);
             FilterChangedCommand = new RelayCommand(FilterComponents);
 
             if (autoLoad)
@@ -316,21 +315,20 @@ namespace YasGMP.ViewModels
             finally { IsBusy = false; }
         }
 
-        private async Task ExecuteExportComponentsCommandAsync()
+        private async Task ExecuteExportComponentsCommandAsync(string? format)
         {
-            await ExportComponentsAsync().ConfigureAwait(false);
+            await ExportComponentsAsync(format).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Exports the current filtered component list to a user-chosen format with audit logging.
         /// Returns the exported file path or <c>null</c> if the operation failed or was cancelled.
         /// </summary>
-        public async Task<string?> ExportComponentsAsync()
+        public async Task<string?> ExportComponentsAsync(string? format = null)
         {
             IsBusy = true;
             try
             {
-                var format = await ExportFormatPrompt.PromptAsync().ConfigureAwait(false);
                 var normalizedFormat = string.IsNullOrWhiteSpace(format)
                     ? "csv"
                     : format.Trim().ToLowerInvariant();

--- a/Views/ComponentsPage.xaml.cs
+++ b/Views/ComponentsPage.xaml.cs
@@ -293,7 +293,25 @@ WHERE id=@id;";
         {
             try
             {
-                string? path = await _viewModel.ExportComponentsAsync().ConfigureAwait(false);
+                string? choice = await SafeNavigator.ActionSheetAsync(
+                    "Odaberite format",
+                    "Cancel",
+                    null,
+                    "CSV",
+                    "XLSX",
+                    "PDF").ConfigureAwait(false);
+
+                if (string.IsNullOrWhiteSpace(choice) || choice.Equals("Cancel", StringComparison.OrdinalIgnoreCase))
+                {
+                    await SafeNavigator.ShowAlertAsync("Komponente", "Export je otkazan.", "OK");
+                    return;
+                }
+
+                string normalizedFormat = choice.Equals("XLSX", StringComparison.OrdinalIgnoreCase) ? "xlsx"
+                    : choice.Equals("PDF", StringComparison.OrdinalIgnoreCase) ? "pdf"
+                    : "csv";
+
+                string? path = await _viewModel.ExportComponentsAsync(normalizedFormat).ConfigureAwait(false);
 
                 if (string.IsNullOrWhiteSpace(path))
                 {


### PR DESCRIPTION
## Summary
- allow `ComponentViewModel.ExportComponentsAsync` to receive an optional format and stop prompting from the view-model
- add a dispatcher-safe `SafeNavigator.ActionSheetAsync` helper and update the export prompt utility to use it
- have the Components page gather the export format via the new helper before invoking the view-model export logic

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caae13c90083319ad388b8b9eb1b27