### PR TITLE
Limit WPF desktop project to .NET 8 target

### DIFF
--- a/YasGMP.Wpf/YasGMP.Wpf.csproj
+++ b/YasGMP.Wpf/YasGMP.Wpf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary
- limit the YasGMP.Wpf project to the .NET 8 Windows target now that .NET 9 support is being removed

## Testing
- dotnet restore yasgmp.sln -p:EnableWindowsTargeting=true
- dotnet build yasgmp.sln -p:EnableWindowsTargeting=true *(fails: Microsoft.UI.Xaml markup compiler cannot run on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68d242a3ee3c8331ba058239e32b1815