### PR TITLE
Add change control assignment picker UI

### DIFF
--- a/AppShell.xaml
+++ b/AppShell.xaml
@@ -23,6 +23,7 @@
     <ToolbarItem Text="Calibrations" Clicked="OnToolbarGoCalibrations" />
     <ToolbarItem Text="CAPA"         Clicked="OnToolbarGoCapa" />
     <ToolbarItem Text="Validation"   Clicked="OnToolbarGoValidation" />
+    <ToolbarItem Text="Change Control" Clicked="OnToolbarGoChangeControl" />
     <ToolbarItem Text="Audit Dash"   Clicked="OnToolbarGoAuditDash" />
     <ToolbarItem Text="Audit Log"    Clicked="OnToolbarGoAuditLog" />
     <ToolbarItem Text="Users"        Clicked="OnToolbarGoUsers" />
@@ -72,6 +73,8 @@
                     ContentTemplate="{DataTemplate views:CapaPage}" />
       <ShellContent Title="Validation"      Route="validation"
                     ContentTemplate="{DataTemplate views:ValidationPage}" />
+      <ShellContent Title="Change Control"  Route="changecontrol"
+                    ContentTemplate="{DataTemplate views:ChangeControlPage}" />
       <ShellContent Title="Documents"       Route="documents"
                     ContentTemplate="{DataTemplate views:DocumentControlPage}" />
       <ShellContent Title="Audit Dashboard" Route="auditdashboard"

--- a/AppShell.xaml.cs
+++ b/AppShell.xaml.cs
@@ -28,6 +28,7 @@ namespace YasGMP
             // Quality
             public const string Capa           = "//root/quality/capa";
             public const string Validation     = "//root/quality/validation";
+            public const string ChangeControl  = "//root/quality/changecontrol";
             public const string AuditDashboard = "//root/quality/auditdashboard";
             public const string AuditLog       = "//root/quality/auditlog";
 
@@ -105,6 +106,7 @@ namespace YasGMP
 
         private async void OnToolbarGoCapa      (object s, EventArgs e) => await GoAsync(Paths.Capa);
         private async void OnToolbarGoValidation(object s, EventArgs e) => await GoAsync(Paths.Validation);
+        private async void OnToolbarGoChangeControl(object s, EventArgs e) => await GoAsync(Paths.ChangeControl);
         private async void OnToolbarGoAuditDash (object s, EventArgs e) => await GoAsync(Paths.AuditDashboard);
         private async void OnToolbarGoAuditLog  (object s, EventArgs e) => await GoAsync(Paths.AuditLog);
 

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -176,6 +176,7 @@ namespace YasGMP
             builder.Services.AddTransient<PpmViewModel>();
             builder.Services.AddTransient<WarehouseViewModel>();
             builder.Services.AddTransient<DocumentControlViewModel>();
+            builder.Services.AddTransient<ChangeControlViewModel>();
 
             // Pages
             builder.Services.AddTransient<YasGMP.Views.LoginPage>();
@@ -192,6 +193,7 @@ namespace YasGMP
             builder.Services.AddTransient<YasGMP.Views.ComponentsPage>();
             builder.Services.AddTransient<YasGMP.Views.SuppliersPage>();
             builder.Services.AddTransient<YasGMP.Views.DocumentControlPage>();
+            builder.Services.AddTransient<YasGMP.Views.ChangeControlPage>();
             builder.Services.AddTransient<YasGMP.ExternalServicersPage>();
             builder.Services.AddTransient<YasGMP.Pages.PpmPage>();
             builder.Services.AddTransient<YasGMP.Views.ValidationPage>();

