### PR TITLE
Mark RiskWorkflowEntry as not mapped

### DIFF
--- a/Data/YasGmpDbContext.cs
+++ b/Data/YasGmpDbContext.cs
@@ -142,7 +142,6 @@ namespace YasGMP.Data
         public DbSet<ResponsibleParty> ResponsibleParties { get; set; }
         public DbSet<RiskAssessment> RiskAssessments { get; set; }
         public DbSet<RiskAssessmentAuditLog> RiskAssessmentAuditLogs { get; set; }
-        public DbSet<RiskWorkflowEntry> RiskWorkflowEntries { get; set; }
         public DbSet<Role> Roles { get; set; }
         public DbSet<RoleAudit> RoleAudits { get; set; }
         public DbSet<RolePermission> RolePermissions { get; set; }

--- a/Models/RiskAssessment.cs
+++ b/Models/RiskAssessment.cs
@@ -157,6 +157,7 @@ namespace YasGMP.Models
     /// <b>RiskWorkflowEntry</b> – Lightweight workflow history line for a risk assessment (for UI/export).
     /// Use DB audit tables for authoritative history; this is a convenience projection.
     /// </summary>
+    [NotMapped]
     public class RiskWorkflowEntry
     {
         /// <summary>UTC timestamp of the workflow event.</summary>


### PR DESCRIPTION
## Summary
- annotate RiskWorkflowEntry with NotMapped to keep it out of EF Core entity mapping
- remove the RiskWorkflowEntry DbSet from YasGmpDbContext so EF Core no longer expects a mapped table

## Testing
- `dotnet build yasgmp.sln` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d10965a82483318b816a068fd84c5d