### PR TITLE
Add WPF docking shell and shared layout persistence

### DIFF
--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -167,10 +167,13 @@ namespace YasGMP
                 // Attach diagnostics to the central DB service
                 var ctx = sp.GetService<DiagnosticContext>();
                 var tr  = sp.GetService<ITrace>();
+                var cfgRoot = sp.GetService<IConfiguration>();
                 if (ctx != null && tr != null) db.SetDiagnostics(ctx, tr);
                 // Set global fallbacks for ad-hoc DatabaseService instantiation
                 DatabaseService.GlobalDiagnosticContext = ctx;
                 DatabaseService.GlobalTrace = tr;
+                if (cfgRoot != null)
+                    DatabaseService.GlobalConfiguration = cfgRoot;
                 return db;
             });
             builder.Services.AddSingleton<AuditService>();

--- a/Models/UserWindowLayout.cs
+++ b/Models/UserWindowLayout.cs
@@ -38,6 +38,10 @@ namespace YasGMP.Models
         [Column("height")]
         public int Height { get; set; }
 
+        /// <summary>Gets or sets the serialized layout snapshot.</summary>
+        [Column("layout_xml")]
+        public string? LayoutXml { get; set; }
+
         /// <summary>Gets or sets the saved at.</summary>
         [Column("saved_at")]
         public DateTime SavedAt { get; set; } = DateTime.UtcNow;

--- a/Services/WindowManagerService.cs
+++ b/Services/WindowManagerService.cs
@@ -69,6 +69,7 @@ namespace YasGMP.Services
             public int  Width { get; set; }
             public int  Height { get; set; }
             public DateTime SavedAtUtc { get; set; }
+            public string? LayoutXml { get; set; }
         }
 
         private async Task RestoreGeometryAsync(string key, Window window)
@@ -106,7 +107,8 @@ namespace YasGMP.Services
                 Width  = (int)Math.Round(window.Width),
                 Height = (int)Math.Round(window.Height),
 #endif
-                SavedAtUtc = DateTime.UtcNow
+                SavedAtUtc = DateTime.UtcNow,
+                LayoutXml = null
             };
 
             if (!await SaveToDbAsync(key, g).ConfigureAwait(false))
@@ -201,13 +203,14 @@ LIMIT 1;";
                 var db = new DatabaseService(connStr);
 
                 const string sql = @"
-INSERT INTO user_window_layouts (user_id, page_type, pos_x, pos_y, width, height, saved_at)
-VALUES (@u,@p,@x,@y,@w,@h,UTC_TIMESTAMP())
+INSERT INTO user_window_layouts (user_id, page_type, pos_x, pos_y, width, height, layout_xml, saved_at)
+VALUES (@u,@p,@x,@y,@w,@h,@layout,UTC_TIMESTAMP())
 ON DUPLICATE KEY UPDATE
 pos_x=VALUES(pos_x),
 pos_y=VALUES(pos_y),
 width=VALUES(width),
 height=VALUES(height),
+layout_xml=VALUES(layout_xml),
 saved_at=UTC_TIMESTAMP();";
 
                 var pars = new[]
@@ -217,7 +220,8 @@ saved_at=UTC_TIMESTAMP();";
                     new MySqlParameter("@x", (object?)g.X ?? DBNull.Value),
                     new MySqlParameter("@y", (object?)g.Y ?? DBNull.Value),
                     new MySqlParameter("@w", g.Width),
-                    new MySqlParameter("@h", g.Height)
+                    new MySqlParameter("@h", g.Height),
+                    new MySqlParameter("@layout", (object?)g.LayoutXml ?? DBNull.Value)
                 };
 
                 await db.ExecuteNonQueryAsync(sql, pars).ConfigureAwait(false);

--- a/YasGMP.Wpf/App.xaml
+++ b/YasGMP.Wpf/App.xaml
@@ -1,0 +1,17 @@
+<Application x:Class="YasGMP.Wpf.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:YasGMP.Wpf.ViewModels"
+             xmlns:views="clr-namespace:YasGMP.Wpf.Views">
+    <Application.Resources>
+        <DataTemplate DataType="{x:Type vm:MachinesDocumentViewModel}">
+            <views:MachinesDocumentView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:ModuleTreeViewModel}">
+            <views:ModuleTreeView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:CockpitViewModel}">
+            <views:CockpitView />
+        </DataTemplate>
+    </Application.Resources>
+</Application>

