### PR TITLE
Configure work order to incident relationship

### DIFF
--- a/Data/YasGmpDbContext.cs
+++ b/Data/YasGmpDbContext.cs
@@ -337,6 +337,12 @@ namespace YasGMP.Data
                 .HasForeignKey(wo => wo.LastModifiedById)
                 .OnDelete(DeleteBehavior.SetNull);
 
+            modelBuilder.Entity<WorkOrder>()
+                .HasOne(wo => wo.Incident)
+                .WithOne(i => i.WorkOrder)
+                .HasForeignKey<WorkOrder>(wo => wo.IncidentId)
+                .OnDelete(DeleteBehavior.SetNull);
+
             modelBuilder.Entity<WorkOrderAudit>()
                 .HasOne(a => a.WorkOrder)
                 .WithMany(w => w.AuditTrail)

--- a/Models/Incident.cs
+++ b/Models/Incident.cs
@@ -47,7 +47,6 @@ namespace YasGMP.Models
 
         [Column("work_order_id")]
         public int? WorkOrderId { get; set; }
-        [ForeignKey(nameof(WorkOrderId))]
         public virtual WorkOrder? WorkOrder { get; set; }
 
         [Column("capa_case_id")]

--- a/Models/WorkOrder.cs
+++ b/Models/WorkOrder.cs
@@ -146,7 +146,6 @@ namespace YasGMP.Models
         [Display(Name = "Incident")]
         public int? IncidentId { get; set; }
 
-        [ForeignKey("IncidentId")]
         public virtual Incident? Incident { get; set; }
 
         // ========== RESULTS / FINDINGS ==========


### PR DESCRIPTION
## Summary
- remove redundant `[ForeignKey]` attributes from the work order/incident navigations
- configure the work order to incident one-to-one relationship explicitly in the DbContext with a nullifying delete behavior

## Testing
- `dotnet build` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf82b22188331ba2c35bb7be33753