### PR TITLE
Stream attachments through database with encryption and audit logging

### DIFF
--- a/Data/Migrations/202411010001_AttachmentContentIndex.cs
+++ b/Data/Migrations/202411010001_AttachmentContentIndex.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace YasGMP.Data.Migrations
+{
+    public partial class AttachmentContentIndex : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("ALTER TABLE attachments MODIFY file_path VARCHAR(512) NULL;");
+            migrationBuilder.Sql("CREATE UNIQUE INDEX ux_attachments_sha_size ON attachments (file_hash, file_size);");
+            migrationBuilder.Sql("UPDATE attachments SET file_path = NULL WHERE file_content IS NOT NULL;");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP INDEX ux_attachments_sha_size ON attachments;");
+        }
+    }
+}

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -80,6 +80,27 @@ namespace YasGMP
             builder.Services.AddSingleton<IEnumerable<YasGMP.Diagnostics.ILogSink>>(sinksList);
             builder.Services.AddSingleton(new DiagnosticsHub(diagCtx, sinksList));
 
+            var encryptionOptions = new AttachmentEncryptionOptions
+            {
+                KeyMaterial = Environment.GetEnvironmentVariable("YASGMP_ATTACHMENT_KEY")
+                              ?? diagConfig["Attachments:Encryption:Key"],
+                KeyId = Environment.GetEnvironmentVariable("YASGMP_ATTACHMENT_KEY_ID")
+                         ?? diagConfig["Attachments:Encryption:KeyId"]
+                         ?? "default"
+            };
+
+            var chunkEnv = Environment.GetEnvironmentVariable("YASGMP_ATTACHMENT_CHUNK_SIZE");
+            if (!string.IsNullOrWhiteSpace(chunkEnv) && int.TryParse(chunkEnv, out var chunkSizeEnv) && chunkSizeEnv > 0)
+            {
+                encryptionOptions.ChunkSize = chunkSizeEnv;
+            }
+            else if (int.TryParse(diagConfig["Attachments:Encryption:ChunkSize"], out var chunkSizeCfg) && chunkSizeCfg > 0)
+            {
+                encryptionOptions.ChunkSize = chunkSizeCfg;
+            }
+
+            builder.Services.AddSingleton(encryptionOptions);
+
             // Optional: register Syncfusion license if provided (prevents trial watermark)
             try
             {

--- a/Models/Attachment.cs
+++ b/Models/Attachment.cs
@@ -43,10 +43,10 @@ namespace YasGMP.Models
         /// <summary>
         /// File storage path, URL, or blob identifier (location on disk/cloud/DB).
         /// </summary>
-        [Required, StringLength(512)]
+        [StringLength(512)]
         [Column("file_path")]
         [Display(Name = "Putanja/URL")]
-        public string FilePath { get; set; } = string.Empty;
+        public string? FilePath { get; set; }
 
         /// <summary>
         /// File extension/type (pdf, jpg, docx, etc.).

--- a/Services/AttachmentEncryptionOptions.cs
+++ b/Services/AttachmentEncryptionOptions.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace YasGMP.Services
+{
+    /// <summary>
+    /// Configuration options for attachment envelope encryption.
+    /// </summary>
+    public class AttachmentEncryptionOptions
+    {
+        /// <summary>
+        /// Base64 or hex encoded master key material used for AES-GCM encryption.
+        /// </summary>
+        public string? KeyMaterial { get; set; }
+
+        /// <summary>
+        /// Logical identifier for the key material (logged in audit events).
+        /// </summary>
+        public string KeyId { get; set; } = "default";
+
+        /// <summary>
+        /// Preferred chunk size (in bytes) when streaming attachment payloads.
+        /// </summary>
+        public int ChunkSize { get; set; } = 128 * 1024;
+    }
+}

--- a/Services/AttachmentService.cs
+++ b/Services/AttachmentService.cs
@@ -1,15 +1,15 @@
 using System;
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.Data;
 using System.IO;
 using System.Linq;
-using System.Data;
-using MySqlConnector;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Maui.Storage;
+using MySqlConnector;
 using YasGMP.Data;
 using YasGMP.Models;
 using YasGMP.Services.Interfaces;
@@ -25,17 +25,25 @@ namespace YasGMP.Services
     {
         private readonly IDbContextFactory<YasGmpDbContext> _contextFactory;
         private readonly DatabaseService _legacyDb;
-        private readonly string _rootPath;
+        private readonly IRBACService _rbac;
+        private readonly AttachmentEncryptionOptions _encryptionOptions;
+        private readonly AttachmentCryptoProvider _cryptoProvider;
+        private readonly MalwareScanner _malwareScanner = new();
 
         private bool? _supportsEfSchema;
         private readonly SemaphoreSlim _schemaGate = new(1, 1);
 
-        public AttachmentService(IDbContextFactory<YasGmpDbContext> contextFactory, DatabaseService legacyDatabase)
+        public AttachmentService(
+            IDbContextFactory<YasGmpDbContext> contextFactory,
+            DatabaseService legacyDatabase,
+            IRBACService rbacService,
+            AttachmentEncryptionOptions encryptionOptions)
         {
             _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
             _legacyDb = legacyDatabase ?? throw new ArgumentNullException(nameof(legacyDatabase));
-            _rootPath = Path.Combine(FileSystem.AppDataDirectory, "attachments");
-            Directory.CreateDirectory(_rootPath);
+            _rbac = rbacService ?? throw new ArgumentNullException(nameof(rbacService));
+            _encryptionOptions = encryptionOptions ?? throw new ArgumentNullException(nameof(encryptionOptions));
+            _cryptoProvider = new AttachmentCryptoProvider(_encryptionOptions);
         }
 
         private async Task<bool> SupportsEfAttachmentsAsync(CancellationToken token)
@@ -90,44 +98,19 @@ namespace YasGMP.Services
             if (!await SupportsEfAttachmentsAsync(token).ConfigureAwait(false))
                 throw new InvalidOperationException("Attachment upload requires the new attachment_links schema. Please migrate the database or disable uploads.");
 
+            await EnsureEntityPermissionAsync(request.UploadedById, request.EntityType, "upload", token).ConfigureAwait(false);
+
             if (content.CanSeek)
-            {
                 content.Seek(0, SeekOrigin.Begin);
-            }
 
             string sanitizedName = Path.GetFileName(request.FileName);
-            string uniqueName = $"{DateTime.UtcNow:yyyyMMddHHmmssfff}_{Guid.NewGuid():N}_{sanitizedName}";
-            string destination = Path.Combine(_rootPath, uniqueName);
+            string? contentType = !string.IsNullOrWhiteSpace(request.ContentType)
+                ? request.ContentType
+                : Path.GetExtension(sanitizedName)?.TrimStart('.')?.ToLowerInvariant();
 
-            long totalBytes = 0;
-            string hashHex;
-            var buffer = ArrayPool<byte>.Shared.Rent(128 * 1024);
-            try
-            {
-                using var fileStream = File.Create(destination);
-                using var sha = SHA256.Create();
-
-                int read;
-                while ((read = await content.ReadAsync(buffer.AsMemory(0, buffer.Length), token).ConfigureAwait(false)) > 0)
-                {
-                    await fileStream.WriteAsync(buffer.AsMemory(0, read), token).ConfigureAwait(false);
-                    sha.TransformBlock(buffer, 0, read, null, 0);
-                    totalBytes += read;
-                }
-
-                sha.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
-                hashHex = Convert.ToHexString(sha.Hash ?? Array.Empty<byte>());
-                await fileStream.FlushAsync(token).ConfigureAwait(false);
-            }
-            catch
-            {
-                try { if (File.Exists(destination)) File.Delete(destination); } catch { }
-                throw;
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
-            }
+            var buffer = ArrayPool<byte>.Shared.Rent(_cryptoProvider.ChunkSize);
+            var encryptionSession = _cryptoProvider.CreateEncryptionSession();
+            var malwareContext = _malwareScanner.CreateContext();
 
             await using var context = await _contextFactory.CreateDbContextAsync(token).ConfigureAwait(false);
             await using var transaction = await context.Database.BeginTransactionAsync(token).ConfigureAwait(false);
@@ -136,48 +119,123 @@ namespace YasGMP.Services
             {
                 Name = request.DisplayName ?? sanitizedName,
                 FileName = sanitizedName,
-                FilePath = destination,
-                FileType = !string.IsNullOrWhiteSpace(request.ContentType)
-                    ? request.ContentType
-                    : Path.GetExtension(sanitizedName)?.TrimStart('.')?.ToLowerInvariant(),
-                FileSize = totalBytes,
+                FilePath = null,
+                FileType = contentType,
+                FileSize = 0,
                 EntityType = request.EntityType,
                 EntityId = request.EntityId,
-                FileHash = hashHex,
+                FileHash = string.Empty,
                 UploadedAt = DateTime.UtcNow,
                 UploadedById = request.UploadedById,
-                Status = "uploaded",
-                Notes = request.Notes
+                Status = _cryptoProvider.IsEncryptionEnabled ? $"encrypted:{_encryptionOptions.KeyId}" : "uploaded",
+                Notes = AppendNote(request.Notes, request.Reason),
+                IpAddress = request.SourceIp,
+                DeviceInfo = request.SourceHost
             };
 
-            await context.Attachments.AddAsync(attachment, token).ConfigureAwait(false);
-            await context.SaveChangesAsync(token).ConfigureAwait(false);
+            long totalBytes = 0;
+            string hashHex = string.Empty;
 
-            var link = new AttachmentLink
+            try
             {
-                AttachmentId = attachment.Id,
-                EntityType = request.EntityType,
-                EntityId = request.EntityId,
-                LinkedAt = DateTime.UtcNow,
-                LinkedById = request.UploadedById
-            };
-            await context.AttachmentLinks.AddAsync(link, token).ConfigureAwait(false);
+                await context.Attachments.AddAsync(attachment, token).ConfigureAwait(false);
+                await context.SaveChangesAsync(token).ConfigureAwait(false);
 
-            var retention = new RetentionPolicy
+                var connection = context.Database.GetDbConnection();
+                if (connection.State != ConnectionState.Open)
+                    await connection.OpenAsync(token).ConfigureAwait(false);
+
+                var dbTransaction = transaction.GetDbTransaction();
+                using var command = connection.CreateCommand();
+                command.Transaction = dbTransaction;
+                var chunkParam = command.CreateParameter();
+                chunkParam.ParameterName = "@chunk";
+                if (chunkParam is MySqlParameter mysqlChunk)
+                    mysqlChunk.MySqlDbType = MySqlDbType.LongBlob;
+                var idParam = command.CreateParameter();
+                idParam.ParameterName = "@id";
+                idParam.Value = attachment.Id;
+                command.Parameters.Add(chunkParam);
+                command.Parameters.Add(idParam);
+
+                using var sha = SHA256.Create();
+                bool firstChunk = true;
+                int chunkIndex = 0;
+                int read;
+                while ((read = await content.ReadAsync(buffer.AsMemory(0, buffer.Length), token).ConfigureAwait(false)) > 0)
+                {
+                    var slice = new ReadOnlyMemory<byte>(buffer, 0, read);
+                    sha.TransformBlock(buffer, 0, read, null, 0);
+                    totalBytes += read;
+                    _malwareScanner.Update(malwareContext, slice.Span);
+
+                    var encrypted = _cryptoProvider.EncryptChunk(encryptionSession, slice, chunkIndex++);
+                    chunkParam.Value = encrypted.Payload;
+                    command.CommandText = firstChunk
+                        ? "UPDATE attachments SET file_content = @chunk WHERE id=@id"
+                        : "UPDATE attachments SET file_content = IFNULL(CONCAT(file_content, @chunk), @chunk) WHERE id=@id";
+                    await command.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+                    firstChunk = false;
+                }
+
+                sha.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                hashHex = Convert.ToHexString(sha.Hash ?? Array.Empty<byte>());
+
+                var malware = await _malwareScanner.CompleteAsync(malwareContext, sanitizedName, hashHex, totalBytes, token).ConfigureAwait(false);
+
+                attachment.FileHash = hashHex;
+                attachment.FileSize = totalBytes;
+                attachment.Status = malware.IsClean
+                    ? (_cryptoProvider.IsEncryptionEnabled ? $"encrypted:{_encryptionOptions.KeyId}" : "uploaded")
+                    : "quarantined";
+
+                await context.SaveChangesAsync(token).ConfigureAwait(false);
+
+                var link = new AttachmentLink
+                {
+                    AttachmentId = attachment.Id,
+                    EntityType = request.EntityType,
+                    EntityId = request.EntityId,
+                    LinkedAt = DateTime.UtcNow,
+                    LinkedById = request.UploadedById
+                };
+                await context.AttachmentLinks.AddAsync(link, token).ConfigureAwait(false);
+
+                var retention = new RetentionPolicy
+                {
+                    AttachmentId = attachment.Id,
+                    PolicyName = request.RetentionPolicyName ?? "default",
+                    RetainUntil = request.RetainUntil,
+                    CreatedAt = DateTime.UtcNow,
+                    CreatedById = request.UploadedById,
+                    Notes = request.Notes
+                };
+                await context.RetentionPolicies.AddAsync(retention, token).ConfigureAwait(false);
+
+                var encryptionNote = _cryptoProvider.CompleteEncryption(encryptionSession);
+                await LogAuditAsync(context, attachment.Id, request.UploadedById, "UPLOAD", request.SourceIp, request.SourceHost, request.Reason, token).ConfigureAwait(false);
+                await LogAuditAsync(context, attachment.Id, request.UploadedById, "MALWARE_SCAN", request.SourceIp, request.SourceHost, $"engine={malware.Engine}; result={(malware.IsClean ? "clean" : "blocked")}", token).ConfigureAwait(false);
+                if (!string.IsNullOrWhiteSpace(encryptionNote))
+                {
+                    await LogAuditAsync(context, attachment.Id, request.UploadedById, "ENCRYPTION", request.SourceIp, request.SourceHost, encryptionNote, token).ConfigureAwait(false);
+                }
+
+                var duplicate = await FindDuplicateInternalAsync(context, hashHex, totalBytes, attachment.Id, token).ConfigureAwait(false);
+                if (duplicate is not null)
+                {
+                    await LogAuditAsync(context, attachment.Id, request.UploadedById, "DEDUP_MATCH", request.SourceIp, request.SourceHost, $"existing={duplicate.Id}", token).ConfigureAwait(false);
+                }
+
+                await context.SaveChangesAsync(token).ConfigureAwait(false);
+                await transaction.CommitAsync(token).ConfigureAwait(false);
+
+                return new AttachmentUploadResult(attachment, link, retention);
+            }
+            finally
             {
-                AttachmentId = attachment.Id,
-                PolicyName = request.RetentionPolicyName ?? "default",
-                RetainUntil = request.RetainUntil,
-                CreatedAt = DateTime.UtcNow,
-                CreatedById = request.UploadedById,
-                Notes = request.Notes
-            };
-            await context.RetentionPolicies.AddAsync(retention, token).ConfigureAwait(false);
-
-            await context.SaveChangesAsync(token).ConfigureAwait(false);
-            await transaction.CommitAsync(token).ConfigureAwait(false);
-
-            return new AttachmentUploadResult(attachment, link, retention);
+                ArrayPool<byte>.Shared.Return(buffer);
+                encryptionSession.Dispose();
+            }
         }
 
         public async Task<Attachment?> FindByHashAsync(string sha256, CancellationToken token = default)
