### PR TITLE
Use published AvalonDock version

### DIFF
--- a/YasGMP.Wpf/YasGMP.Wpf.csproj
+++ b/YasGMP.Wpf/YasGMP.Wpf.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dirkster.AvalonDock" Version="4.80.0" />
+    <PackageReference Include="Dirkster.AvalonDock" Version="4.72.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />


### PR DESCRIPTION
## Summary
- downgrade the YasGMP.Wpf project to use the published Dirkster.AvalonDock 4.72.1 package instead of the unreleased 4.80.0 version

## Testing
- dotnet restore *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d22e1665c88331afea91c7f3700239