### PR TITLE
Add not mapped counters to part schema

### DIFF
--- a/Models/Part.Schema.cs
+++ b/Models/Part.Schema.cs
@@ -50,6 +50,12 @@ namespace YasGMP.Models
         [NotMapped]
         public bool IsWarehouseStockCritical { get; set; }
 
+        [NotMapped]
+        public int LowWarehouseCount { get; set; } = 0;
+
+        [NotMapped]
+        public int LinkedWorkOrdersCount { get; set; } = 0;
+
         private List<string> Split(string? raw) => string.IsNullOrWhiteSpace(raw)
             ? new List<string>()
             : raw!.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();


### PR DESCRIPTION
## Summary
- add not mapped helpers on the Part schema for low warehouse and linked work orders counts

## Testing
- `dotnet build` *(fails: command not found `dotnet` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fb1460f0833188957e768b4f9b1f