### PR TITLE
Align Microsoft.Extensions packages at 8.0.1

### DIFF
--- a/YasGMP.Wpf/YasGMP.Wpf.csproj
+++ b/YasGMP.Wpf/YasGMP.Wpf.csproj
@@ -6,6 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>YasGMP.Wpf</RootNamespace>
+    <!-- Keep Microsoft.Extensions packages aligned on the same patch to avoid downgrade warnings. -->
+    <MicrosoftExtensionsVersion>8.0.1</MicrosoftExtensionsVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,9 +16,9 @@
     <PackageReference Include="Dirkster.AvalonDock.Themes.VS2013" Version="4.72.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- centralize the Microsoft.Extensions package version for the WPF app on 8.0.1 to avoid downgrade warnings

## Testing
- dotnet restore yasgmp.sln -p:EnableWindowsTargeting=true

------
https://chatgpt.com/codex/tasks/task_e_68d2610190988331a75ecc505d69c462