### PR TITLE
Align test project target with MAUI app

### DIFF
--- a/YasGMP.Tests/YasGMP.Tests.csproj
+++ b/YasGMP.Tests/YasGMP.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Align test target with the MAUI app so the project reference remains compatible -->
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
- document that the test project targets the Windows TFM required by the MAUI app
- allow cross-compiling the tests by enabling Windows targeting on non-Windows hosts

## Testing
- dotnet restore YasGMP.Tests/YasGMP.Tests.csproj *(fails: requires MAUI workloads unavailable on this platform)*
- dotnet build YasGMP.Tests/YasGMP.Tests.csproj *(fails: requires MAUI workloads unavailable on this platform)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc32c7e788331b516a1c06c407f9b