### PR TITLE
Restrict WPF project to .NET 8

### DIFF
--- a/YasGMP.Wpf/YasGMP.Wpf.csproj
+++ b/YasGMP.Wpf/YasGMP.Wpf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net9.0-windows10.0.22621.0;net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows10.0.19041.0</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary
- remove the .NET 9 target from YasGMP.Wpf so it builds only against the .NET 8 Windows target

## Testing
- dotnet restore *(fails: command not found)*
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d22c52aba8833180dcc6734b909992