--- a/Views/ChangeControlPage.xaml
+++ b/Views/ChangeControlPage.xaml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="YasGMP.Views.ChangeControlPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    Title="Upravljanje promjenama – YasGMP">
+  <ScrollView>
+    <Grid Padding="24"
+          RowSpacing="18"
+          ColumnSpacing="18"
+          RowDefinitions="Auto,*"
+          ColumnDefinitions="320,*">
+
+      <Frame Grid.ColumnSpan="2"
+             BackgroundColor="{StaticResource YtSurfaceCard}"
+             BorderColor="{StaticResource YtRowBorder}"
+             Padding="12">
+        <VerticalStackLayout Spacing="4">
+          <Label Text="{Binding StatusMessage}"
+                 FontSize="14"
+                 TextColor="{StaticResource YtOnSurface}"
+                 IsVisible="True">
+            <Label.Triggers>
+              <DataTrigger TargetType="Label"
+                           Binding="{Binding StatusMessage}"
+                           Value="{x:Null}">
+                <Setter Property="IsVisible" Value="False" />
+              </DataTrigger>
+              <DataTrigger TargetType="Label"
+                           Binding="{Binding StatusMessage}"
+                           Value="">
+                <Setter Property="IsVisible" Value="False" />
+              </DataTrigger>
+            </Label.Triggers>
+          </Label>
+        </VerticalStackLayout>
+      </Frame>
+
+      <Frame Grid.Row="1"
+             Grid.Column="0"
+             BackgroundColor="{StaticResource YtSurfaceCard}"
+             BorderColor="{StaticResource YtRowBorder}"
+             Padding="14"
+             CornerRadius="14"
+             HasShadow="True">
+        <VerticalStackLayout Spacing="10">
+          <Label Text="Promjene"
+                 FontSize="18"
+                 FontAttributes="Bold"
+                 TextColor="{StaticResource YtPrimary700}" />
+          <SearchBar Placeholder="Pretraži promjene"
+                     Text="{Binding SearchTerm}" />
+          <Grid ColumnDefinitions="*,Auto"
+                ColumnSpacing="10">
+            <Picker Grid.Column="0"
+                    Title="Status"
+                    ItemsSource="{Binding AvailableStatuses}"
+                    SelectedItem="{Binding StatusFilter}" />
+            <Entry Grid.Column="1"
+                   WidthRequest="120"
+                   Placeholder="Vrsta"
+                   Text="{Binding TypeFilter}" />
+          </Grid>
+          <CollectionView ItemsSource="{Binding FilteredChangeControls}"
+                          SelectionMode="Single"
+                          SelectedItem="{Binding SelectedChangeControl}"
+                          HeightRequest="420"
+                          BackgroundColor="{StaticResource YtSurface}">
+            <CollectionView.EmptyView>
+              <VerticalStackLayout Padding="12" Spacing="6">
+                <Label Text="Nema promjena za prikaz." />
+              </VerticalStackLayout>
+            </CollectionView.EmptyView>
+            <CollectionView.ItemTemplate>
+              <DataTemplate>
+                <Frame Margin="0,4"
+                       Padding="10"
+                       CornerRadius="10"
+                       BackgroundColor="{StaticResource YtSurface}"
+                       BorderColor="{StaticResource YtRowBorder}">
+                  <VerticalStackLayout Spacing="4">
+                    <Label Text="{Binding Title}"
+                           FontAttributes="Bold"
+                           TextColor="{StaticResource YtOnSurface}" />
+                    <Label Text="{Binding Code, StringFormat='Šifra: {0}'}"
+                           FontSize="12"
+                           TextColor="{StaticResource YtOnSurfaceDim}" />
+                    <Label Text="{Binding Status}"
+                           FontSize="12"
+                           TextColor="{StaticResource YtPrimary700}" />
+                    <Label Text="{Binding Description}"
+                           FontSize="11"
+                           LineBreakMode="WordWrap"
+                           MaxLines="2"
+                           TextColor="{StaticResource YtOnSurfaceDim}" />
+                  </VerticalStackLayout>
+                </Frame>
+              </DataTemplate>
+            </CollectionView.ItemTemplate>
+          </CollectionView>
+        </VerticalStackLayout>
+      </Frame>
+
+      <Frame Grid.Row="1"
+             Grid.Column="1"
+             BackgroundColor="{StaticResource YtSurfaceCard}"
+             BorderColor="{StaticResource YtRowBorder}"
+             Padding="14"
+             CornerRadius="14"
+             HasShadow="True">
+        <VerticalStackLayout Spacing="16">
+          <VerticalStackLayout x:Name="PlaceholderPanel"
+                                Spacing="8"
+                                IsVisible="False">
+            <VerticalStackLayout.Triggers>
+              <DataTrigger TargetType="VerticalStackLayout"
+                           Binding="{Binding SelectedChangeControl}"
+                           Value="{x:Null}">
+                <Setter Property="IsVisible" Value="True" />
+              </DataTrigger>
+            </VerticalStackLayout.Triggers>
+            <Label Text="Odaberite promjenu s popisa kako biste vidjeli detalje."
+                   FontSize="14"
+                   TextColor="{StaticResource YtOnSurfaceDim}" />
+          </VerticalStackLayout>
+
+          <VerticalStackLayout x:Name="DetailsPanel"
+                                Spacing="10"
+                                IsVisible="True">
+            <VerticalStackLayout.Triggers>
+              <DataTrigger TargetType="VerticalStackLayout"
+                           Binding="{Binding SelectedChangeControl}"
+                           Value="{x:Null}">
+                <Setter Property="IsVisible" Value="False" />
+              </DataTrigger>
+            </VerticalStackLayout.Triggers>
+
+            <Label Text="{Binding SelectedChangeControl.Title}"
+                   FontSize="20"
+                   FontAttributes="Bold"
+                   TextColor="{StaticResource YtPrimary700}" />
+            <Label Text="{Binding SelectedChangeControl.Code, StringFormat='Šifra: {0}'}"
+                   FontSize="12"
+                   TextColor="{StaticResource YtOnSurfaceDim}" />
+            <Label Text="{Binding SelectedChangeControl.Status, StringFormat='Status: {0}'}"
+                   FontSize="12"
+                   TextColor="{StaticResource YtOnSurfaceDim}" />
+            <Label Text="{Binding SelectedChangeControl.Description}"
+                   FontSize="13"
+                   LineBreakMode="WordWrap"
+                   TextColor="{StaticResource YtOnSurface}" />
+            <Label Text="{Binding SelectedChangeControl.DateRequested, StringFormat='Datum zahtjeva: {0:yyyy-MM-dd HH:mm}'}"
+                   FontSize="12"
+                   TextColor="{StaticResource YtOnSurfaceDim}" />
+          </VerticalStackLayout>
+
+          <VerticalStackLayout x:Name="AssignmentPanel"
+                                Spacing="12"
+                                IsVisible="True">
+            <VerticalStackLayout.Triggers>
+              <DataTrigger TargetType="VerticalStackLayout"
+                           Binding="{Binding SelectedChangeControl}"
+                           Value="{x:Null}">
+                <Setter Property="IsVisible" Value="False" />
+              </DataTrigger>
+            </VerticalStackLayout.Triggers>
+
+            <Label Text="Dodjela odgovorne osobe"
+                   FontSize="16"
+                   FontAttributes="Bold"
+                   TextColor="{StaticResource YtPrimary700}" />
+            <Picker Title="Odaberite osobu"
+                    ItemsSource="{Binding AvailableAssignees}"
+                    SelectedItem="{Binding SelectedAssignee}"
+                    ItemDisplayBinding="{Binding FullName}" />
+            <Label Text="{Binding StatusMessage}"
+                   TextColor="{StaticResource YtDanger700}"
+                   FontSize="12"
+                   IsVisible="False">
+              <Label.Triggers>
+                <DataTrigger TargetType="Label"
+                             Binding="{Binding IsAssigneeSelectionValid}"
+                             Value="False">
+                  <Setter Property="IsVisible" Value="True" />
+                </DataTrigger>
+              </Label.Triggers>
+            </Label>
+            <Button Text="Dodijeli promjenu"
+                    Command="{Binding AssignChangeControlCommand}" />
+          </VerticalStackLayout>
+        </VerticalStackLayout>
+      </Frame>
+
+    </Grid>
+  </ScrollView>
+</ContentPage>

