### PR TITLE
Clarify AvalonDock package pin

### DIFF
--- a/YasGMP.Wpf/YasGMP.Wpf.csproj
+++ b/YasGMP.Wpf/YasGMP.Wpf.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Pin AvalonDock to the last published version to avoid MC3074 design-time warnings. -->
+    <!-- Pin AvalonDock to the published 4.72.1 build to avoid MC3074 design-time warnings. -->
     <PackageReference Include="Dirkster.AvalonDock" Version="4.72.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />


### PR DESCRIPTION
## Summary
- highlight that Dirkster.AvalonDock remains pinned to the published 4.72.1 package to avoid MC3074 warnings

## Testing
- dotnet restore yasgmp.sln *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d251eb2ad08331aa8a877d285d02c0