--- a/YasGMP.Wpf/App.xaml.cs
+++ b/YasGMP.Wpf/App.xaml.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Windows;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using YasGMP.Services;
+using YasGMP.Wpf.Services;
+using YasGMP.Wpf.ViewModels;
+
+namespace YasGMP.Wpf
+{
+    /// <summary>
+    /// Bootstrapper for the YasGMP WPF shell. Wires the generic host, DI and root window.
+    /// </summary>
+    public partial class App : Application
+    {
+        private IHost? _host;
+
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+
+            _host = Host.CreateDefaultBuilder()
+                .ConfigureAppConfiguration((_, cfg) =>
+                {
+                    cfg.SetBasePath(AppContext.BaseDirectory);
+                    cfg.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
+                })
+                .ConfigureServices((ctx, services) =>
+                {
+                    services.AddSingleton(ctx.Configuration);
+
+                    services.AddSingleton<IUserSession, UserSession>();
+                    services.AddSingleton<IMachineDataService, MockMachineDataService>();
+                    services.AddSingleton<DockLayoutPersistenceService>();
+                    services.AddSingleton<ShellLayoutController>();
+
+                    services.AddSingleton<MainWindowViewModel>();
+                    services.AddSingleton<MainWindow>();
+
+                    services.AddSingleton(sp =>
+                    {
+                        var cfg = sp.GetRequiredService<IConfiguration>();
+                        var conn = cfg.GetConnectionString("MySqlDb")
+                                   ?? cfg["ConnectionStrings:MySqlDb"]
+                                   ?? string.Empty;
+                        if (string.IsNullOrWhiteSpace(conn))
+                        {
+                            conn = "Server=127.0.0.1;Port=3306;Database=YASGMP;User ID=yasgmp_app;Password=Jasenka1;Character Set=utf8mb4;Connection Timeout=5;Default Command Timeout=30;Pooling=true;Minimum Pool Size=0;Maximum Pool Size=50;";
+                        }
+
+                        var db = new DatabaseService(conn);
+                        DatabaseService.GlobalConfiguration = cfg;
+                        return db;
+                    });
+                })
+                .Build();
+
+            DatabaseService.GlobalConfiguration = _host.Services.GetRequiredService<IConfiguration>();
+
+            _host.Start();
+
+            var window = _host.Services.GetRequiredService<MainWindow>();
+            window.Show();
+        }
+
+        protected override void OnExit(ExitEventArgs e)
+        {
+            if (_host != null)
+            {
+                try
+                {
+                    _host.StopAsync(TimeSpan.FromSeconds(2)).GetAwaiter().GetResult();
+                }
+                catch
+                {
+                    // ignore shutdown failures
+                }
+                finally
+                {
+                    _host.Dispose();
+                }
+            }
+
+            base.OnExit(e);
+        }
+    }
+}

--- a/YasGMP.Wpf/MainWindow.xaml
+++ b/YasGMP.Wpf/MainWindow.xaml
@@ -1,0 +1,70 @@
+<Window x:Class="YasGMP.Wpf.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:ad="http://schemas.xceed.com/wpf/xaml/avalondock"
+        xmlns:adLayout="clr-namespace:Xceed.Wpf.AvalonDock.Layout;assembly=Xceed.Wpf.AvalonDock"
+        mc:Ignorable="d"
+        Title="YasGMP Cockpit"
+        Width="1280"
+        Height="800"
+        Loaded="OnLoaded"
+        Closing="OnClosing">
+    <DockPanel>
+        <Menu DockPanel.Dock="Top">
+            <MenuItem Header="_Window">
+                <MenuItem Header="_New Machines Tab" Command="{Binding WindowCommands.NewMachinesDocumentCommand}" />
+                <MenuItem Header="_Navigate to Machines" Command="{Binding WindowCommands.NavigateToMachinesCommand}" />
+                <Separator />
+                <MenuItem Header="_Save Layout" Command="{Binding WindowCommands.SaveLayoutCommand}" />
+                <MenuItem Header="_Reset Layout" Command="{Binding WindowCommands.ResetLayoutCommand}" />
+            </MenuItem>
+        </Menu>
+
+        <StatusBar DockPanel.Dock="Bottom">
+            <StatusBarItem>
+                <TextBlock Text="{Binding StatusText}" />
+            </StatusBarItem>
+        </StatusBar>
+
+        <Grid>
+            <ad:DockingManager x:Name="DockManager"
+                               DocumentsSource="{Binding Documents}"
+                               ActiveContent="{Binding ActiveDocument, Mode=TwoWay}">
+                <ad:DockingManager.DocumentHeaderTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Title}" />
+                    </DataTemplate>
+                </ad:DockingManager.DocumentHeaderTemplate>
+
+                <ad:DockingManager.LayoutItemContainerStyle>
+                    <Style TargetType="{x:Type ad:LayoutItem}">
+                        <Setter Property="Title" Value="{Binding Model.Title}" />
+                        <Setter Property="ContentId" Value="{Binding Model.ContentId}" />
+                    </Style>
+                </ad:DockingManager.LayoutItemContainerStyle>
+
+                <ad:DockingManager.Layout>
+                    <adLayout:LayoutRoot>
+                        <adLayout:LayoutPanel Orientation="Horizontal">
+                            <adLayout:LayoutAnchorablePane DockWidth="280">
+                                <adLayout:LayoutAnchorable Title="Modules"
+                                                          ContentId="YasGmp.Shell.Modules"
+                                                          Content="{Binding ModuleTree}" />
+                            </adLayout:LayoutAnchorablePane>
+                            <adLayout:LayoutPanel Orientation="Vertical">
+                                <adLayout:LayoutDocumentPane />
+                                <adLayout:LayoutAnchorablePane DockHeight="220">
+                                    <adLayout:LayoutAnchorable Title="Cockpit"
+                                                              ContentId="YasGmp.Shell.Cockpit"
+                                                              Content="{Binding Cockpit}" />
+                                </adLayout:LayoutAnchorablePane>
+                            </adLayout:LayoutPanel>
+                        </adLayout:LayoutPanel>
+                    </adLayout:LayoutRoot>
+                </ad:DockingManager.Layout>
+            </ad:DockingManager>
+        </Grid>
+    </DockPanel>
+</Window>

