### PR TITLE
Configure attachment user relationships

### DIFF
--- a/Data/YasGmpDbContext.cs
+++ b/Data/YasGmpDbContext.cs
@@ -199,6 +199,18 @@ namespace YasGMP.Data
         {
             base.OnModelCreating(modelBuilder);
 
+            modelBuilder.Entity<Attachment>()
+                .HasOne(a => a.UploadedBy)
+                .WithMany(u => u.UploadedAttachments)
+                .HasForeignKey(a => a.UploadedById)
+                .OnDelete(DeleteBehavior.SetNull);
+
+            modelBuilder.Entity<Attachment>()
+                .HasOne(a => a.ApprovedBy)
+                .WithMany()
+                .HasForeignKey(a => a.ApprovedById)
+                .OnDelete(DeleteBehavior.SetNull);
+
             // Konfiguracija enum polja u WorkOrderAudit (Action) kao string u bazi
             modelBuilder.Entity<WorkOrderAudit>()
                 .Property(a => a.Action)


### PR DESCRIPTION
## Summary
- configure EF relationship pairing Attachment.UploadedBy with User.UploadedAttachments
- map Attachment.ApprovedBy optional relationship without inverse collection

## Testing
- ⚠️ `dotnet build` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbdc9b86008331864dfb55a8a60dc4