### PR TITLE
Add runtime identifier for Windows x64 build

### DIFF
--- a/yasgmp.csproj
+++ b/yasgmp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <!-- Windows-only target while debugging (fast, no mobile workloads) -->
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary
- add a Windows x64 runtime identifier to the MAUI project property group

## Testing
- not run (dotnet CLI is unavailable in the container environment)

------
https://chatgpt.com/codex/tasks/task_e_68cbb42166f88331a754dfcec31f3466