--- a/YasGMP.Wpf/MainWindow.xaml.cs
+++ b/YasGMP.Wpf/MainWindow.xaml.cs
@@ -1,0 +1,52 @@
+using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using System.Windows;
+using YasGMP.Wpf.Services;
+using YasGMP.Wpf.ViewModels;
+
+namespace YasGMP.Wpf
+{
+    /// <summary>
+    /// Shell host window that bridges the view-model with AvalonDock layout services.
+    /// </summary>
+    public partial class MainWindow : Window
+    {
+        private readonly MainWindowViewModel _viewModel;
+        private readonly ShellLayoutController _layoutController;
+
+        public MainWindow(MainWindowViewModel viewModel, ShellLayoutController layoutController)
+        {
+            InitializeComponent();
+            _viewModel = viewModel;
+            _layoutController = layoutController;
+            DataContext = _viewModel;
+
+            _viewModel.WindowCommands.SaveLayoutRequested += OnSaveLayoutRequested;
+            _viewModel.WindowCommands.ResetLayoutRequested += OnResetLayoutRequested;
+        }
+
+        private async void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            _layoutController.Attach(DockManager, _viewModel);
+            _viewModel.InitializeWorkspace();
+            _layoutController.CaptureDefaultLayout();
+            await _layoutController.RestoreLayoutAsync(this);
+        }
+
+        private async void OnClosing(object? sender, CancelEventArgs e)
+        {
+            await _layoutController.SaveLayoutAsync(this);
+        }
+
+        private async void OnSaveLayoutRequested(object? sender, EventArgs e)
+        {
+            await _layoutController.SaveLayoutAsync(this);
+        }
+
+        private async void OnResetLayoutRequested(object? sender, EventArgs e)
+        {
+            await _layoutController.ResetLayoutAsync(this);
+        }
+    }
+}

--- a/YasGMP.Wpf/Services/DockLayoutPersistenceService.cs
+++ b/YasGMP.Wpf/Services/DockLayoutPersistenceService.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using MySqlConnector;
+using YasGMP.Services;
+
+namespace YasGMP.Wpf.Services
+{
+    /// <summary>Persists and restores AvalonDock layouts using the shared user_window_layouts table.</summary>
+    public sealed class DockLayoutPersistenceService
+    {
+        private readonly DatabaseService _database;
+        private readonly IUserSession _session;
+
+        public DockLayoutPersistenceService(DatabaseService database, IUserSession session)
+        {
+            _database = database;
+            _session = session;
+        }
+
+        public async Task<LayoutSnapshot?> LoadAsync(string layoutKey, CancellationToken token = default)
+        {
+            const string sql = @"
+SELECT layout_xml, pos_x, pos_y, width, height
+FROM user_window_layouts
+WHERE user_id=@u AND page_type=@p
+LIMIT 1;";
+
+            var parameters = new[]
+            {
+                new MySqlParameter("@u", _session.UserId),
+                new MySqlParameter("@p", layoutKey)
+            };
+
+            var table = await _database.ExecuteSelectAsync(sql, parameters, token).ConfigureAwait(false);
+            if (table.Rows.Count == 0)
+            {
+                return null;
+            }
+
+            var row = table.Rows[0];
+            return new LayoutSnapshot(
+                row["layout_xml"] as string ?? string.Empty,
+                ReadNullableDouble(row, "pos_x"),
+                ReadNullableDouble(row, "pos_y"),
+                ReadNullableDouble(row, "width"),
+                ReadNullableDouble(row, "height"));
+        }
+
+        public async Task SaveAsync(string layoutKey, string layoutXml, WindowGeometry geometry, CancellationToken token = default)
+        {
+            const string sql = @"
+INSERT INTO user_window_layouts (user_id, page_type, layout_xml, pos_x, pos_y, width, height, saved_at)
+VALUES (@u,@p,@layout,@x,@y,@w,@h,UTC_TIMESTAMP())
+ON DUPLICATE KEY UPDATE
+layout_xml=VALUES(layout_xml),
+pos_x=VALUES(pos_x),
+pos_y=VALUES(pos_y),
+width=VALUES(width),
+height=VALUES(height),
+saved_at=UTC_TIMESTAMP();";
+
+            var parameters = new[]
+            {
+                new MySqlParameter("@u", _session.UserId),
+                new MySqlParameter("@p", layoutKey),
+                new MySqlParameter("@layout", layoutXml),
+                new MySqlParameter("@x", geometry.Left.HasValue ? geometry.Left.Value : (object)DBNull.Value),
+                new MySqlParameter("@y", geometry.Top.HasValue ? geometry.Top.Value : (object)DBNull.Value),
+                new MySqlParameter("@w", geometry.Width.HasValue ? geometry.Width.Value : (object)DBNull.Value),
+                new MySqlParameter("@h", geometry.Height.HasValue ? geometry.Height.Value : (object)DBNull.Value)
+            };
+
+            await _database.ExecuteNonQueryAsync(sql, parameters, token).ConfigureAwait(false);
+        }
+
+        private static double? ReadNullableDouble(DataRow row, string column)
+        {
+            if (!row.Table.Columns.Contains(column))
+            {
+                return null;
+            }
+
+            var value = row[column];
+            if (value == null || value is DBNull)
+            {
+                return null;
+            }
+
+            return Convert.ToDouble(value);
+        }
+    }
+
+    public readonly record struct WindowGeometry(double? Left, double? Top, double? Width, double? Height);
+
+    public readonly record struct LayoutSnapshot(string LayoutXml, double? Left, double? Top, double? Width, double? Height)
+    {
+        public WindowGeometry Geometry => new(Left, Top, Width, Height);
+    }
+}

