### PR TITLE
Align test runtime identifier with app

### DIFF
--- a/YasGMP.Tests/YasGMP.Tests.csproj
+++ b/YasGMP.Tests/YasGMP.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary
- align YasGMP.Tests target framework with the main app by switching to net8.0-windows10.0.19041.0
- set the test project's runtime identifier to win10-x64 so the referenced MAUI project builds in compatible configuration

## Testing
- _not run (dotnet CLI is unavailable in the execution environment)_

------
https://chatgpt.com/codex/tasks/task_e_68cba90c12488331ba9862347cc7799a