### PR TITLE
Exclude WPF assets from MAUI build

### DIFF
--- a/yasgmp.csproj
+++ b/yasgmp.csproj
@@ -75,6 +75,11 @@
     <!-- Exclude test sources from the main app build -->
     <Compile Remove="YasGMP.Tests\**\*.cs" />
     <None Include="YasGMP.Tests\**\*.cs" />
+    <!-- Exclude WPF desktop project sources from the main app build -->
+    <Compile Remove="YasGMP.Wpf\**\*.cs" />
+    <None Include="YasGMP.Wpf\**\*.cs" />
+    <MauiXaml Remove="YasGMP.Wpf\**\*.xaml" />
+    <None Include="YasGMP.Wpf\**\*.xaml" />
   </ItemGroup>
 
   <Target Name="DbSyncAnalyzer" BeforeTargets="Build" Condition="'$(RUN_DB_ANALYZER_ON_BUILD)'=='true'">


### PR DESCRIPTION
## Summary
- exclude the YasGMP.Wpf C# and XAML files from the MAUI project so they are not compiled alongside the mobile app
- add matching None includes so the WPF-specific sources stay visible to the WPF project

## Testing
- `dotnet build yasgmp.csproj -p:EnableWindowsTargeting=true` *(fails: Microsoft.UI.Xaml compiler cannot run on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68d27e1e73cc8331be388e520823a91c