### PR TITLE
Update AvalonDock references

### DIFF
--- a/YasGMP.Wpf/MainWindow.xaml
+++ b/YasGMP.Wpf/MainWindow.xaml
@@ -4,7 +4,8 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:ad="http://schemas.xceed.com/wpf/xaml/avalondock"
-        xmlns:adLayout="clr-namespace:Xceed.Wpf.AvalonDock.Layout;assembly=AvalonDock"
+        xmlns:adLayout="clr-namespace:AvalonDock.Layout;assembly=AvalonDock"
+        xmlns:adControls="clr-namespace:AvalonDock.Controls;assembly=AvalonDock"
         mc:Ignorable="d"
         Title="YasGMP Cockpit"
         Width="1280"
@@ -39,7 +40,7 @@
                 </ad:DockingManager.DocumentHeaderTemplate>
 
                 <ad:DockingManager.LayoutItemContainerStyle>
-                    <Style TargetType="{x:Type ad:LayoutItem}">
+                    <Style TargetType="{x:Type adControls:LayoutItem}">
                         <Setter Property="Title" Value="{Binding Model.Title}" />
                         <Setter Property="ContentId" Value="{Binding Model.ContentId}" />
                     </Style>

--- a/YasGMP.Wpf/Services/ShellLayoutController.cs
+++ b/YasGMP.Wpf/Services/ShellLayoutController.cs
@@ -3,8 +3,8 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-using Xceed.Wpf.AvalonDock;
-using Xceed.Wpf.AvalonDock.Layout.Serialization;
+using AvalonDock;
+using AvalonDock.Layout.Serialization;
 using YasGMP.Wpf.ViewModels;
 
 namespace YasGMP.Wpf.Services


### PR DESCRIPTION
## Summary
- update the MainWindow XAML to reference the AvalonDock CLR namespaces and layout item type from the AvalonDock assembly
- switch the shell layout controller usings to the AvalonDock namespaces

## Testing
- ❌ `dotnet build yasgmp.sln` *(dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d25ed3c9688331a59596654a7aa1f2