--- a/YasGMP.Wpf/Services/IMachineDataService.cs
+++ b/YasGMP.Wpf/Services/IMachineDataService.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using YasGMP.Wpf.ViewModels;
+
+namespace YasGMP.Wpf.Services
+{
+    /// <summary>Provides machines snapshot data for the cockpit shell.</summary>
+    public interface IMachineDataService
+    {
+        IEnumerable<MachineRowViewModel> GetMachines();
+    }
+
+    /// <summary>Mock implementation returning deterministic sample data.</summary>
+    public sealed class MockMachineDataService : IMachineDataService
+    {
+        public IEnumerable<MachineRowViewModel> GetMachines()
+        {
+            return new[]
+            {
+                new MachineRowViewModel
+                {
+                    Id = 1001,
+                    Name = "Blister Line A",
+                    Status = "Running",
+                    Location = "Packaging",
+                    Oee = 89.4,
+                    LastMaintenance = "2024-07-14",
+                    NextMaintenance = "2024-10-14"
+                },
+                new MachineRowViewModel
+                {
+                    Id = 1002,
+                    Name = "Granulator",
+                    Status = "Maintenance",
+                    Location = "Compounding",
+                    Oee = 74.2,
+                    LastMaintenance = "2024-06-30",
+                    NextMaintenance = "2024-09-01"
+                },
+                new MachineRowViewModel
+                {
+                    Id = 1003,
+                    Name = "Sterilizer #2",
+                    Status = "Attention",
+                    Location = "Sterile Suite",
+                    Oee = 68.1,
+                    LastMaintenance = "2024-05-18",
+                    NextMaintenance = "2024-08-15"
+                },
+                new MachineRowViewModel
+                {
+                    Id = 1004,
+                    Name = "Tablet Press",
+                    Status = "Running",
+                    Location = "Compression",
+                    Oee = 92.6,
+                    LastMaintenance = "2024-07-01",
+                    NextMaintenance = "2024-09-29"
+                }
+            };
+        }
+    }
+}

--- a/YasGMP.Wpf/Services/ShellLayoutController.cs
+++ b/YasGMP.Wpf/Services/ShellLayoutController.cs
@@ -1,0 +1,177 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using Xceed.Wpf.AvalonDock;
+using Xceed.Wpf.AvalonDock.Layout.Serialization;
+using YasGMP.Wpf.ViewModels;
+
+namespace YasGMP.Wpf.Services
+{
+    /// <summary>Coordinates AvalonDock with layout persistence and view-model resolution.</summary>
+    public sealed class ShellLayoutController
+    {
+        private readonly DockLayoutPersistenceService _persistence;
+        private DockingManager? _dockManager;
+        private MainWindowViewModel? _viewModel;
+        private string? _defaultLayout;
+        private const string LayoutKey = "YasGmp.Wpf.Shell";
+
+        public ShellLayoutController(DockLayoutPersistenceService persistence)
+        {
+            _persistence = persistence;
+        }
+
+        public void Attach(DockingManager dockManager, MainWindowViewModel viewModel)
+        {
+            _dockManager = dockManager ?? throw new ArgumentNullException(nameof(dockManager));
+            _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+        }
+
+        public void CaptureDefaultLayout()
+        {
+            if (_dockManager == null)
+            {
+                return;
+            }
+
+            var serializer = new XmlLayoutSerializer(_dockManager);
+            using var writer = new StringWriter();
+            serializer.Serialize(writer);
+            _defaultLayout = writer.ToString();
+        }
+
+        public async Task RestoreLayoutAsync(Window window, CancellationToken token = default)
+        {
+            if (_dockManager == null)
+            {
+                return;
+            }
+
+            var snapshot = await _persistence.LoadAsync(LayoutKey, token).ConfigureAwait(false);
+            if (snapshot == null || string.IsNullOrWhiteSpace(snapshot.Value.LayoutXml))
+            {
+                return;
+            }
+
+            _viewModel?.PrepareForLayoutImport();
+            await window.Dispatcher.InvokeAsync(() =>
+            {
+                var serializer = new XmlLayoutSerializer(_dockManager);
+                serializer.LayoutSerializationCallback += OnLayoutSerializationCallback;
+                using var reader = new StringReader(snapshot.Value.LayoutXml);
+                serializer.Deserialize(reader);
+                serializer.LayoutSerializationCallback -= OnLayoutSerializationCallback;
+            });
+
+            ApplyGeometry(window, snapshot.Value.Geometry);
+        }
+
+        public async Task SaveLayoutAsync(Window window, CancellationToken token = default)
+        {
+            if (_dockManager == null)
+            {
+                return;
+            }
+
+            var serializer = new XmlLayoutSerializer(_dockManager);
+            string layoutXml;
+            using (var writer = new StringWriter())
+            {
+                serializer.Serialize(writer);
+                layoutXml = writer.ToString();
+            }
+
+            var geometry = CaptureGeometry(window);
+            await _persistence.SaveAsync(LayoutKey, layoutXml, geometry, token).ConfigureAwait(false);
+        }
+
+        public async Task ResetLayoutAsync(Window window, CancellationToken token = default)
+        {
+            if (_dockManager == null || _defaultLayout == null)
+            {
+                return;
+            }
+
+            _viewModel?.PrepareForLayoutImport();
+            await window.Dispatcher.InvokeAsync(() =>
+            {
+                var serializer = new XmlLayoutSerializer(_dockManager);
+                serializer.LayoutSerializationCallback += OnLayoutSerializationCallback;
+                using var reader = new StringReader(_defaultLayout);
+                serializer.Deserialize(reader);
+                serializer.LayoutSerializationCallback -= OnLayoutSerializationCallback;
+            });
+
+            if (_viewModel != null)
+            {
+                _viewModel.StatusText = "Layout reset to default";
+            }
+            await SaveLayoutAsync(window, token).ConfigureAwait(false);
+        }
+
+        private void OnLayoutSerializationCallback(object? sender, LayoutSerializationCallbackEventArgs e)
+        {
+            if (_viewModel == null)
+            {
+                return;
+            }
+
+            switch (e.Model.ContentId)
+            {
+                case "YasGmp.Shell.Modules":
+                    e.Content = _viewModel.ModuleTree;
+                    break;
+                case "YasGmp.Shell.Cockpit":
+                    e.Content = _viewModel.Cockpit;
+                    break;
+                default:
+                    if (!string.IsNullOrWhiteSpace(e.Model.ContentId))
+                    {
+                        e.Content = _viewModel.EnsureDocumentForId(e.Model.ContentId);
+                    }
+                    break;
+            }
+        }
+
+        private static WindowGeometry CaptureGeometry(Window window)
+        {
+            if (window == null)
+            {
+                return new WindowGeometry(null, null, null, null);
+            }
+
+            if (window.WindowState == WindowState.Normal)
+            {
+                return new WindowGeometry(window.Left, window.Top, window.Width, window.Height);
+            }
+
+            var bounds = window.RestoreBounds;
+            return new WindowGeometry(bounds.Left, bounds.Top, bounds.Width, bounds.Height);
+        }
+
+        private static void ApplyGeometry(Window window, WindowGeometry geometry)
+        {
+            if (geometry.Left.HasValue)
+            {
+                window.Left = geometry.Left.Value;
+            }
+
+            if (geometry.Top.HasValue)
+            {
+                window.Top = geometry.Top.Value;
+            }
+
+            if (geometry.Width.HasValue && geometry.Width.Value > 200)
+            {
+                window.Width = geometry.Width.Value;
+            }
+
+            if (geometry.Height.HasValue && geometry.Height.Value > 200)
+            {
+                window.Height = geometry.Height.Value;
+            }
+        }
+    }
+}

