### PR TITLE
Configure WorkOrder user relationships

### DIFF
--- a/Data/YasGmpDbContext.cs
+++ b/Data/YasGmpDbContext.cs
@@ -313,6 +313,30 @@ namespace YasGMP.Data
                 .HasForeignKey(c => c.NextCalibrationId);
 
             // Primjer konfiguracije odnosa između WorkOrder i WorkOrderAudit
+            modelBuilder.Entity<WorkOrder>()
+                .HasOne(wo => wo.CreatedBy)
+                .WithMany(u => u.CreatedWorkOrders)
+                .HasForeignKey(wo => wo.CreatedById)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<WorkOrder>()
+                .HasOne(wo => wo.AssignedTo)
+                .WithMany(u => u.AssignedWorkOrders)
+                .HasForeignKey(wo => wo.AssignedToId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<WorkOrder>()
+                .HasOne(wo => wo.RequestedBy)
+                .WithMany()
+                .HasForeignKey(wo => wo.RequestedById)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<WorkOrder>()
+                .HasOne(wo => wo.LastModifiedBy)
+                .WithMany()
+                .HasForeignKey(wo => wo.LastModifiedById)
+                .OnDelete(DeleteBehavior.SetNull);
+
             modelBuilder.Entity<WorkOrderAudit>()
                 .HasOne(a => a.WorkOrder)
                 .WithMany(w => w.AuditTrail)


### PR DESCRIPTION
## Summary
- configure the WorkOrder to User navigation mappings so each relationship uses an explicit delete behavior

## Testing
- ~/.dotnet/dotnet build /p:EnableWindowsTargeting=true *(fails: Microsoft.UI.Xaml XamlCompiler.exe cannot run on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf6e4cb44833198598f5ba7bc1f3c