--- a/Views/ChangeControlPage.xaml.cs
+++ b/Views/ChangeControlPage.xaml.cs
@@ -1,0 +1,46 @@
+// Views/ChangeControlPage.xaml.cs
+#nullable enable
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Controls;
+using YasGMP.ViewModels;
+
+namespace YasGMP.Views
+{
+    /// <summary>
+    /// UI surface for managing change control records, including assignment of responsible users.
+    /// </summary>
+    public partial class ChangeControlPage : ContentPage
+    {
+        /// <summary>Backing view-model resolved via the MAUI service provider.</summary>
+        public ChangeControlViewModel ViewModel { get; }
+
+        /// <summary>Initializes the page and resolves the required <see cref="ChangeControlViewModel"/>.</summary>
+        /// <exception cref="InvalidOperationException">Thrown when the MAUI service provider is unavailable.</exception>
+        public ChangeControlPage()
+        {
+            InitializeComponent();
+
+            var services = Application.Current?.Handler?.MauiContext?.Services
+                ?? throw new InvalidOperationException(
+                    "Service provider unavailable. Ensure ChangeControlPage is registered in MauiProgram.");
+
+            ViewModel = services.GetRequiredService<ChangeControlViewModel>();
+            BindingContext = ViewModel;
+        }
+
+        /// <inheritdoc />
+        protected override async void OnAppearing()
+        {
+            base.OnAppearing();
+            try
+            {
+                await ViewModel.LoadAssignableUsersAsync();
+            }
+            catch
+            {
+                // LoadAssignableUsersAsync already reports errors via StatusMessage.
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend the change-control view model with assignee collections, validation flags, and asynchronous user loading
- add a dedicated Change Control page that lists records, exposes the new assignee picker, and surfaces status feedback
- register the new page/view-model and expose navigation hooks through the shell toolbar

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caaee3e7988331bd078a56ea5bcb36