### PR TITLE
Add Fluent Ribbon shell to WPF host

### DIFF
--- a/YasGMP.Wpf/MainWindow.xaml
+++ b/YasGMP.Wpf/MainWindow.xaml
@@ -1,27 +1,65 @@
-<Window x:Class="YasGMP.Wpf.MainWindow"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:ad="http://schemas.xceed.com/wpf/xaml/avalondock"
-        xmlns:adLayout="clr-namespace:AvalonDock.Layout;assembly=AvalonDock"
-        xmlns:adControls="clr-namespace:AvalonDock.Controls;assembly=AvalonDock"
-        mc:Ignorable="d"
-        Title="YasGMP Cockpit"
-        Width="1280"
-        Height="800"
-        Loaded="OnLoaded"
-        Closing="OnClosing">
+<fluent:RibbonWindow x:Class="YasGMP.Wpf.MainWindow"
+                     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                     xmlns:fluent="urn:fluent-ribbon"
+                     xmlns:ad="http://schemas.xceed.com/wpf/xaml/avalondock"
+                     xmlns:adLayout="clr-namespace:AvalonDock.Layout;assembly=AvalonDock"
+                     xmlns:adControls="clr-namespace:AvalonDock.Controls;assembly=AvalonDock"
+                     xmlns:adThemes="clr-namespace:AvalonDock.Themes;assembly=AvalonDock.Themes.Metro"
+                     Title="YasGMP Cockpit"
+                     Width="1280"
+                     Height="800"
+                     Loaded="OnLoaded"
+                     Closing="OnClosing"
+                     mc:Ignorable="d">
     <DockPanel>
-        <Menu DockPanel.Dock="Top">
-            <MenuItem Header="_Window">
-                <MenuItem Header="_New Machines Tab" Command="{Binding WindowCommands.NewMachinesDocumentCommand}" />
-                <MenuItem Header="_Navigate to Machines" Command="{Binding WindowCommands.NavigateToMachinesCommand}" />
-                <Separator />
-                <MenuItem Header="_Save Layout" Command="{Binding WindowCommands.SaveLayoutCommand}" />
-                <MenuItem Header="_Reset Layout" Command="{Binding WindowCommands.ResetLayoutCommand}" />
-            </MenuItem>
-        </Menu>
+        <fluent:Ribbon x:Name="ShellRibbon"
+                       DockPanel.Dock="Top"
+                       fluent:RibbonWindow.Ribbon="{Binding RelativeSource={RelativeSource Self}}"
+                       IsQuickAccessToolBarVisible="False">
+            <fluent:Ribbon.Menu>
+                <fluent:Backstage x:Name="ShellBackstage">
+                    <fluent:BackstageTabControl>
+                        <fluent:BackstageTabItem Header="Layout">
+                            <StackPanel Margin="16">
+                                <fluent:Button Header="Save Layout"
+                                               Width="180"
+                                               Margin="0,0,0,8"
+                                               Command="{Binding WindowCommands.SaveLayoutCommand}" />
+                                <fluent:Button Header="Reset Layout"
+                                               Width="180"
+                                               Command="{Binding WindowCommands.ResetLayoutCommand}" />
+                            </StackPanel>
+                        </fluent:BackstageTabItem>
+                    </fluent:BackstageTabControl>
+                </fluent:Backstage>
+            </fluent:Ribbon.Menu>
+
+            <fluent:RibbonTabItem Header="Home">
+                <fluent:RibbonGroupBox Header="Workspace">
+                    <fluent:Button Header="New Machines Tab"
+                                   Command="{Binding WindowCommands.NewMachinesDocumentCommand}" />
+                    <fluent:Button Header="Navigate to Machines"
+                                   Command="{Binding WindowCommands.NavigateToMachinesCommand}" />
+                </fluent:RibbonGroupBox>
+            </fluent:RibbonTabItem>
+
+            <fluent:RibbonTabItem Header="View">
+                <fluent:RibbonGroupBox Header="Layout">
+                    <fluent:Button Header="Reset Layout"
+                                   Command="{Binding WindowCommands.ResetLayoutCommand}" />
+                </fluent:RibbonGroupBox>
+            </fluent:RibbonTabItem>
+
+            <fluent:RibbonTabItem Header="Tools">
+                <fluent:RibbonGroupBox Header="Persistence">
+                    <fluent:Button Header="Save Layout"
+                                   Command="{Binding WindowCommands.SaveLayoutCommand}" />
+                </fluent:RibbonGroupBox>
+            </fluent:RibbonTabItem>
+        </fluent:Ribbon>
 
         <StatusBar DockPanel.Dock="Bottom">
             <StatusBarItem>
@@ -33,6 +71,10 @@
             <ad:DockingManager x:Name="DockManager"
                                DocumentsSource="{Binding Documents}"
                                ActiveContent="{Binding ActiveDocument, Mode=TwoWay}">
+                <ad:DockingManager.Theme>
+                    <adThemes:MetroTheme />
+                </ad:DockingManager.Theme>
+
                 <ad:DockingManager.DocumentHeaderTemplate>
                     <DataTemplate>
                         <TextBlock Text="{Binding Title}" />
@@ -68,4 +110,4 @@
             </ad:DockingManager>
         </Grid>
     </DockPanel>
-</Window>
+</fluent:RibbonWindow>

--- a/YasGMP.Wpf/MainWindow.xaml.cs
+++ b/YasGMP.Wpf/MainWindow.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Windows;
+using Fluent;
 using YasGMP.Wpf.Services;
 using YasGMP.Wpf.ViewModels;
 
@@ -10,7 +11,7 @@ namespace YasGMP.Wpf
     /// <summary>
     /// Shell host window that bridges the view-model with AvalonDock layout services.
     /// </summary>
-    public partial class MainWindow : Window
+    public partial class MainWindow : RibbonWindow
     {
         private readonly MainWindowViewModel _viewModel;
         private readonly ShellLayoutController _layoutController;
@@ -41,11 +42,13 @@ namespace YasGMP.Wpf
 
         private async void OnSaveLayoutRequested(object? sender, EventArgs e)
         {
+            ShellBackstage.IsOpen = false;
             await _layoutController.SaveLayoutAsync(this);
         }
 
         private async void OnResetLayoutRequested(object? sender, EventArgs e)
         {
+            ShellBackstage.IsOpen = false;
             await _layoutController.ResetLayoutAsync(this);
         }
     }

--- a/YasGMP.Wpf/YasGMP.Wpf.csproj
+++ b/YasGMP.Wpf/YasGMP.Wpf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -14,7 +14,9 @@
   <ItemGroup>
     <!-- Pin AvalonDock to the published 4.72.1 build to avoid MC3074 design-time warnings. -->
     <PackageReference Include="Dirkster.AvalonDock" Version="$(AvalonDockVersion)" />
+    <PackageReference Include="Dirkster.AvalonDock.Themes.Metro" Version="$(AvalonDockVersion)" />
     <PackageReference Include="Dirkster.AvalonDock.Themes.VS2013" Version="$(AvalonDockVersion)" />
+    <PackageReference Include="Fluent.Ribbon" Version="11.0.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsVersion)" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.413",
+    "version": "9.0.100",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Summary
- target .NET 9 for the WPF shell, align the SDK, and add Fluent.Ribbon plus the AvalonDock metro theme package
- swap the legacy menu for a Fluent ribbon with Home/View/Tools tabs and a backstage hosting layout commands while keeping the dock layout/status bar intact
- derive the shell window from RibbonWindow and ensure backstage layout actions close before delegating to the layout controller

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d391b4b4bc83319fa6bc1455bdc711