### PR TITLE
Ensure reauthentication dialog completes on close

### DIFF
--- a/Views/Dialogs/ReauthenticationDialog.xaml.cs
+++ b/Views/Dialogs/ReauthenticationDialog.xaml.cs
@@ -89,6 +89,16 @@ namespace YasGMP.Views.Dialogs
             }
             await Navigation.PopModalAsync();
         }
+
+        protected override void OnDisappearing()
+        {
+            if (!_tcs.Task.IsCompleted)
+            {
+                _tcs.TrySetResult(null);
+            }
+
+            base.OnDisappearing();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure the reauthentication dialog completes its task when the page disappears

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d24878ab8883318d5d8559d28e2c8c