### PR TITLE
Configure DelegatedPermission relationships

### DIFF
--- a/Data/YasGmpDbContext.cs
+++ b/Data/YasGmpDbContext.cs
@@ -358,6 +358,24 @@ namespace YasGMP.Data
                         .WithMany()
                         .HasForeignKey(urm => urm.UserId));
 
+            modelBuilder.Entity<DelegatedPermission>(entity =>
+            {
+                entity.HasOne(dp => dp.FromUser)
+                    .WithMany(u => u.DelegatedPermissions)
+                    .HasForeignKey(dp => dp.FromUserId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(dp => dp.ToUser)
+                    .WithMany()
+                    .HasForeignKey(dp => dp.ToUserId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(dp => dp.ApprovedBy)
+                    .WithMany()
+                    .HasForeignKey(dp => dp.ApprovedById)
+                    .OnDelete(DeleteBehavior.SetNull);
+            });
+
             ConfigureAdminActivityLog(modelBuilder);
             ConfigureApiKey(modelBuilder);
             ConfigureContractorInterventionAudit(modelBuilder);


### PR DESCRIPTION
## Summary
- configure the DelegatedPermission entity mapping so EF Core understands the FromUser, ToUser, and ApprovedBy relationships
- set explicit delete behaviors to avoid ambiguity when the context is initialized

## Testing
- dotnet build yasgmp.sln *(fails: `dotnet`: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe36c0a2c8331b7df6d92c74b6bd2