@@ -201,6 +259,77 @@ namespace YasGMP.Services
                 _supportsEfSchema = false;
                 return await FindByHashLegacyAsync(sha256, token).ConfigureAwait(false);
             }
+        }
+
+        public async Task<Attachment?> FindByHashAndSizeAsync(string sha256, long fileSize, CancellationToken token = default)
+        {
+            if (string.IsNullOrWhiteSpace(sha256))
+                throw new ArgumentException("Hash must be provided", nameof(sha256));
+            if (fileSize < 0)
+                throw new ArgumentOutOfRangeException(nameof(fileSize));
+
+            if (!await SupportsEfAttachmentsAsync(token).ConfigureAwait(false))
+                return await FindByHashLegacyAsync(sha256, token).ConfigureAwait(false);
+
+            try
+            {
+                await using var context = await _contextFactory.CreateDbContextAsync(token).ConfigureAwait(false);
+                return await context.Attachments
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(a => a.FileHash == sha256 && a.FileSize == fileSize, token)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex) when (TryGetMySqlException(ex, out var mysql) && mysql is not null && IsSchemaMissing(mysql))
+            {
+                _supportsEfSchema = false;
+                return await FindByHashLegacyAsync(sha256, token).ConfigureAwait(false);
+            }
+        }
+
+        public async Task<AttachmentStreamResult> StreamContentAsync(int attachmentId, Stream destination, AttachmentReadRequest? request = null, CancellationToken token = default)
+        {
+            if (destination is null) throw new ArgumentNullException(nameof(destination));
+            request ??= new AttachmentReadRequest();
+
+            if (!await SupportsEfAttachmentsAsync(token).ConfigureAwait(false))
+                throw new InvalidOperationException("Attachment streaming requires the new attachment_links schema. Please migrate the database or disable streaming.");
+
+            await using var context = await _contextFactory.CreateDbContextAsync(token).ConfigureAwait(false);
+            var attachment = await context.Attachments
+                .AsNoTracking()
+                .FirstOrDefaultAsync(a => a.Id == attachmentId, token)
+                .ConfigureAwait(false);
+
+            if (attachment is null)
+                throw new FileNotFoundException($"Attachment with id {attachmentId} not found.", attachmentId.ToString());
+
+            await EnsureEntityPermissionAsync(request.RequestedById, attachment.EntityType ?? string.Empty, "read", token).ConfigureAwait(false);
+
+            var connection = context.Database.GetDbConnection();
+            if (connection.State != ConnectionState.Open)
+                await connection.OpenAsync(token).ConfigureAwait(false);
+
+            using var command = connection.CreateCommand();
+            command.CommandText = "SELECT file_content FROM attachments WHERE id=@id";
+            var idParam = command.CreateParameter();
+            idParam.ParameterName = "@id";
+            idParam.Value = attachmentId;
+            command.Parameters.Add(idParam);
+
+            await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, token).ConfigureAwait(false);
+            if (!await reader.ReadAsync(token).ConfigureAwait(false))
+                throw new FileNotFoundException($"Attachment content missing for id {attachmentId}.", attachmentId.ToString());
+
+            await using var blobStream = reader.GetStream(0);
+            bool isEncrypted = (attachment.Status ?? string.Empty).StartsWith("encrypted", StringComparison.OrdinalIgnoreCase);
+            long bytesWritten = await _cryptoProvider.CopyToAsync(blobStream, destination, isEncrypted, request.RangeStart ?? 0, request.RangeLength, token).ConfigureAwait(false);
+
+            await LogAuditAsync(context, attachment.Id, request.RequestedById, "READ", request.SourceIp, request.SourceHost, request.Reason, token).ConfigureAwait(false);
+            await context.SaveChangesAsync(token).ConfigureAwait(false);
+
+            long totalLength = attachment.FileSize ?? bytesWritten;
+            bool partial = request.RangeStart.HasValue || request.RangeLength.HasValue;
+            return new AttachmentStreamResult(attachment, bytesWritten, totalLength, partial, request);
         }
 
         public async Task<IReadOnlyList<AttachmentLinkWithAttachment>> GetLinksForEntityAsync(string entityType, int entityId, CancellationToken token = default)
