### PR TITLE
Add change control assignment QA checklist and harness

### DIFF
--- a/Diagnostics/ChangeControlAssignmentHarness.cs
+++ b/Diagnostics/ChangeControlAssignmentHarness.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using MySqlConnector;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Services.Interfaces;
+using YasGMP.ViewModels;
+
+namespace YasGMP.Diagnostics
+{
+    /// <summary>
+    /// Utility harness that exercises <see cref="ChangeControlViewModel.AssignChangeControlAsync"/> with
+    /// stubbed database/authentication services. It is designed so QA can validate SQL emitted during
+    /// assignment workflows without a full UI automation stack.
+    /// </summary>
+    public static class ChangeControlAssignmentHarness
+    {
+        /// <summary>
+        /// Runs the harness end-to-end: initial assignment followed by a reassignment. The harness captures
+        /// executed SQL statements and audit metadata emitted via <c>system_event_log</c> insertions.
+        /// </summary>
+        public static async Task<ChangeControlAssignmentHarnessResult> RunAsync()
+        {
+            var executedSql = new List<string>();
+            var auditEvents = new List<ChangeControlAssignmentHarnessEvent>();
+            var statusMessages = new List<string>();
+
+            var table = BuildSeedData();
+            var db = new DatabaseService("Server=stub;Database=stub;Uid=stub;Pwd=stub;");
+
+            db.ExecuteSelectOverride = (sql, parameters, token) =>
+            {
+                executedSql.Add(sql);
+                return Task.FromResult(table.Copy());
+            };
+
+            db.ExecuteNonQueryOverride = (sql, parameters, token) =>
+            {
+                executedSql.Add(sql);
+
+                if (sql.Contains("change_controls", StringComparison.OrdinalIgnoreCase))
+                {
+                    var assignedParam = parameters?.FirstOrDefault(p => p.ParameterName == "@assigned");
+                    if (assignedParam != null)
+                    {
+                        table.Rows[0]["assigned_to_id"] = assignedParam.Value ?? DBNull.Value;
+                    }
+                }
+
+                if (sql.Contains("system_event_log", StringComparison.OrdinalIgnoreCase))
+                {
+                    var paramList = parameters?.ToList() ?? new List<MySqlParameter>();
+                    var eventType = paramList.FirstOrDefault(p => p.ParameterName == "@etype")?.Value?.ToString() ?? string.Empty;
+                    var oldValue = paramList.FirstOrDefault(p => p.ParameterName == "@old")?.Value?.ToString();
+                    var newValue = paramList.FirstOrDefault(p => p.ParameterName == "@new")?.Value?.ToString();
+                    var description = paramList.FirstOrDefault(p => p.ParameterName == "@desc")?.Value?.ToString();
+                    auditEvents.Add(new ChangeControlAssignmentHarnessEvent(eventType, NullIfEmpty(oldValue), NullIfEmpty(newValue), description));
+                }
+
+                return Task.FromResult(1);
+            };
+
+            var auth = new HarnessAuthContext();
+            var vm = new ChangeControlViewModel(db, auth);
+            await vm.LoadChangeControlsAsync().ConfigureAwait(false);
+
+            var first = vm.ChangeControls.FirstOrDefault();
+            if (first == null)
+            {
+                db.ResetTestOverrides();
+                return new ChangeControlAssignmentHarnessResult(statusMessages, auditEvents, executedSql);
+            }
+
+            vm.SelectedChangeControl = first;
+            first.AssignedToId = auth.InitialAssigneeId;
+            await vm.AssignChangeControlAsync().ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(vm.StatusMessage))
+                statusMessages.Add(vm.StatusMessage!);
+
+            var second = vm.ChangeControls.FirstOrDefault();
+            if (second != null)
+            {
+                second.AssignedToId = auth.ReassignmentAssigneeId;
+                vm.SelectedChangeControl = second;
+                await vm.AssignChangeControlAsync().ConfigureAwait(false);
+                if (!string.IsNullOrWhiteSpace(vm.StatusMessage))
+                    statusMessages.Add(vm.StatusMessage!);
+            }
+
+            db.ResetTestOverrides();
+
+            return new ChangeControlAssignmentHarnessResult(statusMessages, auditEvents, executedSql);
+        }
+
+        private static DataTable BuildSeedData()
+        {
+            var table = new DataTable();
+            table.Columns.Add("id", typeof(int));
+            table.Columns.Add("code", typeof(string));
+            table.Columns.Add("title", typeof(string));
+            table.Columns.Add("description", typeof(string));
+            table.Columns.Add("status", typeof(string));
+            table.Columns.Add("requested_by_id", typeof(int));
+            table.Columns.Add("date_requested", typeof(DateTime));
+            table.Columns.Add("assigned_to_id", typeof(int));
+            table.Rows.Add(1, "CC-HARNESS", "Harness change control", "Synthetic record for assignment harness", "Draft", 2, DateTime.UtcNow, DBNull.Value);
+            return table;
+        }
+
+        private static string? NullIfEmpty(string? value) => string.IsNullOrWhiteSpace(value) ? null : value;
+
+        private sealed class HarnessAuthContext : IAuthContext
+        {
+            public HarnessAuthContext()
+            {
+                CurrentUser = new User
+                {
+                    Id = 9001,
+                    Username = "qa.harness",
+                    FullName = "QA Harness",
+                    Role = "qa"
+                };
+                CurrentSessionId = Guid.NewGuid().ToString();
+            }
+
+            public User? CurrentUser { get; }
+            public string CurrentSessionId { get; }
+            public string CurrentDeviceInfo { get; } = "Device=Harness;OS=Linux;App=Diagnostics";
+            public string CurrentIpAddress { get; } = "127.0.0.1";
+
+            public int InitialAssigneeId => 2001;
+            public int ReassignmentAssigneeId => 2002;
+        }
+    }
+
+    /// <summary>Minimal projection of an audit event captured by the harness.</summary>
+    public sealed record ChangeControlAssignmentHarnessEvent(string EventType, string? OldValue, string? NewValue, string? Description);
+
+    /// <summary>Return payload for the harness including status messages and captured SQL.</summary>
+    public sealed record ChangeControlAssignmentHarnessResult(
+        IReadOnlyList<string> StatusMessages,
+        IReadOnlyList<ChangeControlAssignmentHarnessEvent> LoggedEvents,
+        IReadOnlyList<string> ExecutedSql)
+    {
+        /// <summary>True when at least one INSERT into system_event_log was observed.</summary>
+        public bool LoggedAudit => LoggedEvents.Count > 0;
+    }
+}

