### PR TITLE
Document change control QA flow and tighten harness checks

### DIFF
--- a/Diagnostics/ChangeControlAssignmentHarness.cs
+++ b/Diagnostics/ChangeControlAssignmentHarness.cs
@@ -147,5 +147,28 @@ namespace YasGMP.Diagnostics
     {
         /// <summary>True when at least one INSERT into system_event_log was observed.</summary>
         public bool LoggedAudit => LoggedEvents.Count > 0;
+
+        /// <summary>True when the harness observed a CC_ASSIGN audit event.</summary>
+        public bool HasInitialAssignmentEvent => LoggedEvents.Any(e =>
+            string.Equals(e.EventType, "CC_ASSIGN", StringComparison.OrdinalIgnoreCase));
+
+        /// <summary>True when the harness observed a CC_REASSIGN audit event.</summary>
+        public bool HasReassignmentEvent => LoggedEvents.Any(e =>
+            string.Equals(e.EventType, "CC_REASSIGN", StringComparison.OrdinalIgnoreCase));
+
+        /// <summary>Returns the expected audit event types that did not appear during the harness run.</summary>
+        public IReadOnlyList<string> MissingAuditEvents => _missingAuditEvents ??= ComputeMissingAuditEvents();
+
+        private IReadOnlyList<string>? _missingAuditEvents;
+
+        private IReadOnlyList<string> ComputeMissingAuditEvents()
+        {
+            var missing = new List<string>();
+            if (!HasInitialAssignmentEvent)
+                missing.Add("CC_ASSIGN");
+            if (!HasReassignmentEvent)
+                missing.Add("CC_REASSIGN");
+            return missing;
+        }
     }
 }

--- a/Diagnostics/SelfTestRunner.cs
+++ b/Diagnostics/SelfTestRunner.cs
@@ -148,9 +148,31 @@ namespace YasGMP.Diagnostics
                     ["statusMessages"] = harnessResult.StatusMessages,
                     ["eventSummary"] = eventSummary,
                     ["executedSqlCount"] = harnessResult.ExecutedSql.Count,
-                    ["loggedAudit"] = harnessResult.LoggedAudit
+                    ["loggedAudit"] = harnessResult.LoggedAudit,
+                    ["hasInitialAssignmentEvent"] = harnessResult.HasInitialAssignmentEvent,
+                    ["hasReassignmentEvent"] = harnessResult.HasReassignmentEvent,
+                    ["missingAuditEvents"] = harnessResult.MissingAuditEvents
                 };
-                _trace.Log(DiagLevel.Info, "selftest", "cc_assign_harness", "Change control assignment harness executed.", data: data);
+
+                if (harnessResult.MissingAuditEvents.Count > 0)
+                {
+                    var missing = string.Join(", ", harnessResult.MissingAuditEvents);
+                    _trace.Log(
+                        DiagLevel.Warn,
+                        "selftest",
+                        "cc_assign_harness_missing_audit",
+                        $"Change control assignment harness executed with missing audit events: {missing}.",
+                        data: data);
+                }
+                else
+                {
+                    _trace.Log(
+                        DiagLevel.Info,
+                        "selftest",
+                        "cc_assign_harness",
+                        "Change control assignment harness executed.",
+                        data: data);
+                }
             }
             catch (Exception ex)
             {

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ contains the mobile/desktop client, common domain services, and diagnostics tool
 
 ## Maintainer resources
 
-- [Change Control Assignment QA Checklist](QA/ChangeControlAssignment.md) – step-by-step manual verification for
-  assigning and reassigning change controls, plus audit-log validation guidance.
+- [Change Control Assignment QA Checklist](QA/ChangeControlAssignment.md) – manual flows and harness guidance for
+  verifying change-control assignments and confirming `system_event_log` auditing.
 - Diagnostics self-tests: launch **Debug → Diagnostics Hub → Run Self Tests** to execute the built-in harnesses
   (including the change-control assignment exercise) before shipping.
 


### PR DESCRIPTION
## Summary
- expand the change-control assignment QA checklist with clearer audit expectations and harness instructions
- have the diagnostics self-test surface missing audit events from the harness as warnings
- expose convenience flags on the assignment harness result so diagnostics and QA tooling can check for CC_ASSIGN/CC_REASSIGN rows

## Testing
- `dotnet build` *(fails locally: dotnet CLI not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb9804dcac8331bae8d88601e230f1