### PR TITLE
Configure photo entity relationships

### DIFF
--- a/Data/YasGmpDbContext.cs
+++ b/Data/YasGmpDbContext.cs
@@ -246,6 +246,21 @@ namespace YasGMP.Data
                 .HasForeignKey(a => a.ApprovedById)
                 .OnDelete(DeleteBehavior.SetNull);
 
+            modelBuilder.Entity<Photo>()
+                .HasOne(p => p.UploadedBy)
+                .WithMany(u => u.UploadedPhotos)
+                .HasForeignKey(p => p.UploadedById);
+
+            modelBuilder.Entity<Photo>()
+                .HasOne(p => p.ApprovedBy)
+                .WithMany()
+                .HasForeignKey(p => p.ApprovedById);
+
+            modelBuilder.Entity<Photo>()
+                .HasOne(p => p.LastModifiedBy)
+                .WithMany()
+                .HasForeignKey(p => p.LastModifiedById);
+
             modelBuilder.Entity<Permission>()
                 .HasOne(p => p.CreatedBy)
                 .WithMany()

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -193,6 +193,7 @@ namespace YasGMP.Models
         public virtual ICollection<SessionLog> SessionLogs { get; set; } = new List<SessionLog>();
         public virtual ICollection<WorkOrder> CreatedWorkOrders { get; set; } = new List<WorkOrder>();
         public virtual ICollection<WorkOrder> AssignedWorkOrders { get; set; } = new List<WorkOrder>();
+        [InverseProperty(nameof(Photo.UploadedBy))]
         public virtual ICollection<Photo> UploadedPhotos { get; set; } = new List<Photo>();
         public virtual ICollection<Attachment> UploadedAttachments { get; set; } = new List<Attachment>();
         public virtual ICollection<AdminActivityLog> AdminActivityLogs { get; set; } = new List<AdminActivityLog>();


### PR DESCRIPTION
## Summary
- configure the Photo entity's relationships to UploadedBy, ApprovedBy, and LastModifiedBy foreign keys in the DbContext
- annotate User.UploadedPhotos with the corresponding inverse property for clarity

## Testing
- ⚠️ `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbede660148331af7a5d74a97220a5