### PR TITLE
Use win-x64 RID for MAUI projects

### DIFF
--- a/YasGMP.Tests/YasGMP.Tests.csproj
+++ b/YasGMP.Tests/YasGMP.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/yasgmp.csproj
+++ b/yasgmp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- Windows-only target while debugging (fast, no mobile workloads) -->
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary
- switch the MAUI app to the win-x64 runtime identifier
- update the test project to use the same portable RID

## Testing
- dotnet build yasgmp.sln -p:EnableWindowsTargeting=true (fails: DatabaseServiceDigitalSignatureTests missing YasGMP.* namespaces)


------
https://chatgpt.com/codex/tasks/task_e_68cbb866865c833198b3b8c9009a739d