### PR TITLE
Fix quality event component mappings

### DIFF
--- a/Data/YasGmpDbContext.cs
+++ b/Data/YasGmpDbContext.cs
@@ -1269,8 +1269,8 @@ namespace YasGMP.Data
                     .HasColumnName("date_close")
                     .HasColumnType("date");
                 entity.Property(e => e.Description).HasColumnName("description");
-                entity.Property(e => e.RelatedMachineId).HasColumnName("related_machine");
-                entity.Property(e => e.RelatedComponentId).HasColumnName("related_component");
+                entity.Property(e => e.RelatedMachineId).HasColumnName("related_machine_id");
+                entity.Property(e => e.RelatedComponentId).HasColumnName("related_component_id");
                 entity.Property(e => e.StatusRaw)
                     .HasColumnName("status")
                     .HasMaxLength(12);


### PR DESCRIPTION
## Summary
- align the QualityEvent foreign keys to the *_id columns so they do not conflict with the legacy column mappings

## Testing
- dotnet build *(fails: `dotnet`: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d110379e6c8331999ff21520298546