@@ -291,6 +420,73 @@ namespace YasGMP.Services
             {
                 await RemoveLegacyLinkAsync(entityType, entityId, attachmentId, token).ConfigureAwait(false);
             }
+        }
+
+        private async Task EnsureEntityPermissionAsync(int? userId, string? entityType, string action, CancellationToken token)
+        {
+            if (userId is null || userId.Value <= 0)
+                return;
+
+            string normalizedEntity = string.IsNullOrWhiteSpace(entityType)
+                ? "attachment"
+                : entityType.Trim().ToLowerInvariant();
+
+            var candidates = new[]
+            {
+                $"attachment.{action}",
+                $"attachment.{normalizedEntity}.{action}",
+                $"{normalizedEntity}.attachment.{action}",
+                $"{normalizedEntity}.{action}"
+            };
+
+            foreach (var candidate in candidates)
+            {
+                if (await _rbac.HasPermissionAsync(userId.Value, candidate).ConfigureAwait(false))
+                    return;
+            }
+
+            throw new UnauthorizedAccessException($"User {userId.Value} is not permitted to {action} attachments for entity '{entityType}'.");
+        }
+
+        private static async Task LogAuditAsync(YasGmpDbContext context, int attachmentId, int? userId, string action, string? ip, string? device, string? note, CancellationToken token)
+        {
+            var log = new AttachmentAuditLog
+            {
+                AttachmentId = attachmentId,
+                Action = action,
+                UserId = userId ?? 0,
+                Ip = ip ?? string.Empty,
+                Device = device ?? string.Empty,
+                Note = note ?? string.Empty,
+                SignatureHash = string.Empty,
+                ActionAt = DateTime.UtcNow
+            };
+
+            await context.AttachmentAuditLogs.AddAsync(log, token).ConfigureAwait(false);
+        }
+
+        private static string? AppendNote(string? existing, string? addition)
+        {
+            if (string.IsNullOrWhiteSpace(addition))
+                return existing;
+
+            if (string.IsNullOrWhiteSpace(existing))
+                return addition;
+
+            if (existing.Contains(addition, StringComparison.OrdinalIgnoreCase))
+                return existing;
+
+            return $"{existing} | {addition}";
+        }
+
+        private static async Task<Attachment?> FindDuplicateInternalAsync(YasGmpDbContext context, string hashHex, long expectedSize, int currentAttachmentId, CancellationToken token)
+        {
+            return await context.Attachments
+                .AsNoTracking()
+                .Where(a => a.FileHash == hashHex && a.FileSize == expectedSize && a.Id != currentAttachmentId)
+                .OrderBy(a => a.Id)
+                .FirstOrDefaultAsync(token)
+                .ConfigureAwait(false);
         }
 
         private async Task<IReadOnlyList<AttachmentLinkWithAttachment>> GetLegacyLinksAsync(string entityType, int entityId, CancellationToken token)
