### PR TITLE
Update Microsoft.Extensions package versions in WPF project

### DIFF
--- a/YasGMP.Wpf/YasGMP.Wpf.csproj
+++ b/YasGMP.Wpf/YasGMP.Wpf.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>YasGMP.Wpf</RootNamespace>
     <!-- Keep Microsoft.Extensions packages aligned on the same patch to avoid downgrade warnings. -->
-    <MicrosoftExtensionsVersion>8.0.1</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsVersion>8.0.2</MicrosoftExtensionsVersion>
     <AvalonDockVersion>4.72.1</AvalonDockVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- bump the Microsoft.Extensions version property in the WPF project to 8.0.2 so dependent packages meet the required minimum version

## Testing
- ~/.dotnet/dotnet restore yasgmp.sln *(fails: NETSDK1147 maui-tizen workload missing; NETSDK1100 Windows targeting on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68d26b88d7f083319ff6ef76d7c1c4d1