### PR TITLE
Pin AvalonDock dependency to published release

### DIFF
--- a/YasGMP.Wpf/YasGMP.Wpf.csproj
+++ b/YasGMP.Wpf/YasGMP.Wpf.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Pin AvalonDock to the last published version to avoid MC3074 design-time warnings. -->
     <PackageReference Include="Dirkster.AvalonDock" Version="4.72.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />


### PR DESCRIPTION
## Summary
- document why the WPF project is pinned to Dirkster.AvalonDock 4.72.1 so that the designer warning MC3074 stays suppressed

## Testing
- dotnet restore yasgmp.sln -p:EnableWindowsTargeting=true

------
https://chatgpt.com/codex/tasks/task_e_68d2319029ec8331a869c55a67d8e332