--- a/YasGMP.Wpf/Services/UserSession.cs
+++ b/YasGMP.Wpf/Services/UserSession.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Configuration;
+
+namespace YasGMP.Wpf.Services
+{
+    /// <summary>Lightweight user context used for per-user layout persistence.</summary>
+    public interface IUserSession
+    {
+        int UserId { get; }
+        string Username { get; }
+    }
+
+    public sealed class UserSession : IUserSession
+    {
+        public UserSession(IConfiguration configuration)
+        {
+            UserId = configuration.GetValue<int?>("Shell:UserId") ?? 1;
+            Username = configuration["Shell:Username"] ?? "wpf-shell";
+        }
+
+        public int UserId { get; }
+
+        public string Username { get; }
+    }
+}

--- a/YasGMP.Wpf/ViewModels/CockpitViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/CockpitViewModel.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace YasGMP.Wpf.ViewModels
+{
+    /// <summary>Simple cockpit summary displayed in the bottom anchorable.</summary>
+    public partial class CockpitViewModel : AnchorableViewModel
+    {
+        public CockpitViewModel()
+        {
+            Title = "Cockpit";
+            ContentId = "YasGmp.Shell.Cockpit";
+            Metrics = new ObservableCollection<CockpitMetric>
+            {
+                new("Open CAPAs", 7, "#c7522a"),
+                new("Preventive Jobs Due", 12, "#d9842b"),
+                new("Machines Offline", 2, "#b71c1c"),
+                new("On-Time Deliveries", 96, "#2e7d32")
+            };
+
+            Notices = new ObservableCollection<string>
+            {
+                "Sterilizer #2 validation expires in 5 days",
+                "Calibration overdue: Dissolution tester",
+                "Two deviations awaiting QA approval"
+            };
+        }
+
+        public ObservableCollection<CockpitMetric> Metrics { get; }
+
+        public ObservableCollection<string> Notices { get; }
+    }
+
+    /// <summary>Represents a key KPI displayed in the cockpit.</summary>
+    public record CockpitMetric(string Label, int Value, string AccentHex)
+    {
+        public string FormattedValue => Value.ToString("N0");
+    }
+}

--- a/YasGMP.Wpf/ViewModels/DockItemViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/DockItemViewModel.cs
@@ -1,0 +1,38 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace YasGMP.Wpf.ViewModels
+{
+    /// <summary>
+    /// Base class for all dockable content hosted in AvalonDock.
+    /// Provides common metadata used during layout serialization.
+    /// </summary>
+    public abstract partial class DockItemViewModel : ObservableObject
+    {
+        private string _title = string.Empty;
+        private string _contentId = string.Empty;
+
+        /// <summary>Gets or sets the tab/header title.</summary>
+        public string Title
+        {
+            get => _title;
+            set => SetProperty(ref _title, value);
+        }
+
+        /// <summary>Unique identifier persisted in the serialized layout.</summary>
+        public string ContentId
+        {
+            get => _contentId;
+            set => SetProperty(ref _contentId, value);
+        }
+    }
+
+    /// <summary>Document pane item (tab).</summary>
+    public abstract class DocumentViewModel : DockItemViewModel
+    {
+    }
+
+    /// <summary>Anchorable pane item (tool window such as module tree/cockpit).</summary>
+    public abstract class AnchorableViewModel : DockItemViewModel
+    {
+    }
+}

