### PR TITLE
Configure role audit relationships

### DIFF
--- a/Data/YasGmpDbContext.cs
+++ b/Data/YasGmpDbContext.cs
@@ -258,6 +258,18 @@ namespace YasGMP.Data
                 .HasForeignKey(p => p.LastModifiedById)
                 .OnDelete(DeleteBehavior.SetNull);
 
+            modelBuilder.Entity<Role>()
+                .HasOne(r => r.CreatedBy)
+                .WithMany()
+                .HasForeignKey(r => r.CreatedById)
+                .OnDelete(DeleteBehavior.SetNull);
+
+            modelBuilder.Entity<Role>()
+                .HasOne(r => r.LastModifiedBy)
+                .WithMany()
+                .HasForeignKey(r => r.LastModifiedById)
+                .OnDelete(DeleteBehavior.SetNull);
+
             // Konfiguracija enum polja u WorkOrderAudit (Action) kao string u bazi
             modelBuilder.Entity<WorkOrderAudit>()
                 .Property(a => a.Action)


### PR DESCRIPTION
## Summary
- configure the Role entity audit navigations to reference users via EF Core relationships

## Testing
- `dotnet ef dbcontext info` *(fails: dotnet CLI is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe889db3083318ce7fc2a5e1d3408