### PR TITLE
Rename SensorType EF entity to avoid enum conflict

### DIFF
--- a/Data/YasGmpDbContext.cs
+++ b/Data/YasGmpDbContext.cs
@@ -153,7 +153,7 @@ namespace YasGMP.Data
         public DbSet<SensitiveDataAccessLog> SensitiveDataAccessLogs { get; set; }
         public DbSet<SensorDataLog> SensorDataLogs { get; set; }
         public DbSet<SensorModel> SensorModels { get; set; }
-        public DbSet<SensorType> SensorTypes { get; set; }
+        public DbSet<SensorTypeEntity> SensorTypes { get; set; }
         public DbSet<SessionLog> SessionLogs { get; set; }
         public DbSet<Setting> Settings { get; set; }
         public DbSet<SettingAuditLog> SettingAuditLogs { get; set; }

--- a/Models/SensorTypeEntity.cs
+++ b/Models/SensorTypeEntity.cs
@@ -6,7 +6,7 @@ namespace YasGMP.Models
 {
     /// <summary>Entity model for the `sensor_types` table.</summary>
     [Table("sensor_types")]
-    public class SensorType
+    public class SensorTypeEntity
     {
         /// <summary>Gets or sets the id.</summary>
         [Key]


### PR DESCRIPTION
## Summary
- rename the EF Core sensor type entity to `SensorTypeEntity` to avoid the name collision with the enum
- update the `YasGmpDbContext` DbSet to use the renamed entity type

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d26cc7765883318ae2ce31ae394761