### PR TITLE
chore: update WPF Microsoft.Extensions packages

### DIFF
--- a/YasGMP.Wpf/YasGMP.Wpf.csproj
+++ b/YasGMP.Wpf/YasGMP.Wpf.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>YasGMP.Wpf</RootNamespace>
     <!-- Keep Microsoft.Extensions packages aligned on the same patch to avoid downgrade warnings. -->
-    <MicrosoftExtensionsVersion>8.0.2</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsVersion>9.0.0</MicrosoftExtensionsVersion>
     <AvalonDockVersion>4.72.1</AvalonDockVersion>
   </PropertyGroup>
 
@@ -16,7 +16,7 @@
     <PackageReference Include="Dirkster.AvalonDock" Version="$(AvalonDockVersion)" />
     <PackageReference Include="Dirkster.AvalonDock.Themes.VS2013" Version="$(AvalonDockVersion)" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />


### PR DESCRIPTION
## Summary
- bump the shared Microsoft.Extensions version in the WPF project to 9.0.0
- align the direct Microsoft.Extensions.Configuration.Binder reference with the shared property

## Testing
- dotnet restore YasGMP.Wpf/YasGMP.Wpf.csproj -p:EnableWindowsTargeting=true -p:UseMaui=false
- dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj -p:EnableWindowsTargeting=true -p:UseMaui=false *(fails: Microsoft.WindowsAppSDK XamlCompiler.exe cannot run on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68d28395013c8331af7cda7609c2c0e4