--- a/QA/ChangeControlAssignment.md
+++ b/QA/ChangeControlAssignment.md
@@ -1,0 +1,104 @@
+# Change Control Assignment QA Checklist
+
+This guide captures the manual verification steps for the change-control assignment workflow. It focuses on
+ensuring that both initial assignments and subsequent reassignments behave as expected and that every action
+is written to `system_event_log` for Annex 11 / 21 CFR Part 11 traceability.
+
+> **Scope**: These checks target the `ChangeControlViewModel.AssignChangeControlAsync` workflow and related audit
+> instrumentation. They should be executed for every release that touches change control routing, audit, or
+> diagnostics infrastructure.
+
+## Prerequisites
+
+1. **Environment**: A QA, staging, or developer instance of YasGMP with a reachable MySQL backend.
+2. **Seed data**: At least one change-control record in status `Draft` or `UnderReview` to exercise the workflow.
+   You can create one through the UI or by executing the `Initiate` action in the Change Control workspace.
+3. **User permissions**: Sign in with an account that has role `qa`, `admin`, or `superadmin`. The assignment command
+   is gated by these roles (`ChangeControlViewModel.CanManageChangeControl`).
+4. **Audit visibility**: Confirm that the Audit Log page (Navigation: **Admin → Audit Log**) is accessible, or that you
+   have SQL access to query `system_event_log` directly.
+
+## Test 1 – Initial assignment
+
+Goal: Assign an unassigned change control to a specific owner and confirm the UI and audit trail update.
+
+1. Navigate to the **Change Control** workspace.
+2. Select an unassigned change-control record (verify the "Assigned To" column or details pane shows `None`).
+3. Choose an assignee (e.g., via the user picker/dropdown) and trigger the **Assign** action.
+4. Observe the toast/status line. Expected message:
+   
+   > `Change control '<title>' assigned to user ID <id>.`
+5. Reload the grid or details panel. The assigned user should now be visible.
+6. Navigate to **Admin → Audit Log** (or query the database) and filter for:
+   - `Table` = `change_controls`
+   - `Event Type` = `CC_ASSIGN`
+   - `Record Id` = the change-control id you acted on
+7. Confirm the audit entry shows:
+   - `old_value` (or description `previous=none`) reflecting no prior assignment.
+   - `new_value` matching the new assignee's user id.
+   - Description includes the change control code and the acting user's id.
+
+## Test 2 – Reassignment
+
+Goal: Reassign the same record to a different user and verify old/new values are tracked.
+
+1. On the same change control, pick a different assignee.
+2. Trigger the **Assign** command again.
+3. Confirm the status message updates to:
+   
+   > `Change control '<title>' reassigned from user ID <old> to user ID <new>.`
+4. Refresh the change-control list to ensure the assignee reflects the new value.
+5. In the Audit Log (or via SQL), filter for `Event Type = CC_REASSIGN`.
+6. Validate the new row contains:
+   - `old_value` = previous user id
+   - `new_value` = the latest user id
+   - Description string summarising the transition (e.g., `code=CC-2025-...; new=user ID 2002; previous=user ID 2001; actor=...`).
+
+## Test 3 – Direct system_event_log verification
+
+When SQL access is available, run the following query after performing the above UI actions:
+
+```sql
+SELECT ts_utc,
+       event_type,
+       record_id,
+       field_name,
+       old_value,
+       new_value,
+       description
+FROM   system_event_log
+WHERE  table_name = 'change_controls'
+  AND  record_id = <CHANGE_CONTROL_ID>
+ORDER BY ts_utc DESC;
+```
+
+Expected results:
+
+- The most recent row is `CC_REASSIGN` with `field_name = 'assigned_to_id'` and the correct `old_value`/`new_value` pair.
+- The preceding row is `CC_ASSIGN` with `old_value` = `NULL` (or empty) and `new_value` = the initial assignee.
+- Each entry includes the acting user's id, IP, and session metadata.
+
+If any of the fields are missing or the event type is not recorded, investigate the assignment command handler
+before releasing.
+
+## Harness / Diagnostics validation (optional but recommended)
+
+A lightweight harness backs these flows and can be executed without a live database:
+
+1. Build the solution (`dotnet build`).
+2. From the Debug dashboard inside the app (**Debug → Diagnostics Hub → Run Self Tests**), execute the self-test suite.
+   - The new harness logs a `cc_assign_harness` entry that summarises the synthetic assignment and reassignment and
+     confirms a `system_event_log` insert was emitted.
+3. Alternatively, from a development shell you can run the harness directly using C# Interactive
+   (requires the [dotnet-script](https://github.com/dotnet-script/dotnet-script) global tool — install via
+   `dotnet tool install -g dotnet-script`):
+   
+   ```bash
+   dotnet script -q -c "await YasGMP.Diagnostics.ChangeControlAssignmentHarness.RunAsync()"
+   ```
+   
+   Examine the returned payload to ensure `LoggedAudit` is `true` and that `LoggedEvents` includes both `CC_ASSIGN`
+   and `CC_REASSIGN` records.
+
+Document any anomalies (unexpected status messages, missing audit rows, SQL failures) in the release notes and block
+shipping until the discrepancy is resolved.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# YasGMP
+
+YasGMP is a cross-platform MAUI application for GMP-compliant manufacturing operations. This repository
+contains the mobile/desktop client, common domain services, and diagnostics tooling used during validation.
+
+## Maintainer resources
+
+- [Change Control Assignment QA Checklist](QA/ChangeControlAssignment.md) – step-by-step manual verification for
+  assigning and reassigning change controls, plus audit-log validation guidance.
+- Diagnostics self-tests: launch **Debug → Diagnostics Hub → Run Self Tests** to execute the built-in harnesses
+  (including the change-control assignment exercise) before shipping.
+
+## Building the app
+
+Install the required .NET workload (see `global.json`) and run:
+
+```bash
+dotnet restore
+dotnet build
+```
+
+Refer to platform-specific documentation for signing, deployment, and device setup.

--- a/Services/AuthService.cs
+++ b/Services/AuthService.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using YasGMP.Models;
+using YasGMP.Services.Interfaces;
 
 namespace YasGMP.Services
 {
@@ -16,7 +17,7 @@ namespace YasGMP.Services
     /// <see cref="AuditService"/>, and tracks minimal session/device forensics.
     /// </para>
     /// </summary>
-    public class AuthService
+    public class AuthService : IAuthContext
     {
         private readonly UserService _userService;
         private readonly AuditService _auditService;

--- a/Services/DatabaseService.TestHooks.cs
+++ b/Services/DatabaseService.TestHooks.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using MySqlConnector;
+
+namespace YasGMP.Services
+{
+    /// <summary>
+    /// Lightweight testing hooks that allow unit/integration harnesses to intercept database operations
+    /// without requiring a live MySQL server. These are internal so they remain invisible to production code.
+    /// </summary>
+    public sealed partial class DatabaseService
+    {
+        internal Func<string, IEnumerable<MySqlParameter>?, CancellationToken, Task<int>>? ExecuteNonQueryOverride { get; set; }
+
+        internal Func<string, IEnumerable<MySqlParameter>?, CancellationToken, Task<object?>>? ExecuteScalarOverride { get; set; }
+
+        internal Func<string, IEnumerable<MySqlParameter>?, CancellationToken, Task<DataTable>>? ExecuteSelectOverride { get; set; }
+
+        internal void ResetTestOverrides()
+        {
+            ExecuteNonQueryOverride = null;
+            ExecuteScalarOverride = null;
+            ExecuteSelectOverride = null;
+        }
+    }
+}

--- a/Services/DatabaseService.cs
+++ b/Services/DatabaseService.cs
@@ -82,6 +82,8 @@ namespace YasGMP.Services
             CancellationToken token = default)
         {
             if (string.IsNullOrWhiteSpace(sql)) throw new ArgumentNullException(nameof(sql));
+            if (ExecuteNonQueryOverride != null)
+                return await ExecuteNonQueryOverride(sql, parameters, token).ConfigureAwait(false);
             await using var conn = CreateConnection();
             await conn.OpenAsync(token).ConfigureAwait(false);
             await using var cmd = new MySqlCommand(sql, conn);
@@ -110,6 +112,8 @@ namespace YasGMP.Services
             CancellationToken token = default)
         {
             if (string.IsNullOrWhiteSpace(sql)) throw new ArgumentNullException(nameof(sql));
+            if (ExecuteScalarOverride != null)
+                return await ExecuteScalarOverride(sql, parameters, token).ConfigureAwait(false);
             await using var conn = CreateConnection();
             await conn.OpenAsync(token).ConfigureAwait(false);
             await using var cmd = new MySqlCommand(sql, conn);
@@ -132,6 +136,8 @@ namespace YasGMP.Services
             CancellationToken token = default)
         {
             if (string.IsNullOrWhiteSpace(sql)) throw new ArgumentNullException(nameof(sql));
+            if (ExecuteSelectOverride != null)
+                return await ExecuteSelectOverride(sql, parameters, token).ConfigureAwait(false);
             await using var conn = CreateConnection();
             await conn.OpenAsync(token).ConfigureAwait(false);
             await using var cmd = new MySqlCommand(sql, conn);

--- a/Services/Interfaces/IAuthContext.cs
+++ b/Services/Interfaces/IAuthContext.cs
@@ -1,0 +1,23 @@
+using YasGMP.Models;
+
+namespace YasGMP.Services.Interfaces
+{
+    /// <summary>
+    /// Minimal authentication context abstraction that exposes the currently authenticated user
+    /// and associated forensic/session metadata required by audit logging.
+    /// </summary>
+    public interface IAuthContext
+    {
+        /// <summary>Currently authenticated user (or <c>null</c> if no session exists).</summary>
+        User? CurrentUser { get; }
+
+        /// <summary>Opaque identifier that ties audit events to the logical user session.</summary>
+        string CurrentSessionId { get; }
+
+        /// <summary>Descriptive device fingerprint captured at sign-in time.</summary>
+        string CurrentDeviceInfo { get; }
+
+        /// <summary>Best-effort IP address associated with the current session.</summary>
+        string CurrentIpAddress { get; }
+    }
+}


### PR DESCRIPTION
## Summary
- add a QA checklist documenting change control assignment and event log verification
- extend the change control view model to log assignment/reassignment events and expose a diagnostics harness
- add database test hooks and surface the harness through the self-test runner; link the checklist from the README

## Testing
- dotnet build *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cab0fa5c088331acc51f312ff17b98