--- a/YasGMP.Wpf/ViewModels/MachinesDocumentViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/MachinesDocumentViewModel.cs
@@ -1,0 +1,34 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace YasGMP.Wpf.ViewModels
+{
+    /// <summary>Represents the tabbed machines workspace.</summary>
+    public partial class MachinesDocumentViewModel : DocumentViewModel
+    {
+        [ObservableProperty]
+        private MachineRowViewModel? _selectedMachine;
+
+        public MachinesDocumentViewModel(string title, string contentId, ObservableCollection<MachineRowViewModel> machines)
+        {
+            Title = title;
+            ContentId = contentId;
+            Machines = machines;
+        }
+
+        /// <summary>Table rows rendered inside the machines tab.</summary>
+        public ObservableCollection<MachineRowViewModel> Machines { get; }
+    }
+
+    /// <summary>Row backing model for the machines data grid.</summary>
+    public partial class MachineRowViewModel : ObservableObject
+    {
+        public int Id { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public string Status { get; init; } = string.Empty;
+        public string Location { get; init; } = string.Empty;
+        public double Oee { get; init; }
+        public string LastMaintenance { get; init; } = string.Empty;
+        public string NextMaintenance { get; init; } = string.Empty;
+    }
+}

--- a/YasGMP.Wpf/ViewModels/MainWindowViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.ViewModels
+{
+    /// <summary>
+    /// View-model backing the root shell window. Hosts dockable content collections
+    /// and exposes menu commands for opening/navigating workspaces.
+    /// </summary>
+    public partial class MainWindowViewModel : ObservableObject
+    {
+        private readonly IMachineDataService _machineDataService;
+        private DocumentViewModel? _activeDocument;
+        private string _statusText = "Ready";
+        private int _machinesOpened = 0;
+
+        public MainWindowViewModel(IMachineDataService machineDataService)
+        {
+            _machineDataService = machineDataService;
+            ModuleTree = new ModuleTreeViewModel();
+            Cockpit = new CockpitViewModel();
+            Documents = new ObservableCollection<DocumentViewModel>();
+            WindowCommands = new WindowMenuViewModel(this);
+        }
+
+        /// <summary>Gets the module navigator anchorable.</summary>
+        public ModuleTreeViewModel ModuleTree { get; }
+
+        /// <summary>Gets the cockpit/status anchorable.</summary>
+        public CockpitViewModel Cockpit { get; }
+
+        /// <summary>Collection of tabbed documents (bound to AvalonDock).</summary>
+        public ObservableCollection<DocumentViewModel> Documents { get; }
+
+        /// <summary>Gets or sets the currently active document.</summary>
+        public DocumentViewModel? ActiveDocument
+        {
+            get => _activeDocument;
+            set => SetProperty(ref _activeDocument, value);
+        }
+
+        /// <summary>Command surface for the Window menu.</summary>
+        public WindowMenuViewModel WindowCommands { get; }
+
+        /// <summary>Status line content shown in the shell status bar.</summary>
+        public string StatusText
+        {
+            get => _statusText;
+            set => SetProperty(ref _statusText, value);
+        }
+
+        /// <summary>Ensures initial anchorables and a starter machines tab are present.</summary>
+        public void InitializeWorkspace()
+        {
+            if (Documents.Count == 0)
+            {
+                OpenMachinesDocument();
+            }
+        }
+
+        /// <summary>Creates a new machines workspace tab populated with mock data.</summary>
+        public MachinesDocumentViewModel OpenMachinesDocument()
+        {
+            _machinesOpened++;
+            var title = _machinesOpened == 1 ? "Machines" : $"Machines {_machinesOpened}";
+            var contentId = $"YasGmp.Shell.Machines.{Guid.NewGuid():N}";
+            var machines = new ObservableCollection<MachineRowViewModel>(_machineDataService.GetMachines());
+            var vm = new MachinesDocumentViewModel(title, contentId, machines);
+            Documents.Add(vm);
+            ActiveDocument = vm;
+            StatusText = $"Opened {title} at {DateTime.Now:t}";
+            return vm;
+        }
+
+        /// <summary>Locates or creates a machines workspace for navigation.</summary>
+        public void NavigateToMachines()
+        {
+            var target = Documents.OfType<MachinesDocumentViewModel>().FirstOrDefault();
+            if (target == null)
+            {
+                target = OpenMachinesDocument();
+            }
+
+            ActiveDocument = target;
+            StatusText = $"Navigated to {target.Title} at {DateTime.Now:t}";
+        }
+
+        /// <summary>
+        /// Used by layout deserialization to resolve persisted content by id.
+        /// Creates a new machines document if the requested id does not exist yet.
+        /// </summary>
+        public DocumentViewModel EnsureDocumentForId(string contentId)
+        {
+            var existing = Documents.FirstOrDefault(d => d.ContentId == contentId);
+            if (existing != null)
+            {
+                return existing;
+            }
+
+            _machinesOpened++;
+            var machines = new ObservableCollection<MachineRowViewModel>(_machineDataService.GetMachines());
+            var title = _machinesOpened == 1 ? "Machines" : $"Machines {_machinesOpened}";
+            var vm = new MachinesDocumentViewModel(title, contentId, machines);
+            Documents.Add(vm);
+            return vm;
+        }
+
+        /// <summary>Clears document state before applying a serialized layout.</summary>
+        public void PrepareForLayoutImport()
+        {
+            Documents.Clear();
+            _machinesOpened = 0;
+            ActiveDocument = null;
+        }
+
+        /// <summary>Removes all dynamic documents and re-adds a fresh machines workspace.</summary>
+        public void ResetWorkspace()
+        {
+            Documents.Clear();
+            _machinesOpened = 0;
+            InitializeWorkspace();
+            StatusText = "Layout reset to default";
+        }
+    }
+}

--- a/YasGMP.Wpf/ViewModels/ModuleTreeViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/ModuleTreeViewModel.cs
@@ -1,0 +1,66 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace YasGMP.Wpf.ViewModels
+{
+    /// <summary>Module explorer anchorable view-model.</summary>
+    public partial class ModuleTreeViewModel : AnchorableViewModel
+    {
+        public ModuleTreeViewModel()
+        {
+            Title = "Modules";
+            ContentId = "YasGmp.Shell.Modules";
+            Modules = new ObservableCollection<ModuleNodeViewModel>(ModuleNodeViewModel.CreateDefaultTree());
+        }
+
+        /// <summary>Tree of modules grouped by feature area.</summary>
+        public ObservableCollection<ModuleNodeViewModel> Modules { get; }
+    }
+
+    /// <summary>Tree node representation for a GMP feature module.</summary>
+    public class ModuleNodeViewModel : ObservableObject
+    {
+        public ModuleNodeViewModel(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+
+        public ObservableCollection<ModuleNodeViewModel> Children { get; } = new();
+
+        public static ObservableCollection<ModuleNodeViewModel> CreateDefaultTree()
+        {
+            return new ObservableCollection<ModuleNodeViewModel>
+            {
+                new("Quality")
+                {
+                    Children =
+                    {
+                        new ModuleNodeViewModel("CAPA"),
+                        new ModuleNodeViewModel("Audits"),
+                        new ModuleNodeViewModel("Document Control")
+                    }
+                },
+                new("Maintenance")
+                {
+                    Children =
+                    {
+                        new ModuleNodeViewModel("Machines"),
+                        new ModuleNodeViewModel("Preventive Plans"),
+                        new ModuleNodeViewModel("Calibration")
+                    }
+                },
+                new("Warehouse")
+                {
+                    Children =
+                    {
+                        new ModuleNodeViewModel("Inventory"),
+                        new ModuleNodeViewModel("Suppliers"),
+                        new ModuleNodeViewModel("Transactions")
+                    }
+                }
+            };
+        }
+    }
+}

--- a/YasGMP.Wpf/ViewModels/WindowMenuViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/WindowMenuViewModel.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Input;
+
+namespace YasGMP.Wpf.ViewModels
+{
+    /// <summary>Window menu command surface wired to shell-level operations.</summary>
+    public partial class WindowMenuViewModel
+    {
+        private readonly MainWindowViewModel _shell;
+
+        public WindowMenuViewModel(MainWindowViewModel shell)
+        {
+            _shell = shell;
+            NewMachinesDocumentCommand = new RelayCommand(() => _shell.OpenMachinesDocument());
+            NavigateToMachinesCommand = new RelayCommand(_shell.NavigateToMachines);
+            SaveLayoutCommand = new AsyncRelayCommand(ExecuteSaveLayoutAsync);
+            ResetLayoutCommand = new AsyncRelayCommand(ExecuteResetLayoutAsync);
+        }
+
+        public IRelayCommand NewMachinesDocumentCommand { get; }
+
+        public IRelayCommand NavigateToMachinesCommand { get; }
+
+        public IAsyncRelayCommand SaveLayoutCommand { get; }
+
+        public IAsyncRelayCommand ResetLayoutCommand { get; }
+
+        public event EventHandler? SaveLayoutRequested;
+
+        public event EventHandler? ResetLayoutRequested;
+
+        private Task ExecuteSaveLayoutAsync()
+        {
+            SaveLayoutRequested?.Invoke(this, EventArgs.Empty);
+            return Task.CompletedTask;
+        }
+
+        private Task ExecuteResetLayoutAsync()
+        {
+            ResetLayoutRequested?.Invoke(this, EventArgs.Empty);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/YasGMP.Wpf/Views/CockpitView.xaml
+++ b/YasGMP.Wpf/Views/CockpitView.xaml
@@ -1,0 +1,57 @@
+<UserControl x:Class="YasGMP.Wpf.Views.CockpitView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="200"
+             d:DesignWidth="600">
+    <Grid Margin="8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Text="Production KPIs"
+                   FontSize="14"
+                   FontWeight="Bold"
+                   Margin="0,0,0,8" />
+
+        <ItemsControl Grid.Row="1" ItemsSource="{Binding Metrics}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal" />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <Border CornerRadius="4"
+                            Background="{Binding AccentHex}"
+                            Margin="0,0,8,0"
+                            Padding="12"
+                            MinWidth="120">
+                        <StackPanel>
+                            <TextBlock Text="{Binding Label}" Foreground="White" FontWeight="Bold" />
+                            <TextBlock Text="{Binding FormattedValue}" Foreground="White" FontSize="18" />
+                        </StackPanel>
+                    </Border>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+
+        <StackPanel Grid.Row="2" Margin="0,12,0,0">
+            <TextBlock Text="Notices" FontWeight="Bold" Margin="0,0,0,4" />
+            <ItemsControl ItemsSource="{Binding Notices}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <DockPanel Margin="0,0,0,4">
+                            <Ellipse Width="6" Height="6" Fill="#007ACC" Margin="0,6,6,0" />
+                            <TextBlock Text="{Binding}" TextWrapping="Wrap" />
+                        </DockPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/YasGMP.Wpf/Views/CockpitView.xaml.cs
+++ b/YasGMP.Wpf/Views/CockpitView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Views
+{
+    public partial class CockpitView : UserControl
+    {
+        public CockpitView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/YasGMP.Wpf/Views/MachinesDocumentView.xaml
+++ b/YasGMP.Wpf/Views/MachinesDocumentView.xaml
@@ -1,0 +1,28 @@
+<UserControl x:Class="YasGMP.Wpf.Views.MachinesDocumentView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="400"
+             d:DesignWidth="600">
+    <Grid>
+        <DataGrid ItemsSource="{Binding Machines}"
+                  SelectedItem="{Binding SelectedMachine, Mode=TwoWay}"
+                  AutoGenerateColumns="False"
+                  IsReadOnly="True"
+                  CanUserAddRows="False"
+                  CanUserDeleteRows="False"
+                  Margin="8">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="80" />
+                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="2*" />
+                <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="120" />
+                <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="160" />
+                <DataGridTextColumn Header="OEE %" Binding="{Binding Oee, StringFormat=F1}" Width="90" />
+                <DataGridTextColumn Header="Last Maintenance" Binding="{Binding LastMaintenance}" Width="160" />
+                <DataGridTextColumn Header="Next Maintenance" Binding="{Binding NextMaintenance}" Width="160" />
+            </DataGrid.Columns>
+        </DataGrid>
+    </Grid>
+</UserControl>

--- a/YasGMP.Wpf/Views/MachinesDocumentView.xaml.cs
+++ b/YasGMP.Wpf/Views/MachinesDocumentView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Views
+{
+    public partial class MachinesDocumentView : UserControl
+    {
+        public MachinesDocumentView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/YasGMP.Wpf/Views/ModuleTreeView.xaml
+++ b/YasGMP.Wpf/Views/ModuleTreeView.xaml
@@ -1,0 +1,18 @@
+<UserControl x:Class="YasGMP.Wpf.Views.ModuleTreeView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="400"
+             d:DesignWidth="260">
+    <Grid>
+        <TreeView ItemsSource="{Binding Modules}" Margin="8">
+            <TreeView.Resources>
+                <HierarchicalDataTemplate DataType="{x:Type vm:ModuleNodeViewModel}" ItemsSource="{Binding Children}" xmlns:vm="clr-namespace:YasGMP.Wpf.ViewModels">
+                    <TextBlock Text="{Binding Name}" />
+                </HierarchicalDataTemplate>
+            </TreeView.Resources>
+        </TreeView>
+    </Grid>
+</UserControl>

--- a/YasGMP.Wpf/Views/ModuleTreeView.xaml.cs
+++ b/YasGMP.Wpf/Views/ModuleTreeView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Views
+{
+    public partial class ModuleTreeView : UserControl
+    {
+        public ModuleTreeView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/YasGMP.Wpf/YasGMP.Wpf.csproj
+++ b/YasGMP.Wpf/YasGMP.Wpf.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFrameworks>net9.0-windows10.0.22621.0;net8.0-windows10.0.19041.0</TargetFrameworks>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>YasGMP.Wpf</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Dirkster.AvalonDock" Version="4.80.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="MySqlConnector" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\yasgmp.csproj" />
+  </ItemGroup>
+</Project>

--- a/yasgmp.sln
+++ b/yasgmp.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "yasgmp", "yasgmp.csproj", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YasGMP.Tests", "YasGMP.Tests\YasGMP.Tests.csproj", "{C1CF9561-4A6F-4E37-AD38-D57E7196C56D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YasGMP.Wpf", "YasGMP.Wpf\YasGMP.Wpf.csproj", "{8FF09402-DFC2-4029-9A9A-1F88C4358FAE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -19,9 +21,13 @@ Global
 		{786C8D2B-F38C-8FEA-E459-576BAF66F464}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C1CF9561-4A6F-4E37-AD38-D57E7196C56D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C1CF9561-4A6F-4E37-AD38-D57E7196C56D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C1CF9561-4A6F-4E37-AD38-D57E7196C56D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C1CF9561-4A6F-4E37-AD38-D57E7196C56D}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {C1CF9561-4A6F-4E37-AD38-D57E7196C56D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {C1CF9561-4A6F-4E37-AD38-D57E7196C56D}.Release|Any CPU.Build.0 = Release|Any CPU
+                {8FF09402-DFC2-4029-9A9A-1F88C4358FAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {8FF09402-DFC2-4029-9A9A-1F88C4358FAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {8FF09402-DFC2-4029-9A9A-1F88C4358FAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {8FF09402-DFC2-4029-9A9A-1F88C4358FAE}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add a .NET 9/8 multi-targeted YasGMP.Wpf project hosting an AvalonDock shell with module tree, cockpit pane, tabbed machines workspace, and window menu commands
- implement docking layout persistence backed by user_window_layouts via a new DockLayoutPersistenceService and integrate with DI/shared services
- extend existing database plumbing to expose configuration globally and wire the MAUI app to keep layout persistence compatible, including new layout_xml column support

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d1403dd4588331b0c2578ca07d306f