### PR TITLE
Exclude test sources from app project

### DIFF
--- a/yasgmp.csproj
+++ b/yasgmp.csproj
@@ -72,6 +72,9 @@
     <!-- Exclude tooling sources from the main app build -->
     <Compile Remove="tools\**\*.cs" />
     <None Include="tools\**\*.cs" />
+    <!-- Exclude test sources from the main app build -->
+    <Compile Remove="YasGMP.Tests\**\*.cs" />
+    <None Include="YasGMP.Tests\**\*.cs" />
   </ItemGroup>
 
   <Target Name="DbSyncAnalyzer" BeforeTargets="Build" Condition="'$(RUN_DB_ANALYZER_ON_BUILD)'=='true'">


### PR DESCRIPTION
## Summary
- exclude the YasGMP.Tests source files from the main app project's compilation
- include the excluded test files as None items to keep them in the project

## Testing
- dotnet build yasgmp.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc29655f083319a7378131256c305