### PR TITLE
Configure Permission audit relationships

### DIFF
--- a/Data/YasGmpDbContext.cs
+++ b/Data/YasGmpDbContext.cs
@@ -246,6 +246,18 @@ namespace YasGMP.Data
                 .HasForeignKey(a => a.ApprovedById)
                 .OnDelete(DeleteBehavior.SetNull);
 
+            modelBuilder.Entity<Permission>()
+                .HasOne(p => p.CreatedBy)
+                .WithMany()
+                .HasForeignKey(p => p.CreatedById)
+                .OnDelete(DeleteBehavior.SetNull);
+
+            modelBuilder.Entity<Permission>()
+                .HasOne(p => p.LastModifiedBy)
+                .WithMany()
+                .HasForeignKey(p => p.LastModifiedById)
+                .OnDelete(DeleteBehavior.SetNull);
+
             // Konfiguracija enum polja u WorkOrderAudit (Action) kao string u bazi
             modelBuilder.Entity<WorkOrderAudit>()
                 .Property(a => a.Action)


### PR DESCRIPTION
## Summary
- configure the Permission entity audit relationships to set CreatedBy and LastModifiedBy foreign keys to null on user deletion

## Testing
- `dotnet build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe7ce33d083318678caab2f53a3e5