### PR TITLE
Clarify InternalsVisibleTo rationale

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,3 +1,5 @@
 using System.Runtime.CompilerServices;
 
+// Allow the test project to interact with the DatabaseService test hooks without widening
+// their visibility beyond internal.
 [assembly: InternalsVisibleTo("YasGMP.Tests")]


### PR DESCRIPTION
## Summary
- document the InternalsVisibleTo attribute that grants the test project access to the internal DatabaseService test hooks

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cbc49b2f188331b2638ba5d60fbfea