### PR TITLE
Limit enum imports in YasGmpDbContext

### DIFF
--- a/Data/YasGmpDbContext.cs
+++ b/Data/YasGmpDbContext.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using YasGMP.Models;
-using YasGMP.Models.Enums;
+using PhotoType = YasGMP.Models.Enums.PhotoType;
 using WorkOrderActionType = YasGMP.Models.Enums.WorkOrderActionType;
 
 namespace YasGMP.Data


### PR DESCRIPTION
## Summary
- replace the broad YasGMP.Models.Enums import in YasGmpDbContext with targeted aliases to avoid enum/entity ambiguity

## Testing
- dotnet build *(fails: dotnet command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d27fcab30c8331a8b43c3b7b09cfef