@@ -469,6 +665,353 @@ namespace YasGMP.Services
 
         private static bool IsSchemaMissing(MySqlException ex)
             => ex.Number == (int)MySqlErrorCode.UnknownTable || ex.Number == (int)MySqlErrorCode.BadFieldError;
+
+        private sealed class AttachmentCryptoProvider
+        {
+            private readonly AttachmentEncryptionOptions _options;
+            private readonly byte[]? _key;
+            private readonly int _chunkSize;
+
+            public AttachmentCryptoProvider(AttachmentEncryptionOptions options)
+            {
+                _options = options ?? throw new ArgumentNullException(nameof(options));
+                _key = ParseKey(options.KeyMaterial);
+                _chunkSize = options.ChunkSize > 0 ? options.ChunkSize : 128 * 1024;
+            }
+
+            public int ChunkSize => _chunkSize;
+            public bool IsEncryptionEnabled => _key is not null;
+            public string KeyId => string.IsNullOrWhiteSpace(_options.KeyId) ? "default" : _options.KeyId!;
+
+            public EncryptionSession CreateEncryptionSession() => new EncryptionSession(_key);
+
+            public EncryptedChunk EncryptChunk(EncryptionSession session, ReadOnlyMemory<byte> plaintext, int chunkIndex)
+            {
+                if (!IsEncryptionEnabled || session.Cipher is null)
+                {
+                    var payload = plaintext.ToArray();
+                    session.RecordChunk(plaintext.Length);
+                    return new EncryptedChunk(payload);
+                }
+
+                var payload = new byte[4 + 12 + plaintext.Length + 16];
+                BinaryPrimitives.WriteInt32LittleEndian(payload.AsSpan(0, 4), plaintext.Length);
+                var nonceSpan = payload.AsSpan(4, 12);
+                RandomNumberGenerator.Fill(nonceSpan);
+                var cipherSpan = payload.AsSpan(4 + 12, plaintext.Length);
+                var tagSpan = payload.AsSpan(4 + 12 + plaintext.Length, 16);
+
+                session.Cipher.Encrypt(nonceSpan, plaintext.Span, cipherSpan, tagSpan);
+                session.RecordChunk(plaintext.Length);
+
+                return new EncryptedChunk(payload, Convert.ToHexString(nonceSpan), Convert.ToHexString(tagSpan));
+            }
+
+            public string? CompleteEncryption(EncryptionSession session)
+            {
+                try
+                {
+                    if (!IsEncryptionEnabled)
+                        return null;
+
+                    return $"key={KeyId}; chunks={session.ChunkCount}; bytes={session.TotalBytes}";
+                }
+                finally
+                {
+                    session.Dispose();
+                }
+            }
+
+            public async Task<long> CopyToAsync(Stream source, Stream destination, bool isEncrypted, long rangeStart, long? rangeLength, CancellationToken token)
+            {
+                if (rangeStart < 0) rangeStart = 0;
+
+                if (!isEncrypted)
+                {
+                    return await CopyPlainAsync(source, destination, rangeStart, rangeLength, token).ConfigureAwait(false);
+                }
+
+                if (_key is null)
+                    throw new InvalidOperationException("Attachment is encrypted but no encryption key is configured.");
+
+                return await CopyEncryptedAsync(source, destination, rangeStart, rangeLength, token).ConfigureAwait(false);
+            }
+
+            private async Task<long> CopyPlainAsync(Stream source, Stream destination, long rangeStart, long? rangeLength, CancellationToken token)
+            {
+                long position = 0;
+                long written = 0;
+                long remaining = rangeLength ?? long.MaxValue;
+
+                var buffer = ArrayPool<byte>.Shared.Rent(_chunkSize);
+                try
+                {
+                    int read;
+                    while ((read = await source.ReadAsync(buffer.AsMemory(0, buffer.Length), token).ConfigureAwait(false)) > 0)
+                    {
+                        long chunkStart = position;
+                        long chunkEnd = position + read;
+                        position = chunkEnd;
+
+                        if (chunkEnd <= rangeStart)
+                            continue;
+
+                        int offset = chunkStart < rangeStart ? (int)(rangeStart - chunkStart) : 0;
+                        int available = read - offset;
+                        if (available <= 0)
+                            continue;
+
+                        if (rangeLength.HasValue && available > remaining)
+                            available = (int)remaining;
+
+                        if (available <= 0)
+                            continue;
+
+                        await destination.WriteAsync(buffer.AsMemory(offset, available), token).ConfigureAwait(false);
+                        written += available;
+
+                        if (rangeLength.HasValue)
+                        {
+                            remaining -= available;
+                            if (remaining <= 0)
+                                break;
+                        }
+                    }
+
+                    return written;
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                }
+            }
+
+            private async Task<long> CopyEncryptedAsync(Stream source, Stream destination, long rangeStart, long? rangeLength, CancellationToken token)
+            {
+                long position = 0;
+                long written = 0;
+                long remaining = rangeLength ?? long.MaxValue;
+
+                var headerBuffer = new byte[4];
+                var nonceBuffer = new byte[12];
+                var tagBuffer = new byte[16];
+                var cipherBuffer = ArrayPool<byte>.Shared.Rent(_chunkSize);
+                var plainBuffer = ArrayPool<byte>.Shared.Rent(_chunkSize);
+
+                try
+                {
+                    using var aes = new AesGcm(_key!);
+                    while (true)
+                    {
+                        int headerRead = await ReadAtLeastAsync(source, headerBuffer, token).ConfigureAwait(false);
+                        if (headerRead == 0)
+                            break;
+                        if (headerRead != headerBuffer.Length)
+                            throw new InvalidDataException("Unexpected end of encrypted attachment stream.");
+
+                        int plainLength = BinaryPrimitives.ReadInt32LittleEndian(headerBuffer);
+                        if (plainLength < 0)
+                            throw new InvalidDataException("Invalid encrypted attachment chunk length.");
+
+                        await ReadExactlyAsync(source, nonceBuffer, token).ConfigureAwait(false);
+                        await ReadExactlyAsync(source, tagBuffer, token).ConfigureAwait(false);
+
+                        if (cipherBuffer.Length < plainLength)
+                        {
+                            ArrayPool<byte>.Shared.Return(cipherBuffer);
+                            cipherBuffer = ArrayPool<byte>.Shared.Rent(plainLength);
+                        }
+
+                        await ReadExactlyAsync(source, cipherBuffer.AsMemory(0, plainLength), token).ConfigureAwait(false);
+
+                        if (plainBuffer.Length < plainLength)
+                        {
+                            ArrayPool<byte>.Shared.Return(plainBuffer);
+                            plainBuffer = ArrayPool<byte>.Shared.Rent(plainLength);
+                        }
+
+                        aes.Decrypt(nonceBuffer, cipherBuffer.AsSpan(0, plainLength), tagBuffer, plainBuffer.AsSpan(0, plainLength));
+
+                        long chunkStart = position;
+                        long chunkEnd = position + plainLength;
+                        position = chunkEnd;
+
+                        if (chunkEnd <= rangeStart)
+                            continue;
+
+                        int offset = chunkStart < rangeStart ? (int)(rangeStart - chunkStart) : 0;
+                        int available = plainLength - offset;
+                        if (available <= 0)
+                            continue;
+
+                        if (rangeLength.HasValue && available > remaining)
+                            available = (int)remaining;
+
+                        if (available <= 0)
+                            continue;
+
+                        await destination.WriteAsync(plainBuffer.AsMemory(offset, available), token).ConfigureAwait(false);
+                        written += available;
+
+                        if (rangeLength.HasValue)
+                        {
+                            remaining -= available;
+                            if (remaining <= 0)
+                                break;
+                        }
+                    }
+
+                    return written;
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(cipherBuffer);
+                    ArrayPool<byte>.Shared.Return(plainBuffer);
+                }
+            }
+
+            private static async Task<int> ReadAtLeastAsync(Stream source, Memory<byte> buffer, CancellationToken token)
+            {
+                int total = 0;
+                while (total < buffer.Length)
+                {
+                    int read = await source.ReadAsync(buffer.Slice(total), token).ConfigureAwait(false);
+                    if (read == 0)
+                        return total;
+                    total += read;
+                }
+
+                return total;
+            }
+
+            private static Task ReadExactlyAsync(Stream source, Memory<byte> buffer, CancellationToken token)
+                => ReadExactlyInternalAsync(source, buffer, token);
+
+            private static async Task ReadExactlyInternalAsync(Stream source, Memory<byte> buffer, CancellationToken token)
+            {
+                int total = 0;
+                while (total < buffer.Length)
+                {
+                    int read = await source.ReadAsync(buffer.Slice(total), token).ConfigureAwait(false);
+                    if (read == 0)
+                        throw new EndOfStreamException("Unexpected end of encrypted attachment stream.");
+                    total += read;
+                }
+            }
+
+            private static byte[]? ParseKey(string? material)
+            {
+                if (string.IsNullOrWhiteSpace(material))
+                    return null;
+
+                var trimmed = material.Trim();
+                try
+                {
+                    return Convert.FromBase64String(trimmed);
+                }
+                catch (FormatException)
+                {
+                    if (trimmed.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                        trimmed = trimmed[2..];
+
+                    if (trimmed.Length % 2 != 0)
+                        throw new FormatException("Attachment encryption key must be valid base64 or hex.");
+
+                    var bytes = new byte[trimmed.Length / 2];
+                    for (int i = 0; i < bytes.Length; i++)
+                    {
+                        var pair = trimmed.Substring(i * 2, 2);
+                        bytes[i] = Convert.ToByte(pair, 16);
+                    }
+
+                    return bytes;
+                }
+            }
+
+            internal sealed class EncryptionSession : IDisposable
+            {
+                private bool _disposed;
+
+                public EncryptionSession(byte[]? key)
+                {
+                    Cipher = key is not null ? new AesGcm(key) : null;
+                }
+
+                public AesGcm? Cipher { get; }
+                public int ChunkCount { get; private set; }
+                public long TotalBytes { get; private set; }
+
+                public void RecordChunk(int length)
+                {
+                    ChunkCount++;
+                    TotalBytes += length;
+                }
+
+                public void Dispose()
+                {
+                    if (_disposed)
+                        return;
+
+                    _disposed = true;
+                    Cipher?.Dispose();
+                }
+            }
+
+            internal readonly struct EncryptedChunk
+            {
+                public EncryptedChunk(byte[] payload, string? nonceHex = null, string? tagHex = null)
+                {
+                    Payload = payload;
+                    NonceHex = nonceHex;
+                    TagHex = tagHex;
+                }
+
+                public byte[] Payload { get; }
+                public string? NonceHex { get; }
+                public string? TagHex { get; }
+            }
+        }
+
+        private sealed class MalwareScanner
+        {
+            public MalwareScanContext CreateContext() => new MalwareScanContext();
+
+            public void Update(MalwareScanContext context, ReadOnlySpan<byte> chunk)
+            {
+                context.TotalBytes += chunk.Length;
+
+                if (context.Sampled < context.SampleBuffer.Length)
+                {
+                    int toCopy = Math.Min(chunk.Length, context.SampleBuffer.Length - context.Sampled);
+                    chunk.Slice(0, toCopy).CopyTo(context.SampleBuffer.AsSpan(context.Sampled));
+                    context.Sampled += toCopy;
+                }
+            }
+
+            public Task<MalwareScanResult> CompleteAsync(MalwareScanContext context, string fileName, string hashHex, long size, CancellationToken token)
+            {
+                bool clean = true;
+                string detail = "clean";
+
+                if (hashHex.EndsWith("BAD", StringComparison.OrdinalIgnoreCase))
+                {
+                    clean = false;
+                    detail = "hash-heuristic-match";
+                }
+
+                var result = new MalwareScanResult(clean, "stub-heuristic", detail);
+                return Task.FromResult(result);
+            }
+
+            internal sealed class MalwareScanContext
+            {
+                public long TotalBytes { get; set; }
+                public byte[] SampleBuffer { get; } = new byte[64];
+                public int Sampled { get; set; }
+            }
+
+            internal readonly record struct MalwareScanResult(bool IsClean, string Engine, string Details);
+        }
 
     }
 }

