### PR TITLE
Limit WPF project to .NET 8

### DIFF
--- a/YasGMP.Wpf/YasGMP.Wpf.csproj
+++ b/YasGMP.Wpf/YasGMP.Wpf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary
- retarget the WPF project to the supported .NET 8 Windows TFM

## Testing
- dotnet restore YasGMP.Wpf/YasGMP.Wpf.csproj -p:EnableWindowsTargeting=true *(fails: requires maui-tizen workload, but NETSDK1045 is no longer reported)*
- dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj -p:EnableWindowsTargeting=true *(fails: requires maui-tizen workload, but NETSDK1045 is no longer reported)*

------
https://chatgpt.com/codex/tasks/task_e_68d26542b31c8331ae1bdf49f50b1598