### PR TITLE
Configure composite keys for RBAC join tables

### DIFF
--- a/Data/YasGmpDbContext.cs
+++ b/Data/YasGmpDbContext.cs
@@ -245,6 +245,105 @@ namespace YasGMP.Data
                 .HasIndex(u => u.Username)
                 .IsUnique();
 
+            modelBuilder.Entity<RolePermission>(entity =>
+            {
+                entity.ToTable("role_permissions");
+
+                entity.HasKey(rp => new { rp.RoleId, rp.PermissionId });
+
+                entity.HasOne(rp => rp.Role)
+                    .WithMany(r => r.RolePermissions)
+                    .HasForeignKey(rp => rp.RoleId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(rp => rp.Permission)
+                    .WithMany(p => p.RolePermissions)
+                    .HasForeignKey(rp => rp.PermissionId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(rp => rp.AssignedBy)
+                    .WithMany()
+                    .HasForeignKey(rp => rp.AssignedById)
+                    .OnDelete(DeleteBehavior.SetNull);
+            });
+
+            modelBuilder.Entity<UserPermission>(entity =>
+            {
+                entity.ToTable("user_permissions");
+
+                entity.HasKey(up => new { up.UserId, up.PermissionId });
+
+                entity.HasOne(up => up.User)
+                    .WithMany()
+                    .HasForeignKey(up => up.UserId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(up => up.Permission)
+                    .WithMany(p => p.UserPermissions)
+                    .HasForeignKey(up => up.PermissionId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(up => up.AssignedBy)
+                    .WithMany()
+                    .HasForeignKey(up => up.AssignedById)
+                    .OnDelete(DeleteBehavior.SetNull);
+            });
+
+            modelBuilder.Entity<UserRoleMapping>(entity =>
+            {
+                entity.ToTable("user_roles");
+
+                entity.HasKey(urm => new { urm.UserId, urm.RoleId });
+
+                entity.HasOne(urm => urm.User)
+                    .WithMany()
+                    .HasForeignKey(urm => urm.UserId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(urm => urm.Role)
+                    .WithMany()
+                    .HasForeignKey(urm => urm.RoleId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(urm => urm.AssignedBy)
+                    .WithMany()
+                    .HasForeignKey(urm => urm.AssignedById)
+                    .OnDelete(DeleteBehavior.SetNull);
+            });
+
+            modelBuilder.Entity<Role>()
+                .HasMany(r => r.Permissions)
+                .WithMany(p => p.Roles)
+                .UsingEntity<RolePermission>(
+                    j => j.HasOne(rp => rp.Permission)
+                        .WithMany(p => p.RolePermissions)
+                        .HasForeignKey(rp => rp.PermissionId),
+                    j => j.HasOne(rp => rp.Role)
+                        .WithMany(r => r.RolePermissions)
+                        .HasForeignKey(rp => rp.RoleId));
+
+            modelBuilder.Entity<User>()
+                .HasMany(u => u.Permissions)
+                .WithMany(p => p.Users)
+                .UsingEntity<UserPermission>(
+                    j => j.HasOne(up => up.Permission)
+                        .WithMany(p => p.UserPermissions)
+                        .HasForeignKey(up => up.PermissionId),
+                    j => j.HasOne(up => up.User)
+                        .WithMany()
+                        .HasForeignKey(up => up.UserId));
+
+            modelBuilder.Entity<User>()
+                .HasMany(u => u.Roles)
+                .WithMany(r => r.Users)
+                .UsingEntity<UserRoleMapping>(
+                    j => j.HasOne(urm => urm.Role)
+                        .WithMany()
+                        .HasForeignKey(urm => urm.RoleId),
+                    j => j.HasOne(urm => urm.User)
+                        .WithMany()
+                        .HasForeignKey(urm => urm.UserId));
+
             ConfigureAdminActivityLog(modelBuilder);
             ConfigureApiKey(modelBuilder);
             ConfigureContractorInterventionAudit(modelBuilder);

--- a/Models/RolePermission.cs
+++ b/Models/RolePermission.cs
@@ -22,7 +22,7 @@ namespace YasGMP.Models
         /// <summary>
         /// Role ID (Foreign Key, part of composite key).
         /// </summary>
-        [Key, Column("role_id", Order = 0)]
+        [Column("role_id")]
         [Display(Name = "Uloga")]
         public int RoleId { get; set; }
 
@@ -35,7 +35,7 @@ namespace YasGMP.Models
         /// <summary>
         /// Permission ID (Foreign Key, part of composite key).
         /// </summary>
-        [Key, Column("permission_id", Order = 1)]
+        [Column("permission_id")]
         [Display(Name = "Dozvola")]
         public int PermissionId { get; set; }
 

--- a/Models/UserPermission.cs
+++ b/Models/UserPermission.cs
@@ -23,7 +23,7 @@ namespace YasGMP.Models
         /// <summary>
         /// User ID (Foreign Key, part of composite key).
         /// </summary>
-        [Key, Column("user_id", Order = 0)]
+        [Column("user_id")]
         [Display(Name = "Korisnik")]
         public int UserId { get; set; }
 
@@ -36,7 +36,7 @@ namespace YasGMP.Models
         /// <summary>
         /// Permission ID (Foreign Key, part of composite key).
         /// </summary>
-        [Key, Column("permission_id", Order = 1)]
+        [Column("permission_id")]
         [Display(Name = "Dozvola")]
         public int PermissionId { get; set; }
 

--- a/Models/UserRoleMapping.cs
+++ b/Models/UserRoleMapping.cs
@@ -14,7 +14,7 @@ namespace YasGMP.Models
         /// <summary>
         /// User ID (Foreign Key, part of composite key).
         /// </summary>
-        [Key, Column("user_id", Order = 0)]
+        [Column("user_id")]
         [Display(Name = "Korisnik")]
         public int UserId { get; set; }
 
@@ -22,14 +22,13 @@ namespace YasGMP.Models
         /// Navigation property for the assigned user.
         /// </summary>
         [ForeignKey("UserId")]
-        public virtual User User { get; set; } = null!
+        public virtual User User { get; set; } = null!;
 
-        ;
 
         /// <summary>
         /// Role ID (Foreign Key, part of composite key).
         /// </summary>
-        [Key, Column("role_id", Order = 1)]
+        [Column("role_id")]
         [Display(Name = "Uloga")]
         public int RoleId { get; set; }
 


### PR DESCRIPTION
## Summary
- remove data annotation key attributes from the role, user permission, and user role join entities so EF stops treating each column as a separate primary key
- configure the RolePermission, UserPermission, and UserRoleMapping entities with composite keys and explicit relationships inside `YasGmpDbContext`
- fix the `UserRoleMapping.User` navigation property initialization so the model compiles after the annotation changes

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd55aa9f483319f42a94300e0ee6f