### PR TITLE
Add missing enum namespace to ChangeControlViewModel

### DIFF
--- a/ViewModels/ChangeControlViewModel.cs
+++ b/ViewModels/ChangeControlViewModel.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using MySqlConnector;
 using Microsoft.Maui.Controls;
 using YasGMP.Models;
+using YasGMP.Models.Enums;
 using YasGMP.Services;
 using YasGMP.Services.Interfaces;
 


### PR DESCRIPTION
## Summary
- import `YasGMP.Models.Enums` in `ChangeControlViewModel` so the `ChangeControlStatus` enum resolves

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f8d7db548331a8c056726f0dd5f5