--- a/Services/DatabaseService.WorkOrders.Extensions.cs
+++ b/Services/DatabaseService.WorkOrders.Extensions.cs
@@ -305,7 +305,10 @@ WHERE w.id=@id";
                 EntityType = "WorkOrder",
                 EntityId = workOrderId,
                 UploadedById = uploadedBy,
-                Notes = kind
+                Notes = kind,
+                Reason = string.IsNullOrWhiteSpace(kind) ? "workorder-photo" : $"workorder-photo:{kind}",
+                SourceIp = "ui",
+                SourceHost = Environment.MachineName
             }, token).ConfigureAwait(false);
             int attachmentId = result.Attachment.Id;
             // Persist before/after classification (best effort)

--- a/Views/MachinesPage.xaml.cs
+++ b/Views/MachinesPage.xaml.cs
@@ -131,7 +131,10 @@ namespace YasGMP.Views
                                 EntityType = "Machine",
                                 EntityId = newId,
                                 UploadedById = null,
-                                Notes = "Machine document"
+                                Notes = "Machine document",
+                                Reason = "machine-doc-upload",
+                                SourceIp = "ui",
+                                SourceHost = Environment.MachineName
                             }).ConfigureAwait(false);
                         }
                         catch { }
@@ -201,7 +204,10 @@ namespace YasGMP.Views
                                 EntityType = "Machine",
                                 EntityId = m.Id,
                                 UploadedById = null,
-                                Notes = "Machine document"
+                                Notes = "Machine document",
+                                Reason = "machine-doc-upload",
+                                SourceIp = "ui",
+                                SourceHost = Environment.MachineName
                             }).ConfigureAwait(false);
                         }
                         catch { }


### PR DESCRIPTION
## Summary
- stream attachment uploads directly into the database BLOB while enforcing RBAC, auditing, duplicate detection, envelope encryption, and malware scan hooks
- expose streaming download APIs and enriched contracts for attachment operations and update consumers to supply upload/read context metadata
- add unique hash/size index migration and wire encryption configuration in MauiProgram

## Testing
- ⚠️ `dotnet build` *(not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d128d43f1c8331ab2431b815d254c1