### PR TITLE
Fix calibration self reference mappings

### DIFF
--- a/Data/YasGmpDbContext.cs
+++ b/Data/YasGmpDbContext.cs
@@ -205,6 +205,16 @@ namespace YasGMP.Data
                 .HasConversion(new EnumToStringConverter<WorkOrderActionType>())
                 .IsRequired();
 
+            modelBuilder.Entity<Calibration>()
+                .HasOne(c => c.PreviousCalibration)
+                .WithMany()
+                .HasForeignKey(c => c.PreviousCalibrationId);
+
+            modelBuilder.Entity<Calibration>()
+                .HasOne(c => c.NextCalibration)
+                .WithMany()
+                .HasForeignKey(c => c.NextCalibrationId);
+
             // Primjer konfiguracije odnosa između WorkOrder i WorkOrderAudit
             modelBuilder.Entity<WorkOrderAudit>()
                 .HasOne(a => a.WorkOrder)

--- a/Models/Calibration.cs
+++ b/Models/Calibration.cs
@@ -119,7 +119,6 @@ namespace YasGMP.Models
 
         /// <summary>Navigation to previous calibration (optional).</summary>
         [ForeignKey(nameof(PreviousCalibrationId))]
-        [InverseProperty("NextCalibration")]
         public virtual Calibration? PreviousCalibration { get; set; }
 
         /// <summary>Bonus: Next planned calibration reference (for traceability).</summary>
@@ -128,7 +127,6 @@ namespace YasGMP.Models
 
         /// <summary>Navigation to next calibration (optional).</summary>
         [ForeignKey(nameof(NextCalibrationId))]
-        [InverseProperty("PreviousCalibration")]
         public virtual Calibration? NextCalibration { get; set; }
 
         /// <summary>Full chain/version support for audit, rollback, event sourcing.</summary>


### PR DESCRIPTION
## Summary
- remove the conflicting InverseProperty attributes from the calibration chaining navigations
- configure the calibration self-references explicitly in OnModelCreating to avoid ambiguity while preserving chaining

## Testing
- dotnet build *(fails: required maui-tizen workload is not installed in the container)*
- dotnet ef migrations add CalibrationChainFix --no-build *(fails: restore requires the maui-tizen workload, leaving project.assets.json unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd1335f648331986e37657105b489