### PR TITLE
Adjust user role relationship to avoid navigation conflict

### DIFF
--- a/Data/YasGmpDbContext.cs
+++ b/Data/YasGmpDbContext.cs
@@ -864,7 +864,7 @@ namespace YasGMP.Data
                     .HasConstraintName("fk_users_last_modified_by");
 
                 entity.HasOne<Role>()
-                    .WithMany(r => r.Users)
+                    .WithMany()
                     .HasForeignKey(u => u.RoleId)
                     .OnDelete(DeleteBehavior.SetNull)
                     .HasConstraintName("fk_users_role");


### PR DESCRIPTION
## Summary
- update the User->Role relationship configuration to avoid using the Role.Users navigation so it no longer conflicts with the many-to-many setup

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d1072d7b488331b6716be8821c8b01