### PR TITLE
Align test project TFM with app

### DIFF
--- a/YasGMP.Tests/YasGMP.Tests.csproj
+++ b/YasGMP.Tests/YasGMP.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary
- align YasGMP.Tests target framework with the main app by switching to net8.0-windows10.0.19041.0

## Testing
- dotnet restore yasgmp.sln -p:EnableWindowsTargeting=true
- dotnet build yasgmp.sln -p:EnableWindowsTargeting=true *(fails: Windows XamlCompiler.exe cannot run on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68cba90c12488331ba9862347cc7799a