### PR TITLE
Add AvalonDock VS2013 theme package

### DIFF
--- a/YasGMP.Wpf/YasGMP.Wpf.csproj
+++ b/YasGMP.Wpf/YasGMP.Wpf.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <!-- Pin AvalonDock to the published 4.72.1 build to avoid MC3074 design-time warnings. -->
     <PackageReference Include="Dirkster.AvalonDock" Version="4.72.1" />
+    <PackageReference Include="Dirkster.AvalonDock.Themes.VS2013" Version="4.72.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />


### PR DESCRIPTION
## Summary
- add the AvalonDock VS2013 theme NuGet package so the styling matches the main library version

## Testing
- dotnet restore *(fails: `dotnet` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d25e0b3ad88331b976a0550755f9be