### PR TITLE
Configure session log impersonation relationship

### DIFF
--- a/Data/YasGmpDbContext.cs
+++ b/Data/YasGmpDbContext.cs
@@ -261,6 +261,17 @@ namespace YasGMP.Data
                 .WithMany()
                 .HasForeignKey(p => p.LastModifiedById);
 
+            modelBuilder.Entity<SessionLog>()
+                .HasOne(sl => sl.User)
+                .WithMany(u => u.SessionLogs)
+                .HasForeignKey(sl => sl.UserId);
+
+            modelBuilder.Entity<SessionLog>()
+                .HasOne(sl => sl.ImpersonatedBy)
+                .WithMany()
+                .HasForeignKey(sl => sl.ImpersonatedById)
+                .OnDelete(DeleteBehavior.SetNull);
+
             modelBuilder.Entity<Permission>()
                 .HasOne(p => p.CreatedBy)
                 .WithMany()

--- a/Models/SessionLog.cs
+++ b/Models/SessionLog.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace YasGMP.Models
 {
@@ -52,7 +53,8 @@ namespace YasGMP.Models
         public int? ImpersonatedById { get; set; }
 
         /// <summary>Navigation property for impersonating user.</summary>
-        public User ImpersonatedBy { get; set; } = null!;
+        [ForeignKey(nameof(ImpersonatedById))]
+        public User? ImpersonatedBy { get; set; }
 
         /// <summary>True if temporary escalation was granted for this session.</summary>
         [Display(Name = "Privremena eskalacija")]


### PR DESCRIPTION
## Summary
- mark SessionLog.ImpersonatedBy as an optional foreign key navigation tied to ImpersonatedById
- configure SessionLog relationships in OnModelCreating for both the owning user and optional impersonator

## Testing
- dotnet build yasgmp.sln *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf43ac5888331b74e31c73123bb16