### PR TITLE
Align user permission mapping with navigation properties

### DIFF
--- a/Data/YasGmpDbContext.cs
+++ b/Data/YasGmpDbContext.cs
@@ -397,28 +397,6 @@ namespace YasGMP.Data
                     .OnDelete(DeleteBehavior.SetNull);
             });
 
-            modelBuilder.Entity<UserPermission>(entity =>
-            {
-                entity.ToTable("user_permissions");
-
-                entity.HasKey(up => new { up.UserId, up.PermissionId });
-
-                entity.HasOne(up => up.User)
-                    .WithMany()
-                    .HasForeignKey(up => up.UserId)
-                    .OnDelete(DeleteBehavior.Cascade);
-
-                entity.HasOne(up => up.Permission)
-                    .WithMany()
-                    .HasForeignKey(up => up.PermissionId)
-                    .OnDelete(DeleteBehavior.Cascade);
-
-                entity.HasOne(up => up.AssignedBy)
-                    .WithMany()
-                    .HasForeignKey(up => up.AssignedById)
-                    .OnDelete(DeleteBehavior.SetNull);
-            });
-
             modelBuilder.Entity<UserRoleMapping>(entity =>
             {
                 entity.ToTable("user_roles");
@@ -458,10 +436,10 @@ namespace YasGMP.Data
                 .WithMany(p => p.Users)
                 .UsingEntity<UserPermission>(
                     j => j.HasOne(up => up.Permission)
-                        .WithMany()
+                        .WithMany(p => p.UserPermissions)
                         .HasForeignKey(up => up.PermissionId),
                     j => j.HasOne(up => up.User)
-                        .WithMany()
+                        .WithMany(u => u.UserPermissions)
                         .HasForeignKey(up => up.UserId));
 
             modelBuilder.Entity<User>()
@@ -983,7 +961,7 @@ namespace YasGMP.Data
                     .OnDelete(DeleteBehavior.SetNull)
                     .HasConstraintName("fk_up_by");
 
-                entity.HasOne<User>()
+                entity.HasOne(up => up.AssignedBy)
                     .WithMany()
                     .HasForeignKey(up => up.AssignedById)
                     .OnDelete(DeleteBehavior.SetNull);

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -187,6 +187,7 @@ namespace YasGMP.Models
 
         public virtual ICollection<Role> Roles { get; set; } = new List<Role>();
         public virtual ICollection<Permission> Permissions { get; set; } = new List<Permission>();
+        public virtual ICollection<UserPermission> UserPermissions { get; set; } = new List<UserPermission>();
         public virtual ICollection<DelegatedPermission> DelegatedPermissions { get; set; } = new List<DelegatedPermission>();
         public virtual ICollection<AuditLog> AuditLogs { get; set; } = new List<AuditLog>();
         public virtual ICollection<DigitalSignature> DigitalSignatures { get; set; } = new List<DigitalSignature>();


### PR DESCRIPTION
## Summary
- remove the redundant user permission entity configuration so only the scaffolded mapping remains
- update the many-to-many setup to reuse existing navigation properties, including the AssignedBy navigation
- expose the User.UserPermissions collection so EF can align the join entity mapping

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d118b93e4083319d8de81e89708f72