### PR TITLE
Disambiguate incident audit log relationships

### DIFF
--- a/Models/IncidentReport.cs
+++ b/Models/IncidentReport.cs
@@ -82,7 +82,10 @@ namespace YasGMP.Models
         public List<Attachment> Attachments { get; set; } = new();
 
         // audit
+        [InverseProperty(nameof(IncidentAuditLog.Incident))]
         public List<IncidentAuditLog> AuditLogs { get; set; } = new();
+
+        [InverseProperty(nameof(IncidentAuditLog.WorkflowIncident))]
         public List<IncidentAuditLog> WorkflowHistory { get; set; } = new();
     }
 
@@ -97,7 +100,14 @@ namespace YasGMP.Models
         public int IncidentReportId { get; set; }
 
         [ForeignKey(nameof(IncidentReportId))]
+        [InverseProperty(nameof(IncidentReport.AuditLogs))]
         public IncidentReport? Incident { get; set; }
+
+        public int? WorkflowIncidentReportId { get; set; }
+
+        [ForeignKey(nameof(WorkflowIncidentReportId))]
+        [InverseProperty(nameof(IncidentReport.WorkflowHistory))]
+        public IncidentReport? WorkflowIncident { get; set; }
 
         public DateTime Timestamp { get; set; } = DateTime.Now;
 


### PR DESCRIPTION
## Summary
- add explicit inverse property mappings for IncidentReport.AuditLogs and WorkflowHistory
- introduce a dedicated WorkflowIncident navigation and key on IncidentAuditLog to separate the two relationships

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe5f7c4e883319b807e34d438624b