### PR TITLE
Handle CAPA digital signature verification

### DIFF
--- a/Services/DatabaseService.DigitalSignatures.Extensions.cs
+++ b/Services/DatabaseService.DigitalSignatures.Extensions.cs
@@ -223,6 +223,16 @@ FROM digital_signatures WHERE id=@id LIMIT 1";
                         var result = DigitalSignatureHelper.ComputeSignature(qualification, sessionId, deviceInfo);
                         return new ExpectedSignatureResult(result.Hash, result.Payload, null);
                     }
+                case "capa_cases":
+                case "capa_case":
+                case "capa":
+                    {
+                        var capaCase = await db.GetCapaCaseByIdAsync(signature.RecordId, token).ConfigureAwait(false);
+                        if (capaCase == null)
+                            return new ExpectedSignatureResult(null, null, "capa_case_missing");
+                        var result = DigitalSignatureHelper.ComputeSignature(capaCase, sessionId, deviceInfo);
+                        return new ExpectedSignatureResult(result.Hash, result.Payload, null);
+                    }
                 default:
                     return new ExpectedSignatureResult(null, null, $"unsupported_table={signature.TableName}");
             }


### PR DESCRIPTION
## Summary
- update the digital signature verification helper to load CAPA cases and compute their expected signature payloads
- return a clear failure reason when a referenced CAPA case is missing
- extend database service signature tests to cover CAPA success and missing-record scenarios

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc55c28748331986cb544d46a0ff9