### PR TITLE
Update WPF dependencies to 8.0.1

### DIFF
--- a/YasGMP.Wpf/YasGMP.Wpf.csproj
+++ b/YasGMP.Wpf/YasGMP.Wpf.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Dirkster.AvalonDock" Version="4.72.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- update the WPF project's Microsoft.Extensions.Configuration.Json and Microsoft.Extensions.DependencyInjection package references to version 8.0.1 to meet the minimum required version

## Testing
- dotnet restore yasgmp.sln -p:EnableWindowsTargeting=true


------
https://chatgpt.com/codex/tasks/task_e_68d2597c9e548331b9a1f72f2fcc0e71