### PR TITLE
Expose internals to test project

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("YasGMP.Tests")]


### PR DESCRIPTION
## Summary
- add Properties/AssemblyInfo.cs for the MAUI project
- expose internal members to the YasGMP.Tests assembly via InternalsVisibleTo

## Testing
- dotnet build yasgmp.sln -p:EnableWindowsTargeting=true *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbbb985ad88331983e4598127681de