### PR TITLE
Update AvalonDock layout assembly reference

### DIFF
--- a/YasGMP.Wpf/MainWindow.xaml
+++ b/YasGMP.Wpf/MainWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:ad="http://schemas.xceed.com/wpf/xaml/avalondock"
-        xmlns:adLayout="clr-namespace:Xceed.Wpf.AvalonDock.Layout;assembly=Xceed.Wpf.AvalonDock"
+        xmlns:adLayout="clr-namespace:Xceed.Wpf.AvalonDock.Layout;assembly=AvalonDock"
         mc:Ignorable="d"
         Title="YasGMP Cockpit"
         Width="1280"


### PR DESCRIPTION
## Summary
- update the AvalonDock layout namespace to point to the correct assembly name so layout types resolve in XAML

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d24c76eb90833194a82ad04564eae5