### PR TITLE
Add WPF shell panes and module document framework

### DIFF
--- a/YasGMP.Wpf/App.xaml
+++ b/YasGMP.Wpf/App.xaml
@@ -2,16 +2,54 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:YasGMP.Wpf.ViewModels"
-             xmlns:views="clr-namespace:YasGMP.Wpf.Views">
+             xmlns:views="clr-namespace:YasGMP.Wpf.Views"
+             xmlns:shell="clr-namespace:YasGMP.Wpf.Shell"
+             xmlns:controls="clr-namespace:YasGMP.Wpf.Controls">
     <Application.Resources>
-        <DataTemplate DataType="{x:Type vm:MachinesDocumentViewModel}">
-            <views:MachinesDocumentView />
+        <DataTemplate DataType="{x:Type vm:ModulesPaneViewModel}">
+            <shell:ModulesPane />
         </DataTemplate>
-        <DataTemplate DataType="{x:Type vm:ModuleTreeViewModel}">
-            <views:ModuleTreeView />
+        <DataTemplate DataType="{x:Type vm:InspectorPaneViewModel}">
+            <shell:InspectorPane />
         </DataTemplate>
-        <DataTemplate DataType="{x:Type vm:CockpitViewModel}">
-            <views:CockpitView />
+        <DataTemplate DataType="{x:Type vm:ShellStatusBarViewModel}">
+            <controls:ShellStatusBar />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:DashboardModuleViewModel}">
+            <views:DashboardModuleView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:AssetsModuleViewModel}">
+            <views:AssetsModuleView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:WarehouseModuleViewModel}">
+            <views:WarehouseModuleView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:WorkOrdersModuleViewModel}">
+            <views:WorkOrdersModuleView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:CalibrationModuleViewModel}">
+            <views:CalibrationModuleView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:QualityModuleViewModel}">
+            <views:QualityModuleView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:SchedulingModuleViewModel}">
+            <views:SchedulingModuleView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:SecurityModuleViewModel}">
+            <views:SecurityModuleView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:VendorsModuleViewModel}">
+            <views:VendorsModuleView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:AdminModuleViewModel}">
+            <views:AdminModuleView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:AuditModuleViewModel}">
+            <views:AuditModuleView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:AttachmentsModuleViewModel}">
+            <views:AttachmentsModuleView />
         </DataTemplate>
     </Application.Resources>
 </Application>

--- a/YasGMP.Wpf/App.xaml.cs
+++ b/YasGMP.Wpf/App.xaml.cs
@@ -9,6 +9,7 @@ using YasGMP.Services;
 using YasGMP.Services.Interfaces;
 using YasGMP.Wpf.Services;
 using YasGMP.Wpf.ViewModels;
+using YasGMP.Wpf.ViewModels.Modules;
 
 namespace YasGMP.Wpf
 {
@@ -43,9 +44,47 @@ namespace YasGMP.Wpf
 
                         var svc = core.Services;
                         svc.AddSingleton<IUserSession, UserSession>();
-                        svc.AddSingleton<IMachineDataService, MockMachineDataService>();
                         svc.AddSingleton<IPlatformService, WpfPlatformService>();
                         svc.AddSingleton<IAuthContext, WpfAuthContext>();
+                        svc.AddSingleton<ICflDialogService, CflDialogService>();
+                        svc.AddSingleton<ShellInteractionService>();
+                        svc.AddSingleton<IModuleNavigationService>(sp => sp.GetRequiredService<ShellInteractionService>());
+                        svc.AddSingleton<IShellInteractionService>(sp => sp.GetRequiredService<ShellInteractionService>());
+                        svc.AddSingleton<ModulesPaneViewModel>();
+                        svc.AddSingleton<InspectorPaneViewModel>();
+                        svc.AddSingleton<ShellStatusBarViewModel>();
+
+                        svc.AddTransient<DashboardModuleViewModel>();
+                        svc.AddTransient<AssetsModuleViewModel>();
+                        svc.AddTransient<WarehouseModuleViewModel>();
+                        svc.AddTransient<WorkOrdersModuleViewModel>();
+                        svc.AddTransient<CalibrationModuleViewModel>();
+                        svc.AddTransient<QualityModuleViewModel>();
+                        svc.AddTransient<SchedulingModuleViewModel>();
+                        svc.AddTransient<SecurityModuleViewModel>();
+                        svc.AddTransient<VendorsModuleViewModel>();
+                        svc.AddTransient<AdminModuleViewModel>();
+                        svc.AddTransient<AuditModuleViewModel>();
+                        svc.AddTransient<AttachmentsModuleViewModel>();
+
+                        svc.AddSingleton<ModuleRegistry>(sp =>
+                        {
+                            var registry = new ModuleRegistry(sp);
+                            registry.Register<DashboardModuleViewModel>(DashboardModuleViewModel.ModuleKey, "Dashboard", "Cockpit", "Operations overview and KPIs");
+                            registry.Register<AssetsModuleViewModel>(AssetsModuleViewModel.ModuleKey, "Assets", "Maintenance", "Asset register and lifecycle");
+                            registry.Register<WarehouseModuleViewModel>(WarehouseModuleViewModel.ModuleKey, "Warehouse", "Maintenance", "Warehouse master data");
+                            registry.Register<WorkOrdersModuleViewModel>(WorkOrdersModuleViewModel.ModuleKey, "Work Orders", "Maintenance", "Corrective and preventive jobs");
+                            registry.Register<CalibrationModuleViewModel>(CalibrationModuleViewModel.ModuleKey, "Calibration", "Maintenance", "Calibration records");
+                            registry.Register<QualityModuleViewModel>(QualityModuleViewModel.ModuleKey, "Quality", "Quality", "CAPA and quality events");
+                            registry.Register<SchedulingModuleViewModel>(SchedulingModuleViewModel.ModuleKey, "Scheduling", "Planning", "Automated job schedules");
+                            registry.Register<SecurityModuleViewModel>(SecurityModuleViewModel.ModuleKey, "Security", "Administration", "Users and security roles");
+                            registry.Register<VendorsModuleViewModel>(VendorsModuleViewModel.ModuleKey, "Vendors", "Supply Chain", "Approved suppliers and contractors");
+                            registry.Register<AdminModuleViewModel>(AdminModuleViewModel.ModuleKey, "Administration", "Administration", "Global configuration settings");
+                            registry.Register<AuditModuleViewModel>(AuditModuleViewModel.ModuleKey, "Audit Trail", "Compliance", "System event history");
+                            registry.Register<AttachmentsModuleViewModel>(AttachmentsModuleViewModel.ModuleKey, "Attachments", "Documents", "File attachments and certificates");
+                            return registry;
+                        });
+                        svc.AddSingleton<IModuleRegistry>(sp => sp.GetRequiredService<ModuleRegistry>());
                         svc.AddSingleton<DockLayoutPersistenceService>();
                         svc.AddSingleton<ShellLayoutController>();
 

--- a/YasGMP.Wpf/Controls/GoldenArrowButton.xaml
+++ b/YasGMP.Wpf/Controls/GoldenArrowButton.xaml
@@ -1,0 +1,20 @@
+<Button x:Class="YasGMP.Wpf.Controls.GoldenArrowButton"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Width="24"
+        Height="24"
+        ToolTip="Open related record"
+        Background="#FFB000"
+        BorderBrush="#C89000"
+        BorderThickness="1"
+        Cursor="Hand">
+    <Button.Template>
+        <ControlTemplate TargetType="Button">
+            <Border CornerRadius="3" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+                <Grid>
+                    <Path Data="M4,4 L20,12 L4,20 Z" Fill="#1B1B1B" />
+                </Grid>
+            </Border>
+        </ControlTemplate>
+    </Button.Template>
+</Button>

--- a/YasGMP.Wpf/Controls/GoldenArrowButton.xaml.cs
+++ b/YasGMP.Wpf/Controls/GoldenArrowButton.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Controls;
+
+public partial class GoldenArrowButton : Button
+{
+    public GoldenArrowButton()
+    {
+        InitializeComponent();
+    }
+}

--- a/YasGMP.Wpf/Controls/ShellStatusBar.xaml
+++ b/YasGMP.Wpf/Controls/ShellStatusBar.xaml
@@ -1,0 +1,18 @@
+<UserControl x:Class="YasGMP.Wpf.Controls.ShellStatusBar"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="24"
+             d:DesignWidth="800">
+    <Border Background="#2D2D30" Padding="8,2">
+        <DockPanel>
+            <TextBlock Text="{Binding StatusText}" Foreground="White" />
+            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
+                <TextBlock Text="Active:" Foreground="#AAAAAA" Margin="0,0,4,0" />
+                <TextBlock Text="{Binding ActiveModule}" Foreground="#CCCCCC" />
+            </StackPanel>
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/YasGMP.Wpf/Controls/ShellStatusBar.xaml.cs
+++ b/YasGMP.Wpf/Controls/ShellStatusBar.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Controls;
+
+public partial class ShellStatusBar : UserControl
+{
+    public ShellStatusBar()
+    {
+        InitializeComponent();
+    }
+}

--- a/YasGMP.Wpf/Dialogs/CflDialog.xaml
+++ b/YasGMP.Wpf/Dialogs/CflDialog.xaml
@@ -1,0 +1,34 @@
+<Window x:Class="YasGMP.Wpf.Dialogs.CflDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Choose From List"
+        SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterOwner"
+        MinWidth="420"
+        MinHeight="340"
+        ResizeMode="CanResizeWithGrip">
+    <DockPanel Margin="12">
+        <TextBlock Text="{Binding Title}"
+                   FontSize="16"
+                   FontWeight="SemiBold"
+                   DockPanel.Dock="Top"
+                   Margin="0,0,0,8" />
+        <ListView ItemsSource="{Binding Items}"
+                  SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
+                  MinHeight="220"
+                  Margin="0,0,0,8">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel>
+                        <TextBlock Text="{Binding Label}" FontWeight="Bold" />
+                        <TextBlock Text="{Binding Description}" FontStyle="Italic" Foreground="Gray" />
+                    </StackPanel>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Bottom" Margin="0,8,0,0">
+            <Button Content="OK" Width="80" Margin="0,0,8,0" IsDefault="True" Command="{Binding ConfirmCommand}" />
+            <Button Content="Cancel" Width="80" IsCancel="True" />
+        </StackPanel>
+    </DockPanel>
+</Window>

--- a/YasGMP.Wpf/Dialogs/CflDialog.xaml.cs
+++ b/YasGMP.Wpf/Dialogs/CflDialog.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows;
+
+namespace YasGMP.Wpf.Dialogs;
+
+public partial class CflDialog : Window
+{
+    public CflDialog()
+    {
+        InitializeComponent();
+    }
+}

--- a/YasGMP.Wpf/Dialogs/CflDialogViewModel.cs
+++ b/YasGMP.Wpf/Dialogs/CflDialogViewModel.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.Dialogs;
+
+public partial class CflDialogViewModel : ObservableObject
+{
+    public CflDialogViewModel(CflRequest request)
+    {
+        Title = request.Title;
+        Items = new ObservableCollection<CflItem>(request.Items);
+        ConfirmCommand = new RelayCommand(Confirm, () => SelectedItem is not null);
+    }
+
+    public string Title { get; }
+
+    public ObservableCollection<CflItem> Items { get; }
+
+    public RelayCommand ConfirmCommand { get; }
+
+    [ObservableProperty]
+    private CflItem? _selectedItem;
+
+    public event EventHandler<CflResult>? Confirmed;
+
+    private void Confirm()
+    {
+        if (SelectedItem is null)
+        {
+            return;
+        }
+
+        Confirmed?.Invoke(this, new CflResult(SelectedItem));
+    }
+
+    partial void OnSelectedItemChanged(CflItem? value)
+    {
+        ConfirmCommand.NotifyCanExecuteChanged();
+    }
+}

--- a/YasGMP.Wpf/MainWindow.xaml
+++ b/YasGMP.Wpf/MainWindow.xaml
@@ -8,6 +8,7 @@
                      xmlns:adLayout="clr-namespace:AvalonDock.Layout;assembly=AvalonDock"
                      xmlns:adControls="clr-namespace:AvalonDock.Controls;assembly=AvalonDock"
                      xmlns:adThemes="clr-namespace:AvalonDock.Themes;assembly=AvalonDock.Themes.Metro"
+                     xmlns:controls="clr-namespace:YasGMP.Wpf.Controls"
                      Title="YasGMP Cockpit"
                      Width="1280"
                      Height="800"
@@ -38,11 +39,13 @@
             </fluent:Ribbon.Menu>
 
             <fluent:RibbonTabItem Header="Home">
-                <fluent:RibbonGroupBox Header="Workspace">
-                    <fluent:Button Header="New Machines Tab"
-                                   Command="{Binding WindowCommands.NewMachinesDocumentCommand}" />
-                    <fluent:Button Header="Navigate to Machines"
-                                   Command="{Binding WindowCommands.NavigateToMachinesCommand}" />
+                <fluent:RibbonGroupBox Header="Modules">
+                    <fluent:Button Header="Dashboard"
+                                   Command="{Binding WindowCommands.OpenDashboardCommand}" />
+                    <fluent:Button Header="Assets"
+                                   Command="{Binding WindowCommands.OpenAssetsCommand}" />
+                    <fluent:Button Header="Work Orders"
+                                   Command="{Binding WindowCommands.OpenWorkOrdersCommand}" />
                 </fluent:RibbonGroupBox>
             </fluent:RibbonTabItem>
 
@@ -61,11 +64,7 @@
             </fluent:RibbonTabItem>
         </fluent:Ribbon>
 
-        <StatusBar DockPanel.Dock="Bottom">
-            <StatusBarItem>
-                <TextBlock Text="{Binding StatusText}" />
-            </StatusBarItem>
-        </StatusBar>
+        <controls:ShellStatusBar DockPanel.Dock="Bottom" DataContext="{Binding StatusBar}" />
 
         <Grid>
             <ad:DockingManager x:Name="DockManager"
@@ -94,14 +93,14 @@
                             <adLayout:LayoutAnchorablePane DockWidth="280">
                                 <adLayout:LayoutAnchorable Title="Modules"
                                                           ContentId="YasGmp.Shell.Modules"
-                                                          Content="{Binding ModuleTree}" />
+                                                          Content="{Binding ModulesPane}" />
                             </adLayout:LayoutAnchorablePane>
                             <adLayout:LayoutPanel Orientation="Vertical">
                                 <adLayout:LayoutDocumentPane />
                                 <adLayout:LayoutAnchorablePane DockHeight="220">
-                                    <adLayout:LayoutAnchorable Title="Cockpit"
-                                                              ContentId="YasGmp.Shell.Cockpit"
-                                                              Content="{Binding Cockpit}" />
+                                    <adLayout:LayoutAnchorable Title="Inspector"
+                                                              ContentId="YasGmp.Shell.Inspector"
+                                                              Content="{Binding InspectorPane}" />
                                 </adLayout:LayoutAnchorablePane>
                             </adLayout:LayoutPanel>
                         </adLayout:LayoutPanel>

--- a/YasGMP.Wpf/MainWindow.xaml.cs
+++ b/YasGMP.Wpf/MainWindow.xaml.cs
@@ -1,6 +1,5 @@
 using System;
 using System.ComponentModel;
-using System.Threading.Tasks;
 using System.Windows;
 using Fluent;
 using YasGMP.Wpf.Services;

--- a/YasGMP.Wpf/Services/CflDialogService.cs
+++ b/YasGMP.Wpf/Services/CflDialogService.cs
@@ -1,0 +1,53 @@
+using System.Threading.Tasks;
+using System.Windows;
+using YasGMP.Wpf.Dialogs;
+
+namespace YasGMP.Wpf.Services;
+
+public sealed class CflDialogService : ICflDialogService
+{
+    public Task<CflResult?> ShowAsync(CflRequest request)
+    {
+        var tcs = new TaskCompletionSource<CflResult?>();
+        Application.Current.Dispatcher.Invoke(() =>
+        {
+            var dialog = new CflDialog
+            {
+                Owner = Application.Current.Windows.Count > 0 ? Application.Current.Windows[0] : null,
+                DataContext = CreateViewModel(request, tcs)
+            };
+
+            dialog.ShowDialog();
+            if (!tcs.Task.IsCompleted)
+            {
+                tcs.TrySetResult(null);
+            }
+        });
+
+        return tcs.Task;
+    }
+
+    private static CflDialogViewModel CreateViewModel(CflRequest request, TaskCompletionSource<CflResult?> tcs)
+    {
+        var vm = new CflDialogViewModel(request);
+        vm.Confirmed += (_, result) =>
+        {
+            tcs.TrySetResult(result);
+            CloseDialog();
+        };
+        return vm;
+
+        void CloseDialog()
+        {
+            foreach (Window window in Application.Current.Windows)
+            {
+                if (window is CflDialog dlg && Equals(dlg.DataContext, vm))
+                {
+                    dlg.DialogResult = true;
+                    dlg.Close();
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/YasGMP.Wpf/Services/ICflDialogService.cs
+++ b/YasGMP.Wpf/Services/ICflDialogService.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using YasGMP.Wpf.ViewModels.Modules;
+
+namespace YasGMP.Wpf.Services;
+
+/// <summary>Service used to display SAP Business One style choose-from-list dialogs.</summary>
+public interface ICflDialogService
+{
+    Task<CflResult?> ShowAsync(CflRequest request);
+}
+
+/// <summary>Descriptor for CFL invocations.</summary>
+public sealed class CflRequest
+{
+    public CflRequest(string title, IReadOnlyList<CflItem> items)
+    {
+        Title = title;
+        Items = items;
+    }
+
+    public string Title { get; }
+
+    public IReadOnlyList<CflItem> Items { get; }
+}
+
+/// <summary>Single CFL row.</summary>
+public sealed class CflItem
+{
+    public CflItem(string key, string label, string? description = null)
+    {
+        Key = key;
+        Label = label;
+        Description = description ?? string.Empty;
+    }
+
+    public string Key { get; }
+
+    public string Label { get; }
+
+    public string Description { get; }
+}
+
+/// <summary>Result returned from a CFL dialog.</summary>
+public sealed class CflResult
+{
+    public CflResult(CflItem selected)
+    {
+        Selected = selected;
+    }
+
+    public CflItem Selected { get; }
+}

--- a/YasGMP.Wpf/Services/IShellInteractionService.cs
+++ b/YasGMP.Wpf/Services/IShellInteractionService.cs
@@ -1,0 +1,19 @@
+using YasGMP.Wpf.ViewModels.Modules;
+
+namespace YasGMP.Wpf.Services;
+
+/// <summary>Exposes status/inspector updates for docked module documents.</summary>
+public interface IShellInteractionService
+{
+    void UpdateStatus(string message);
+
+    void UpdateInspector(InspectorContext context);
+}
+
+/// <summary>Navigation contract used by golden-arrow buttons to activate related modules.</summary>
+public interface IModuleNavigationService
+{
+    ModuleDocumentViewModel OpenModule(string moduleKey, object? parameter = null);
+
+    void Activate(ModuleDocumentViewModel document);
+}

--- a/YasGMP.Wpf/Services/ModuleRegistry.cs
+++ b/YasGMP.Wpf/Services/ModuleRegistry.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using YasGMP.Wpf.ViewModels.Modules;
+
+namespace YasGMP.Wpf.Services;
+
+/// <summary>Provides factories for module documents discoverable in the Modules pane.</summary>
+public interface IModuleRegistry
+{
+    IReadOnlyList<ModuleMetadata> Modules { get; }
+
+    ModuleDocumentViewModel CreateModule(string moduleKey);
+}
+
+public sealed class ModuleMetadata
+{
+    public ModuleMetadata(string key, string title, string category, string? description = null)
+    {
+        Key = key;
+        Title = title;
+        Category = category;
+        Description = description ?? string.Empty;
+    }
+
+    public string Key { get; }
+
+    public string Title { get; }
+
+    public string Category { get; }
+
+    public string Description { get; }
+}
+
+/// <summary>Runtime implementation backed by DI factories.</summary>
+public sealed class ModuleRegistry : IModuleRegistry
+{
+    private readonly IServiceProvider _services;
+    private readonly Dictionary<string, ModuleRegistration> _registrations = new(StringComparer.OrdinalIgnoreCase);
+
+    public ModuleRegistry(IServiceProvider services)
+    {
+        _services = services;
+    }
+
+    public IReadOnlyList<ModuleMetadata> Modules
+        => _registrations.Values
+            .Select(r => r.Metadata)
+            .OrderBy(r => r.Category)
+            .ThenBy(r => r.Title)
+            .ToList();
+
+    public ModuleDocumentViewModel CreateModule(string moduleKey)
+    {
+        if (!_registrations.TryGetValue(moduleKey, out var registration))
+        {
+            throw new InvalidOperationException($"Module '{moduleKey}' is not registered.");
+        }
+
+        return (ModuleDocumentViewModel)_services.GetRequiredService(registration.ViewModelType);
+    }
+
+    public void Register<TViewModel>(string key, string title, string category, string? description = null)
+        where TViewModel : ModuleDocumentViewModel
+    {
+        _registrations[key] = new ModuleRegistration(key, typeof(TViewModel), new ModuleMetadata(key, title, category, description));
+    }
+
+    private sealed record ModuleRegistration(string Key, Type ViewModelType, ModuleMetadata Metadata);
+}

--- a/YasGMP.Wpf/Services/ShellInteractionService.cs
+++ b/YasGMP.Wpf/Services/ShellInteractionService.cs
@@ -1,0 +1,66 @@
+using System;
+using YasGMP.Wpf.ViewModels.Modules;
+
+namespace YasGMP.Wpf.Services;
+
+/// <summary>Bridges module documents with the shell window.</summary>
+public sealed class ShellInteractionService : IShellInteractionService, IModuleNavigationService
+{
+    private Func<string, object?, ModuleDocumentViewModel>? _openModule;
+    private Action<ModuleDocumentViewModel>? _activate;
+    private Action<string>? _statusUpdater;
+    private Action<InspectorContext>? _inspectorUpdater;
+
+    public void Configure(
+        Func<string, object?, ModuleDocumentViewModel> openModule,
+        Action<ModuleDocumentViewModel> activate,
+        Action<string> statusUpdater,
+        Action<InspectorContext> inspectorUpdater)
+    {
+        _openModule = openModule ?? throw new ArgumentNullException(nameof(openModule));
+        _activate = activate ?? throw new ArgumentNullException(nameof(activate));
+        _statusUpdater = statusUpdater ?? throw new ArgumentNullException(nameof(statusUpdater));
+        _inspectorUpdater = inspectorUpdater ?? throw new ArgumentNullException(nameof(inspectorUpdater));
+    }
+
+    public ModuleDocumentViewModel OpenModule(string moduleKey, object? parameter = null)
+    {
+        if (_openModule == null)
+        {
+            throw new InvalidOperationException("Shell interaction service not configured.");
+        }
+
+        var document = _openModule(moduleKey, parameter);
+        return document;
+    }
+
+    public void Activate(ModuleDocumentViewModel document)
+    {
+        if (_activate == null)
+        {
+            throw new InvalidOperationException("Shell interaction service not configured.");
+        }
+
+        _activate(document);
+    }
+
+    public void UpdateStatus(string message)
+    {
+        if (_statusUpdater == null)
+        {
+            return;
+        }
+
+        _statusUpdater(message);
+    }
+
+    public void UpdateInspector(InspectorContext context)
+    {
+        if (_inspectorUpdater == null)
+        {
+            return;
+        }
+
+        _inspectorUpdater(context);
+    }
+}

--- a/YasGMP.Wpf/Services/ShellLayoutController.cs
+++ b/YasGMP.Wpf/Services/ShellLayoutController.cs
@@ -121,10 +121,10 @@ namespace YasGMP.Wpf.Services
             switch (e.Model.ContentId)
             {
                 case "YasGmp.Shell.Modules":
-                    e.Content = _viewModel.ModuleTree;
+                    e.Content = _viewModel.ModulesPane;
                     break;
-                case "YasGmp.Shell.Cockpit":
-                    e.Content = _viewModel.Cockpit;
+                case "YasGmp.Shell.Inspector":
+                    e.Content = _viewModel.InspectorPane;
                     break;
                 default:
                     if (!string.IsNullOrWhiteSpace(e.Model.ContentId))

--- a/YasGMP.Wpf/Shell/InspectorPane.xaml
+++ b/YasGMP.Wpf/Shell/InspectorPane.xaml
@@ -1,0 +1,31 @@
+<UserControl x:Class="YasGMP.Wpf.Shell.InspectorPane"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="240"
+             d:DesignWidth="400">
+    <Border Padding="12" Background="#1E1E1E" CornerRadius="4">
+        <DockPanel>
+            <StackPanel DockPanel.Dock="Top">
+                <TextBlock Text="{Binding ModuleTitle}" FontSize="14" FontWeight="Bold" Foreground="#F9F9F9" />
+                <TextBlock Text="{Binding RecordTitle}" FontSize="12" Foreground="#CCCCCC" Margin="0,4,0,12" />
+            </StackPanel>
+            <ItemsControl ItemsSource="{Binding Fields}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Grid Margin="0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="180" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="{Binding Label}" Foreground="#BBBBBB" />
+                            <TextBlock Text="{Binding Value}" Grid.Column="1" Foreground="#FFFFFF" TextWrapping="Wrap" />
+                        </Grid>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/YasGMP.Wpf/Shell/InspectorPane.xaml.cs
+++ b/YasGMP.Wpf/Shell/InspectorPane.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Shell;
+
+public partial class InspectorPane : UserControl
+{
+    public InspectorPane()
+    {
+        InitializeComponent();
+    }
+}

--- a/YasGMP.Wpf/Shell/ModulesPane.xaml
+++ b/YasGMP.Wpf/Shell/ModulesPane.xaml
@@ -1,0 +1,33 @@
+<UserControl x:Class="YasGMP.Wpf.Shell.ModulesPane"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="400"
+             d:DesignWidth="280">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <ItemsControl ItemsSource="{Binding Groups}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <Expander Header="{Binding Name}"
+                              Margin="0,0,0,8"
+                              IsExpanded="True">
+                        <ItemsControl ItemsSource="{Binding Modules}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Button Content="{Binding Metadata.Title}"
+                                            Command="{Binding OpenCommand}"
+                                            CommandParameter="{Binding}"
+                                            Margin="12,4,0,4"
+                                            HorizontalContentAlignment="Left"
+                                            ToolTip="{Binding Metadata.Description}" />
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </Expander>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+    </ScrollViewer>
+</UserControl>

--- a/YasGMP.Wpf/Shell/ModulesPane.xaml.cs
+++ b/YasGMP.Wpf/Shell/ModulesPane.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Shell;
+
+public partial class ModulesPane : UserControl
+{
+    public ModulesPane()
+    {
+        InitializeComponent();
+    }
+}

--- a/YasGMP.Wpf/ViewModels/InspectorPaneViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/InspectorPaneViewModel.cs
@@ -1,0 +1,49 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using YasGMP.Wpf.ViewModels.Modules;
+
+namespace YasGMP.Wpf.ViewModels;
+
+/// <summary>Inspector pane shown at the bottom of the shell displaying context details.</summary>
+public partial class InspectorPaneViewModel : AnchorableViewModel
+{
+    public InspectorPaneViewModel()
+    {
+        Title = "Inspector";
+        ContentId = "YasGmp.Shell.Inspector";
+        Fields = new ObservableCollection<InspectorFieldViewModel>();
+    }
+
+    [ObservableProperty]
+    private string _moduleTitle = "Module";
+
+    [ObservableProperty]
+    private string _recordTitle = "No record selected";
+
+    public ObservableCollection<InspectorFieldViewModel> Fields { get; }
+
+    public void Update(InspectorContext context)
+    {
+        ModuleTitle = context.ModuleTitle;
+        RecordTitle = context.RecordTitle;
+        Fields.Clear();
+        foreach (var field in context.Fields)
+        {
+            Fields.Add(new InspectorFieldViewModel(field.Label, field.Value));
+        }
+    }
+}
+
+public partial class InspectorFieldViewModel : ObservableObject
+{
+    public InspectorFieldViewModel(string label, string value)
+    {
+        Label = label;
+        Value = value;
+    }
+
+    public string Label { get; }
+
+    [ObservableProperty]
+    private string _value;
+}

--- a/YasGMP.Wpf/ViewModels/Modules/AdminModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/AdminModuleViewModel.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+public sealed class AdminModuleViewModel : DataDrivenModuleDocumentViewModel
+{
+    public const string ModuleKey = "Admin";
+
+    public AdminModuleViewModel(
+        DatabaseService databaseService,
+        ICflDialogService cflDialogService,
+        IShellInteractionService shellInteraction,
+        IModuleNavigationService navigation)
+        : base(ModuleKey, "Administration", databaseService, cflDialogService, shellInteraction, navigation)
+    {
+    }
+
+    protected override async Task<IReadOnlyList<ModuleRecord>> LoadAsync(object? parameter)
+    {
+        var settings = await Database.GetAllSettingsFullAsync().ConfigureAwait(false);
+        return settings.Select(ToRecord).ToList();
+    }
+
+    protected override IReadOnlyList<ModuleRecord> CreateDesignTimeRecords()
+        => new List<ModuleRecord>
+        {
+            new("CFG-001", "Default Locale", "locale", "Active", "System default locale",
+                new[]
+                {
+                    new InspectorField("Value", "hr-HR"),
+                    new InspectorField("Category", "System"),
+                    new InspectorField("Updated", System.DateTime.Now.AddDays(-2).ToString("g"))
+                },
+                null, null),
+            new("CFG-002", "Maintenance Window", "maintenance_window", "Active", "Weekly downtime",
+                new[]
+                {
+                    new InspectorField("Value", "Sundays 02:00-03:00"),
+                    new InspectorField("Category", "System"),
+                    new InspectorField("Updated", System.DateTime.Now.AddDays(-10).ToString("g"))
+                },
+                null, null)
+        };
+
+    private static ModuleRecord ToRecord(Setting setting)
+    {
+        var fields = new List<InspectorField>
+        {
+            new("Category", setting.Category ?? "-"),
+            new("Value", setting.Value ?? string.Empty),
+            new("Description", setting.Description ?? string.Empty),
+            new("Updated", setting.UpdatedAt?.ToString("g") ?? "-"),
+        };
+
+        return new ModuleRecord(
+            setting.Id.ToString(),
+            setting.Name ?? setting.Key ?? "Setting",
+            setting.Key,
+            "Active",
+            setting.Description,
+            fields,
+            null,
+            null);
+    }
+}

--- a/YasGMP.Wpf/ViewModels/Modules/AssetsModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/AssetsModuleViewModel.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+public sealed class AssetsModuleViewModel : DataDrivenModuleDocumentViewModel
+{
+    public const string ModuleKey = "Assets";
+
+    public AssetsModuleViewModel(
+        DatabaseService databaseService,
+        ICflDialogService cflDialogService,
+        IShellInteractionService shellInteraction,
+        IModuleNavigationService navigation)
+        : base(ModuleKey, "Assets", databaseService, cflDialogService, shellInteraction, navigation)
+    {
+    }
+
+    protected override async Task<IReadOnlyList<ModuleRecord>> LoadAsync(object? parameter)
+    {
+        var assets = await Database.GetAllAssetsFullAsync().ConfigureAwait(false);
+        return assets.Select(ToRecord).ToList();
+    }
+
+    protected override IReadOnlyList<ModuleRecord> CreateDesignTimeRecords()
+        => new List<ModuleRecord>
+        {
+            new("AST-001", "Autoclave", "AUTO-001", "Active", "Steam autoclave",
+                new[]
+                {
+                    new InspectorField("Location", "Building A - Cleanroom"),
+                    new InspectorField("Manufacturer", "Steris"),
+                    new InspectorField("Status", "Active")
+                },
+                WorkOrdersModuleViewModel.ModuleKey, 1001),
+            new("AST-002", "pH Meter", "LAB-PH-12", "Calibration Due", "Metrohm pH meter",
+                new[]
+                {
+                    new InspectorField("Location", "QC Lab"),
+                    new InspectorField("Manufacturer", "Metrohm"),
+                    new InspectorField("Status", "Calibration Due")
+                },
+                CalibrationModuleViewModel.ModuleKey, 502)
+        };
+
+    private static ModuleRecord ToRecord(Asset asset)
+    {
+        var fields = new List<InspectorField>
+        {
+            new("Location", asset.Location ?? "-"),
+            new("Model", asset.Model ?? "-"),
+            new("Manufacturer", asset.Manufacturer ?? "-"),
+            new("Status", asset.Status ?? "-"),
+            new("Installed", asset.InstallDate?.ToString("d", CultureInfo.CurrentCulture) ?? "-")
+        };
+
+        return new ModuleRecord(
+            asset.Id.ToString(CultureInfo.InvariantCulture),
+            asset.Name,
+            asset.Code,
+            asset.Status,
+            asset.Description,
+            fields,
+            WorkOrdersModuleViewModel.ModuleKey,
+            asset.Id);
+    }
+}

--- a/YasGMP.Wpf/ViewModels/Modules/AttachmentsModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/AttachmentsModuleViewModel.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+public sealed class AttachmentsModuleViewModel : DataDrivenModuleDocumentViewModel
+{
+    public const string ModuleKey = "Attachments";
+
+    public AttachmentsModuleViewModel(
+        DatabaseService databaseService,
+        ICflDialogService cflDialogService,
+        IShellInteractionService shellInteraction,
+        IModuleNavigationService navigation)
+        : base(ModuleKey, "Attachments", databaseService, cflDialogService, shellInteraction, navigation)
+    {
+    }
+
+    protected override async Task<IReadOnlyList<ModuleRecord>> LoadAsync(object? parameter)
+    {
+        var attachments = await Database.GetAttachmentsFilteredAsync(null, null, null).ConfigureAwait(false);
+        return attachments.Select(ToRecord).ToList();
+    }
+
+    protected override IReadOnlyList<ModuleRecord> CreateDesignTimeRecords()
+        => new List<ModuleRecord>
+        {
+            new("ATT-001", "Calibration Certificate", "certificate.pdf", "Approved", "Calibration PDF",
+                new[]
+                {
+                    new InspectorField("Table", "calibrations"),
+                    new InspectorField("Record", "100"),
+                    new InspectorField("Uploaded", System.DateTime.Now.AddDays(-3).ToString("g", CultureInfo.CurrentCulture))
+                },
+                CalibrationModuleViewModel.ModuleKey, 100),
+            new("ATT-002", "Work Order Photo", "photo.jpg", "Pending", "Machine photo",
+                new[]
+                {
+                    new InspectorField("Table", "work_orders"),
+                    new InspectorField("Record", "1001"),
+                    new InspectorField("Uploaded", System.DateTime.Now.AddDays(-1).ToString("g", CultureInfo.CurrentCulture))
+                },
+                WorkOrdersModuleViewModel.ModuleKey, 1001)
+        };
+
+    private static ModuleRecord ToRecord(Attachment attachment)
+    {
+        var moduleKey = attachment.EntityTable?.ToLowerInvariant() switch
+        {
+            "calibrations" => CalibrationModuleViewModel.ModuleKey,
+            "work_orders" => WorkOrdersModuleViewModel.ModuleKey,
+            "capa_cases" => QualityModuleViewModel.ModuleKey,
+            "users" => SecurityModuleViewModel.ModuleKey,
+            _ => null
+        };
+
+        var fields = new List<InspectorField>
+        {
+            new("Table", attachment.EntityTable ?? "-"),
+            new("Record", attachment.EntityId?.ToString(CultureInfo.InvariantCulture) ?? "-"),
+            new("File Type", attachment.FileType ?? "-"),
+            new("Created", attachment.CreatedAt.ToString("g", CultureInfo.CurrentCulture)),
+            new("Status", attachment.Status ?? "-"),
+        };
+
+        return new ModuleRecord(
+            attachment.Id.ToString(CultureInfo.InvariantCulture),
+            attachment.FileName,
+            attachment.FileName,
+            attachment.Status,
+            attachment.Description,
+            fields,
+            moduleKey,
+            attachment.EntityId);
+    }
+}

--- a/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+public sealed class AuditModuleViewModel : DataDrivenModuleDocumentViewModel
+{
+    public const string ModuleKey = "Audit";
+
+    public AuditModuleViewModel(
+        DatabaseService databaseService,
+        ICflDialogService cflDialogService,
+        IShellInteractionService shellInteraction,
+        IModuleNavigationService navigation)
+        : base(ModuleKey, "Audit Trail", databaseService, cflDialogService, shellInteraction, navigation)
+    {
+    }
+
+    protected override async Task<IReadOnlyList<ModuleRecord>> LoadAsync(object? parameter)
+    {
+        var events = await Database.GetRecentDashboardEventsAsync(100).ConfigureAwait(false);
+        return events.Select(ToRecord).ToList();
+    }
+
+    protected override IReadOnlyList<ModuleRecord> CreateDesignTimeRecords()
+        => new List<ModuleRecord>
+        {
+            new("AUD-001", "User login", "LOGIN_SUCCESS", "info", "User admin logged in",
+                new[]
+                {
+                    new InspectorField("User", "admin"),
+                    new InspectorField("Timestamp", System.DateTime.Now.AddMinutes(-5).ToString("g", CultureInfo.CurrentCulture)),
+                    new InspectorField("Module", "Security")
+                },
+                "Security", 1),
+            new("AUD-002", "Work order closed", "WO_CLOSE", "audit", "WO-1001 closed",
+                new[]
+                {
+                    new InspectorField("User", "tech"),
+                    new InspectorField("Timestamp", System.DateTime.Now.AddMinutes(-60).ToString("g", CultureInfo.CurrentCulture)),
+                    new InspectorField("Module", "WorkOrders")
+                },
+                "WorkOrders", 1001)
+        };
+
+    private static ModuleRecord ToRecord(DashboardEvent evt)
+    {
+        var fields = new List<InspectorField>
+        {
+            new("Timestamp", evt.Timestamp.ToString("g", CultureInfo.CurrentCulture)),
+            new("Severity", evt.Severity),
+            new("Table", evt.RelatedModule ?? "system"),
+            new("Record Id", evt.RelatedRecordId?.ToString(CultureInfo.InvariantCulture) ?? "-"),
+        };
+
+        return new ModuleRecord(
+            evt.Id.ToString(CultureInfo.InvariantCulture),
+            evt.EventType,
+            evt.EventType,
+            evt.Severity,
+            evt.Description,
+            fields,
+            evt.RelatedModule,
+            evt.RelatedRecordId);
+    }
+}

--- a/YasGMP.Wpf/ViewModels/Modules/CalibrationModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/CalibrationModuleViewModel.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+public sealed class CalibrationModuleViewModel : DataDrivenModuleDocumentViewModel
+{
+    public const string ModuleKey = "Calibration";
+
+    public CalibrationModuleViewModel(
+        DatabaseService databaseService,
+        ICflDialogService cflDialogService,
+        IShellInteractionService shellInteraction,
+        IModuleNavigationService navigation)
+        : base(ModuleKey, "Calibration", databaseService, cflDialogService, shellInteraction, navigation)
+    {
+    }
+
+    protected override async Task<IReadOnlyList<ModuleRecord>> LoadAsync(object? parameter)
+    {
+        var calibrations = await Database.GetAllCalibrationsAsync().ConfigureAwait(false);
+        return calibrations.Select(ToRecord).ToList();
+    }
+
+    protected override IReadOnlyList<ModuleRecord> CreateDesignTimeRecords()
+        => new List<ModuleRecord>
+        {
+            new("CAL-100", "pH Meter Calibration", "CAL-100", "Scheduled", "Annual calibration",
+                new[]
+                {
+                    new InspectorField("Asset", "pH Meter"),
+                    new InspectorField("Date", System.DateTime.Now.AddDays(-10).ToString("d", CultureInfo.CurrentCulture)),
+                    new InspectorField("Due", System.DateTime.Now.AddMonths(11).ToString("d", CultureInfo.CurrentCulture))
+                },
+                AssetsModuleViewModel.ModuleKey, 2),
+            new("CAL-200", "Balance Calibration", "CAL-200", "Completed", "Semi-annual calibration",
+                new[]
+                {
+                    new InspectorField("Asset", "Analytical Balance"),
+                    new InspectorField("Date", System.DateTime.Now.AddDays(-5).ToString("d", CultureInfo.CurrentCulture)),
+                    new InspectorField("Due", System.DateTime.Now.AddMonths(6).ToString("d", CultureInfo.CurrentCulture))
+                },
+                AssetsModuleViewModel.ModuleKey, 3)
+        };
+
+    private static ModuleRecord ToRecord(Calibration calibration)
+    {
+        var fields = new List<InspectorField>
+        {
+            new("Component Id", calibration.ComponentId.ToString(CultureInfo.InvariantCulture)),
+            new("Supplier Id", calibration.SupplierId?.ToString(CultureInfo.InvariantCulture) ?? "-"),
+            new("Calibration Date", calibration.CalibrationDate.ToString("d", CultureInfo.CurrentCulture)),
+            new("Next Due", calibration.NextDue.ToString("d", CultureInfo.CurrentCulture)),
+            new("Result", calibration.Result)
+        };
+
+        return new ModuleRecord(
+            calibration.Id.ToString(CultureInfo.InvariantCulture),
+            $"Calibration #{calibration.Id}",
+            calibration.CertDoc,
+            calibration.Status,
+            calibration.Comment,
+            fields,
+            AssetsModuleViewModel.ModuleKey,
+            calibration.ComponentId);
+    }
+}

--- a/YasGMP.Wpf/ViewModels/Modules/DashboardModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/DashboardModuleViewModel.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+public sealed class DashboardModuleViewModel : DataDrivenModuleDocumentViewModel
+{
+    public const string ModuleKey = "Dashboard";
+
+    public DashboardModuleViewModel(
+        DatabaseService databaseService,
+        ICflDialogService cflDialogService,
+        IShellInteractionService shellInteraction,
+        IModuleNavigationService navigation)
+        : base(ModuleKey, "Dashboard", databaseService, cflDialogService, shellInteraction, navigation)
+    {
+    }
+
+    protected override async Task<IReadOnlyList<ModuleRecord>> LoadAsync(object? parameter)
+    {
+        var events = await Database.GetRecentDashboardEventsAsync(25).ConfigureAwait(false);
+        return events.Select(ToRecord).ToList();
+    }
+
+    protected override IReadOnlyList<ModuleRecord> CreateDesignTimeRecords()
+    {
+        var now = DateTime.Now;
+        return new List<ModuleRecord>
+        {
+            new("evt-001", "Work order closed", "work_order_closed", "info", "Preventive maintenance completed",
+                new[]
+                {
+                    new InspectorField("Timestamp", now.ToString("g", CultureInfo.CurrentCulture)),
+                    new InspectorField("Module", "WorkOrders"),
+                    new InspectorField("Severity", "info")
+                },
+                "WorkOrders", 101),
+            new("evt-002", "CAPA escalated", "capa_escalated", "critical", "Deviation escalated to quality director",
+                new[]
+                {
+                    new InspectorField("Timestamp", now.AddMinutes(-42).ToString("g", CultureInfo.CurrentCulture)),
+                    new InspectorField("Module", "Quality"),
+                    new InspectorField("Severity", "critical")
+                },
+                "Quality", 55)
+        };
+    }
+
+    private static ModuleRecord ToRecord(DashboardEvent evt)
+    {
+        var fields = new List<InspectorField>
+        {
+            new("Timestamp", evt.Timestamp.ToString("g", CultureInfo.CurrentCulture)),
+            new("Severity", evt.Severity),
+            new("Module", evt.RelatedModule ?? "-"),
+            new("Record Id", evt.RelatedRecordId?.ToString(CultureInfo.InvariantCulture) ?? "-")
+        };
+
+        if (!string.IsNullOrWhiteSpace(evt.Note))
+        {
+            fields.Add(new InspectorField("Notes", evt.Note));
+        }
+
+        var title = string.IsNullOrWhiteSpace(evt.Description) ? evt.EventType : evt.Description!;
+        return new ModuleRecord(
+            evt.Id.ToString(CultureInfo.InvariantCulture),
+            title,
+            evt.EventType,
+            evt.Severity,
+            evt.Description,
+            fields,
+            evt.RelatedModule,
+            evt.RelatedRecordId);
+    }
+}

--- a/YasGMP.Wpf/ViewModels/Modules/DataDrivenModuleDocumentViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/DataDrivenModuleDocumentViewModel.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using YasGMP.Services;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+/// <summary>Base class for modules backed by <see cref="DatabaseService"/> queries.</summary>
+public abstract class DataDrivenModuleDocumentViewModel : ModuleDocumentViewModel
+{
+    protected DataDrivenModuleDocumentViewModel(
+        string key,
+        string title,
+        DatabaseService databaseService,
+        ICflDialogService cflDialogService,
+        IShellInteractionService shellInteraction,
+        IModuleNavigationService navigation)
+        : base(key, title, cflDialogService, shellInteraction, navigation)
+    {
+        Database = databaseService ?? throw new ArgumentNullException(nameof(databaseService));
+    }
+
+    protected DatabaseService Database { get; }
+
+    protected async Task<IReadOnlyList<ModuleRecord>> ExecuteSafeAsync<T>(
+        Func<DatabaseService, Task<IEnumerable<T>>> loader,
+        Func<IEnumerable<T>, IEnumerable<ModuleRecord>> projector)
+    {
+        try
+        {
+            var data = await loader(Database).ConfigureAwait(false);
+            return projector(data).ToList();
+        }
+        catch
+        {
+            throw;
+        }
+    }
+}

--- a/YasGMP.Wpf/ViewModels/Modules/FormMode.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/FormMode.cs
@@ -1,0 +1,19 @@
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+/// <summary>
+/// SAP Business One style form modes used by legacy cockpit modules.
+/// </summary>
+public enum FormMode
+{
+    /// <summary>Query/filter mode – toolbar actions operate on search criteria.</summary>
+    Find,
+
+    /// <summary>Allows inserting a new record.</summary>
+    Add,
+
+    /// <summary>Read-only view of the active record.</summary>
+    View,
+
+    /// <summary>Editing existing record values.</summary>
+    Update
+}

--- a/YasGMP.Wpf/ViewModels/Modules/InspectorContext.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/InspectorContext.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+/// <summary>
+/// Payload describing the currently selected record for the inspector pane.
+/// </summary>
+public sealed class InspectorContext
+{
+    public InspectorContext(string moduleTitle, string recordTitle, IReadOnlyList<InspectorField> fields)
+    {
+        ModuleTitle = moduleTitle;
+        RecordTitle = recordTitle;
+        Fields = fields;
+    }
+
+    public string ModuleTitle { get; }
+
+    public string RecordTitle { get; }
+
+    public IReadOnlyList<InspectorField> Fields { get; }
+}
+
+/// <summary>Single key/value row rendered inside the inspector pane.</summary>
+public sealed class InspectorField
+{
+    public InspectorField(string label, string? value)
+    {
+        Label = label;
+        Value = value ?? string.Empty;
+    }
+
+    public string Label { get; }
+
+    public string Value { get; }
+}

--- a/YasGMP.Wpf/ViewModels/Modules/ModuleDocumentViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/ModuleDocumentViewModel.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+/// <summary>Base class for domain-specific modules surfaced inside the WPF cockpit.</summary>
+public abstract class ModuleDocumentViewModel : B1FormDocumentViewModel
+{
+    protected ModuleDocumentViewModel(
+        string moduleKey,
+        string title,
+        ICflDialogService cflDialogService,
+        IShellInteractionService shellInteraction,
+        IModuleNavigationService navigation)
+        : base(moduleKey, title, cflDialogService, shellInteraction, navigation)
+    {
+    }
+
+    /// <summary>Called after the module has been opened or reactivated.</summary>
+    public new Task InitializeAsync(object? parameter = null)
+        => base.InitializeAsync(parameter);
+
+    /// <summary>
+    /// Helper used by derived classes to convert a list into a read-only payload.
+    /// </summary>
+    protected static IReadOnlyList<ModuleRecord> ToReadOnlyList(IEnumerable<ModuleRecord> source)
+        => source is IReadOnlyList<ModuleRecord> list ? list : source.ToList();
+}

--- a/YasGMP.Wpf/ViewModels/Modules/ModuleRecord.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/ModuleRecord.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+/// <summary>
+/// Canonical representation of a module list record surfaced in the WPF shell.
+/// </summary>
+public sealed class ModuleRecord
+{
+    public ModuleRecord(
+        string key,
+        string title,
+        string? code = null,
+        string? status = null,
+        string? description = null,
+        IReadOnlyList<InspectorField>? inspectorFields = null,
+        string? relatedModuleKey = null,
+        object? relatedParameter = null)
+    {
+        Key = key;
+        Title = title;
+        Code = code;
+        Status = status;
+        Description = description;
+        InspectorFields = inspectorFields ?? Array.Empty<InspectorField>();
+        RelatedModuleKey = relatedModuleKey;
+        RelatedParameter = relatedParameter;
+    }
+
+    /// <summary>Unique identifier for the record.</summary>
+    public string Key { get; }
+
+    /// <summary>Human readable title rendered in lists.</summary>
+    public string Title { get; }
+
+    /// <summary>Optional system code.</summary>
+    public string? Code { get; }
+
+    /// <summary>Optional workflow/status indicator.</summary>
+    public string? Status { get; }
+
+    /// <summary>Optional long-form description.</summary>
+    public string? Description { get; }
+
+    /// <summary>Inspector payload describing the record in more detail.</summary>
+    public IReadOnlyList<InspectorField> InspectorFields { get; }
+
+    /// <summary>Module key invoked by the golden arrow navigation.</summary>
+    public string? RelatedModuleKey { get; }
+
+    /// <summary>Optional payload forwarded to the related module when navigating.</summary>
+    public object? RelatedParameter { get; }
+}

--- a/YasGMP.Wpf/ViewModels/Modules/ModuleToolbarCommand.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/ModuleToolbarCommand.cs
@@ -1,0 +1,28 @@
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+/// <summary>
+/// Represents a toolbar command in the SAP B1 style command strip.
+/// </summary>
+public partial class ModuleToolbarCommand : ObservableObject
+{
+    public ModuleToolbarCommand(string caption, ICommand command)
+    {
+        Caption = caption;
+        Command = command;
+    }
+
+    /// <summary>Display text rendered in the toolbar.</summary>
+    public string Caption { get; }
+
+    /// <summary>Gets the command executed when the toolbar button is clicked.</summary>
+    public ICommand Command { get; }
+
+    [ObservableProperty]
+    private bool _isEnabled = true;
+
+    [ObservableProperty]
+    private bool _isChecked;
+}

--- a/YasGMP.Wpf/ViewModels/Modules/QualityModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/QualityModuleViewModel.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+public sealed class QualityModuleViewModel : DataDrivenModuleDocumentViewModel
+{
+    public const string ModuleKey = "Quality";
+
+    public QualityModuleViewModel(
+        DatabaseService databaseService,
+        ICflDialogService cflDialogService,
+        IShellInteractionService shellInteraction,
+        IModuleNavigationService navigation)
+        : base(ModuleKey, "Quality", databaseService, cflDialogService, shellInteraction, navigation)
+    {
+    }
+
+    protected override async Task<IReadOnlyList<ModuleRecord>> LoadAsync(object? parameter)
+    {
+        var capaCases = await Database.GetAllCapaCasesAsync().ConfigureAwait(false);
+        return capaCases.Select(ToRecord).ToList();
+    }
+
+    protected override IReadOnlyList<ModuleRecord> CreateDesignTimeRecords()
+        => new List<ModuleRecord>
+        {
+            new("CAPA-001", "Deviation CAPA", "CAPA-001", "Open", "CAPA for deviation 2024-01",
+                new[]
+                {
+                    new InspectorField("Priority", "High"),
+                    new InspectorField("Opened", System.DateTime.Now.AddDays(-15).ToString("d", CultureInfo.CurrentCulture)),
+                    new InspectorField("Assigned To", "QA Lead")
+                },
+                AuditModuleViewModel.ModuleKey, 10),
+            new("CAPA-002", "Audit Finding CAPA", "CAPA-002", "In Progress", "CAPA for external audit finding",
+                new[]
+                {
+                    new InspectorField("Priority", "Medium"),
+                    new InspectorField("Opened", System.DateTime.Now.AddDays(-30).ToString("d", CultureInfo.CurrentCulture)),
+                    new InspectorField("Assigned To", "Quality Manager")
+                },
+                AuditModuleViewModel.ModuleKey, 11)
+        };
+
+    private static ModuleRecord ToRecord(CapaCase capa)
+    {
+        var fields = new List<InspectorField>
+        {
+            new("Priority", string.IsNullOrWhiteSpace(capa.Priority) ? "-" : capa.Priority),
+            new("Status", capa.Status),
+            new("Opened", capa.OpenedAt.ToString("d", CultureInfo.CurrentCulture)),
+            new("Assigned To", capa.AssignedTo?.FullName ?? capa.AssignedTo?.Username ?? "-"),
+            new("Component", capa.ComponentId.ToString(CultureInfo.InvariantCulture))
+        };
+
+        return new ModuleRecord(
+            capa.Id.ToString(CultureInfo.InvariantCulture),
+            capa.Title,
+            capa.CapaCode,
+            capa.Status,
+            capa.Description,
+            fields,
+            AuditModuleViewModel.ModuleKey,
+            capa.Id);
+    }
+}

--- a/YasGMP.Wpf/ViewModels/Modules/SchedulingModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/SchedulingModuleViewModel.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+public sealed class SchedulingModuleViewModel : DataDrivenModuleDocumentViewModel
+{
+    public const string ModuleKey = "Scheduling";
+
+    public SchedulingModuleViewModel(
+        DatabaseService databaseService,
+        ICflDialogService cflDialogService,
+        IShellInteractionService shellInteraction,
+        IModuleNavigationService navigation)
+        : base(ModuleKey, "Scheduling", databaseService, cflDialogService, shellInteraction, navigation)
+    {
+    }
+
+    protected override async Task<IReadOnlyList<ModuleRecord>> LoadAsync(object? parameter)
+    {
+        var jobs = await Database.GetAllScheduledJobsFullAsync().ConfigureAwait(false);
+        return jobs.Select(ToRecord).ToList();
+    }
+
+    protected override IReadOnlyList<ModuleRecord> CreateDesignTimeRecords()
+        => new List<ModuleRecord>
+        {
+            new("JOB-001", "Weekly Work Order Digest", "JOB-001", "Active", "Send weekly summary",
+                new[]
+                {
+                    new InspectorField("Next Due", System.DateTime.Now.AddDays(1).ToString("g", CultureInfo.CurrentCulture)),
+                    new InspectorField("Recurrence", "0 8 * * MON"),
+                    new InspectorField("Entity", "WorkOrders")
+                },
+                WorkOrdersModuleViewModel.ModuleKey, null),
+            new("JOB-002", "Calibration Reminder", "JOB-002", "Paused", "Daily calibration reminder",
+                new[]
+                {
+                    new InspectorField("Next Due", System.DateTime.Now.AddHours(12).ToString("g", CultureInfo.CurrentCulture)),
+                    new InspectorField("Recurrence", "0 6 * * *"),
+                    new InspectorField("Entity", "Calibration")
+                },
+                CalibrationModuleViewModel.ModuleKey, null)
+        };
+
+    private static ModuleRecord ToRecord(ScheduledJob job)
+    {
+        var fields = new List<InspectorField>
+        {
+            new("Next Due", job.NextDue.ToString("g", CultureInfo.CurrentCulture)),
+            new("Recurrence", job.RecurrencePattern ?? "-"),
+            new("Status", job.Status ?? "-"),
+            new("Entity", job.EntityType ?? "-"),
+            new("Created By", job.CreatedBy ?? "-"),
+        };
+
+        return new ModuleRecord(
+            job.Id.ToString(CultureInfo.InvariantCulture),
+            job.Name,
+            job.Name,
+            job.Status,
+            job.Comment,
+            fields,
+            job.EntityType,
+            job.EntityId);
+    }
+}

--- a/YasGMP.Wpf/ViewModels/Modules/SecurityModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/SecurityModuleViewModel.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+public sealed class SecurityModuleViewModel : DataDrivenModuleDocumentViewModel
+{
+    public const string ModuleKey = "Security";
+
+    public SecurityModuleViewModel(
+        DatabaseService databaseService,
+        ICflDialogService cflDialogService,
+        IShellInteractionService shellInteraction,
+        IModuleNavigationService navigation)
+        : base(ModuleKey, "Security", databaseService, cflDialogService, shellInteraction, navigation)
+    {
+    }
+
+    protected override async Task<IReadOnlyList<ModuleRecord>> LoadAsync(object? parameter)
+    {
+        var users = await Database.GetAllUsersAsync().ConfigureAwait(false);
+        return users.Select(ToRecord).ToList();
+    }
+
+    protected override IReadOnlyList<ModuleRecord> CreateDesignTimeRecords()
+        => new List<ModuleRecord>
+        {
+            new("USR-001", "admin", "admin", "Active", "System administrator",
+                new[]
+                {
+                    new InspectorField("Role", "Administrator"),
+                    new InspectorField("Email", "admin@yasgmp.local"),
+                    new InspectorField("Phone", "+385 91 0000")
+                },
+                AdminModuleViewModel.ModuleKey, 1),
+            new("USR-002", "qa.lead", "qa.lead", "Active", "Quality manager",
+                new[]
+                {
+                    new InspectorField("Role", "Quality"),
+                    new InspectorField("Email", "qa@yasgmp.local"),
+                    new InspectorField("Phone", "+385 91 1111")
+                },
+                QualityModuleViewModel.ModuleKey, 2)
+        };
+
+    private static ModuleRecord ToRecord(User user)
+    {
+        var fields = new List<InspectorField>
+        {
+            new("Full Name", user.FullName),
+            new("Role", user.Role),
+            new("Email", user.Email),
+            new("Phone", user.Phone),
+            new("Active", user.Active ? "Yes" : "No")
+        };
+
+        return new ModuleRecord(
+            user.Id.ToString(CultureInfo.InvariantCulture),
+            user.Username,
+            user.Username,
+            user.Active ? "Active" : "Inactive",
+            user.DepartmentName,
+            fields,
+            AdminModuleViewModel.ModuleKey,
+            user.Id);
+    }
+}

--- a/YasGMP.Wpf/ViewModels/Modules/VendorsModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/VendorsModuleViewModel.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+public sealed class VendorsModuleViewModel : DataDrivenModuleDocumentViewModel
+{
+    public const string ModuleKey = "Vendors";
+
+    public VendorsModuleViewModel(
+        DatabaseService databaseService,
+        ICflDialogService cflDialogService,
+        IShellInteractionService shellInteraction,
+        IModuleNavigationService navigation)
+        : base(ModuleKey, "Vendors", databaseService, cflDialogService, shellInteraction, navigation)
+    {
+    }
+
+    protected override async Task<IReadOnlyList<ModuleRecord>> LoadAsync(object? parameter)
+    {
+        var suppliers = await Database.GetAllSuppliersAsync().ConfigureAwait(false);
+        return suppliers.Select(ToRecord).ToList();
+    }
+
+    protected override IReadOnlyList<ModuleRecord> CreateDesignTimeRecords()
+        => new List<ModuleRecord>
+        {
+            new("SUP-001", "Acme Calibration", "SUP-001", "Approved", "Calibration vendor",
+                new[]
+                {
+                    new InspectorField("Category", "Calibration"),
+                    new InspectorField("Phone", "+385 91 2222"),
+                    new InspectorField("Email", "support@acme-calibration.com")
+                },
+                CalibrationModuleViewModel.ModuleKey, null),
+            new("SUP-002", "Steris Service", "SUP-002", "Approved", "Maintenance vendor",
+                new[]
+                {
+                    new InspectorField("Category", "Maintenance"),
+                    new InspectorField("Phone", "+385 91 3333"),
+                    new InspectorField("Email", "service@steris.com")
+                },
+                WorkOrdersModuleViewModel.ModuleKey, null)
+        };
+
+    private static ModuleRecord ToRecord(Supplier supplier)
+    {
+        var fields = new List<InspectorField>
+        {
+            new("Category", supplier.Category ?? "-"),
+            new("Phone", supplier.Phone ?? "-"),
+            new("Email", supplier.Email ?? "-"),
+            new("Status", supplier.Status ?? "-"),
+            new("Rating", supplier.QualityRating?.ToString(CultureInfo.InvariantCulture) ?? "-"),
+        };
+
+        return new ModuleRecord(
+            supplier.Id.ToString(CultureInfo.InvariantCulture),
+            supplier.Name,
+            supplier.Code,
+            supplier.Status,
+            supplier.Description,
+            fields,
+            CalibrationModuleViewModel.ModuleKey,
+            supplier.Id);
+    }
+}

--- a/YasGMP.Wpf/ViewModels/Modules/WarehouseModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/WarehouseModuleViewModel.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+public sealed class WarehouseModuleViewModel : DataDrivenModuleDocumentViewModel
+{
+    public const string ModuleKey = "Warehouse";
+
+    public WarehouseModuleViewModel(
+        DatabaseService databaseService,
+        ICflDialogService cflDialogService,
+        IShellInteractionService shellInteraction,
+        IModuleNavigationService navigation)
+        : base(ModuleKey, "Warehouse", databaseService, cflDialogService, shellInteraction, navigation)
+    {
+    }
+
+    protected override async Task<IReadOnlyList<ModuleRecord>> LoadAsync(object? parameter)
+    {
+        var warehouses = await Database.GetWarehousesAsync().ConfigureAwait(false);
+        return warehouses.Select(ToRecord).ToList();
+    }
+
+    protected override IReadOnlyList<ModuleRecord> CreateDesignTimeRecords()
+        => new List<ModuleRecord>
+        {
+            new("WH-01", "Main Warehouse", "WH-01", "Qualified", "Primary GMP warehouse",
+                new[]
+                {
+                    new InspectorField("Location", "Building B"),
+                    new InspectorField("Responsible", "John Doe"),
+                    new InspectorField("Qualified", "Yes")
+                },
+                null, null),
+            new("WH-02", "Cold Storage", "WH-02", "Qualified", "2-8°C storage" ,
+                new[]
+                {
+                    new InspectorField("Location", "Building C"),
+                    new InspectorField("Responsible", "Jane Smith"),
+                    new InspectorField("Climate", "2-8°C")
+                },
+                null, null)
+        };
+
+    private static ModuleRecord ToRecord(Warehouse warehouse)
+    {
+        var fields = new List<InspectorField>
+        {
+            new("Location", warehouse.Location),
+            new("Responsible", warehouse.LegacyResponsibleName ?? warehouse.Responsible?.FullName ?? "-"),
+            new("Status", warehouse.Status ?? "-"),
+            new("Created", warehouse.CreatedAt.ToString("g", CultureInfo.CurrentCulture))
+        };
+
+        return new ModuleRecord(
+            warehouse.Id.ToString(CultureInfo.InvariantCulture),
+            warehouse.Name,
+            warehouse.Name,
+            warehouse.Status,
+            warehouse.Note,
+            fields,
+            null,
+            warehouse.Id);
+    }
+}

--- a/YasGMP.Wpf/ViewModels/Modules/WorkOrdersModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/WorkOrdersModuleViewModel.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+public sealed class WorkOrdersModuleViewModel : DataDrivenModuleDocumentViewModel
+{
+    public const string ModuleKey = "WorkOrders";
+
+    public WorkOrdersModuleViewModel(
+        DatabaseService databaseService,
+        ICflDialogService cflDialogService,
+        IShellInteractionService shellInteraction,
+        IModuleNavigationService navigation)
+        : base(ModuleKey, "Work Orders", databaseService, cflDialogService, shellInteraction, navigation)
+    {
+    }
+
+    protected override async Task<IReadOnlyList<ModuleRecord>> LoadAsync(object? parameter)
+    {
+        var workOrders = await Database.GetAllWorkOrdersFullAsync().ConfigureAwait(false);
+        return workOrders.Select(ToRecord).ToList();
+    }
+
+    protected override IReadOnlyList<ModuleRecord> CreateDesignTimeRecords()
+        => new List<ModuleRecord>
+        {
+            new("WO-1001", "Preventive maintenance - Autoclave", "WO-1001", "In Progress", "Monthly PM",
+                new[]
+                {
+                    new InspectorField("Assigned To", "Technician A"),
+                    new InspectorField("Priority", "High"),
+                    new InspectorField("Due", System.DateTime.Now.AddDays(2).ToString("d", CultureInfo.CurrentCulture))
+                },
+                AssetsModuleViewModel.ModuleKey, 1),
+            new("WO-1002", "Calibration - pH meter", "WO-1002", "Open", "Annual calibration",
+                new[]
+                {
+                    new InspectorField("Assigned To", "Technician B"),
+                    new InspectorField("Priority", "Medium"),
+                    new InspectorField("Due", System.DateTime.Now.AddDays(5).ToString("d", CultureInfo.CurrentCulture))
+                },
+                CalibrationModuleViewModel.ModuleKey, 2)
+        };
+
+    private static ModuleRecord ToRecord(WorkOrder workOrder)
+    {
+        var fields = new List<InspectorField>
+        {
+            new("Assigned To", workOrder.AssignedTo?.FullName ?? workOrder.AssignedTo?.Username ?? "-"),
+            new("Priority", workOrder.Priority),
+            new("Status", workOrder.Status),
+            new("Due Date", workOrder.DueDate?.ToString("d", CultureInfo.CurrentCulture) ?? "-"),
+            new("Machine", workOrder.Machine?.Name ?? workOrder.MachineId.ToString(CultureInfo.InvariantCulture))
+        };
+
+        return new ModuleRecord(
+            workOrder.Id.ToString(CultureInfo.InvariantCulture),
+            workOrder.Title,
+            workOrder.Title,
+            workOrder.Status,
+            workOrder.Description,
+            fields,
+            AssetsModuleViewModel.ModuleKey,
+            workOrder.MachineId);
+    }
+}

--- a/YasGMP.Wpf/ViewModels/ModulesPaneViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/ModulesPaneViewModel.cs
@@ -1,0 +1,86 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using YasGMP.Wpf.Services;
+using YasGMP.Wpf.ViewModels.Modules;
+
+namespace YasGMP.Wpf.ViewModels;
+
+/// <summary>Anchorable view-model that lists available cockpit modules.</summary>
+public partial class ModulesPaneViewModel : AnchorableViewModel
+{
+    private readonly IModuleRegistry _moduleRegistry;
+    private readonly IModuleNavigationService _navigationService;
+
+    public ModulesPaneViewModel(IModuleRegistry moduleRegistry, IModuleNavigationService navigationService)
+    {
+        _moduleRegistry = moduleRegistry;
+        _navigationService = navigationService;
+        Title = "Modules";
+        ContentId = "YasGmp.Shell.Modules";
+        Groups = new ObservableCollection<ModuleGroupViewModel>();
+        OpenModuleCommand = new RelayCommand<ModuleLinkViewModel>(OpenModule);
+        BuildGroups();
+    }
+
+    /// <summary>Top-level module groupings.</summary>
+    public ObservableCollection<ModuleGroupViewModel> Groups { get; }
+
+    /// <summary>Command triggered when the user double clicks a module entry.</summary>
+    public RelayCommand<ModuleLinkViewModel> OpenModuleCommand { get; }
+
+    private void BuildGroups()
+    {
+        Groups.Clear();
+        foreach (var category in _moduleRegistry.Modules.GroupBy(m => m.Category))
+        {
+            var group = new ModuleGroupViewModel(category.Key);
+            foreach (var metadata in category)
+            {
+                group.Modules.Add(new ModuleLinkViewModel(metadata, OpenModuleCommand));
+            }
+
+            Groups.Add(group);
+        }
+    }
+
+    private void OpenModule(ModuleLinkViewModel? link)
+    {
+        if (link is null)
+        {
+            return;
+        }
+
+        var document = _navigationService.OpenModule(link.Metadata.Key);
+        _navigationService.Activate(document);
+    }
+}
+
+/// <summary>Grouping of modules by category.</summary>
+public partial class ModuleGroupViewModel : ObservableObject
+{
+    public ModuleGroupViewModel(string name)
+    {
+        Name = name;
+        Modules = new ObservableCollection<ModuleLinkViewModel>();
+    }
+
+    public string Name { get; }
+
+    public ObservableCollection<ModuleLinkViewModel> Modules { get; }
+}
+
+/// <summary>Represents a single module entry in the pane.</summary>
+public partial class ModuleLinkViewModel : ObservableObject
+{
+    public ModuleLinkViewModel(ModuleMetadata metadata, RelayCommand<ModuleLinkViewModel> openCommand)
+    {
+        Metadata = metadata;
+        OpenCommand = openCommand;
+    }
+
+    public ModuleMetadata Metadata { get; }
+
+    public RelayCommand<ModuleLinkViewModel> OpenCommand { get; }
+}

--- a/YasGMP.Wpf/ViewModels/ShellStatusBarViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/ShellStatusBarViewModel.cs
@@ -1,0 +1,13 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace YasGMP.Wpf.ViewModels;
+
+/// <summary>Status bar view-model displayed along the bottom edge of the shell.</summary>
+public partial class ShellStatusBarViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string _statusText = "Ready";
+
+    [ObservableProperty]
+    private string _activeModule = string.Empty;
+}

--- a/YasGMP.Wpf/ViewModels/WindowMenuViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/WindowMenuViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
+using YasGMP.Wpf.ViewModels.Modules;
 
 namespace YasGMP.Wpf.ViewModels
 {
@@ -12,15 +13,18 @@ namespace YasGMP.Wpf.ViewModels
         public WindowMenuViewModel(MainWindowViewModel shell)
         {
             _shell = shell;
-            NewMachinesDocumentCommand = new RelayCommand(() => _shell.OpenMachinesDocument());
-            NavigateToMachinesCommand = new RelayCommand(_shell.NavigateToMachines);
+            OpenDashboardCommand = new RelayCommand(() => _shell.OpenModule(DashboardModuleViewModel.ModuleKey));
+            OpenAssetsCommand = new RelayCommand(() => _shell.OpenModule(AssetsModuleViewModel.ModuleKey));
+            OpenWorkOrdersCommand = new RelayCommand(() => _shell.OpenModule(WorkOrdersModuleViewModel.ModuleKey));
             SaveLayoutCommand = new AsyncRelayCommand(ExecuteSaveLayoutAsync);
             ResetLayoutCommand = new AsyncRelayCommand(ExecuteResetLayoutAsync);
         }
 
-        public IRelayCommand NewMachinesDocumentCommand { get; }
+        public IRelayCommand OpenDashboardCommand { get; }
 
-        public IRelayCommand NavigateToMachinesCommand { get; }
+        public IRelayCommand OpenAssetsCommand { get; }
+
+        public IRelayCommand OpenWorkOrdersCommand { get; }
 
         public IAsyncRelayCommand SaveLayoutCommand { get; }
 

--- a/YasGMP.Wpf/Views/AdminModuleView.xaml
+++ b/YasGMP.Wpf/Views/AdminModuleView.xaml
@@ -1,0 +1,58 @@
+<UserControl x:Class="YasGMP.Wpf.Views.AdminModuleView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:YasGMP.Wpf.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="400"
+             d:DesignWidth="600">
+    <DockPanel>
+        <ToolBar DockPanel.Dock="Top">
+            <ItemsControl ItemsSource="{Binding Toolbar}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <ToggleButton Content="{Binding Caption}"
+                                      Command="{Binding Command}"
+                                      IsChecked="{Binding IsChecked}"
+                                      Margin="0,0,4,0" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Separator />
+            <Button Content="CFL" Command="{Binding ShowCflCommand}" />
+            <controls:GoldenArrowButton Command="{Binding GoldenArrowCommand}" Margin="8,0,0,0" />
+        </ToolBar>
+        <Grid Margin="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <DockPanel Grid.Row="0" Margin="0,0,0,8">
+                <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0" />
+                <TextBox Width="220" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+            </DockPanel>
+            <DataGrid Grid.Row="1"
+                      ItemsSource="{Binding RecordsView}"
+                      SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True"
+                      CanUserAddRows="False"
+                      CanUserDeleteRows="False">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Code" Binding="{Binding Code}" Width="120" />
+                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="2*" />
+                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="140" />
+                    <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" FontStyle="Italic" Foreground="Gray" Margin="0,8,0,0" />
+        </Grid>
+    </DockPanel>
+</UserControl>

--- a/YasGMP.Wpf/Views/AdminModuleView.xaml.cs
+++ b/YasGMP.Wpf/Views/AdminModuleView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Views;
+
+public partial class AdminModuleView : UserControl
+{
+    public AdminModuleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YasGMP.Wpf/Views/AssetsModuleView.xaml
+++ b/YasGMP.Wpf/Views/AssetsModuleView.xaml
@@ -1,0 +1,58 @@
+<UserControl x:Class="YasGMP.Wpf.Views.AssetsModuleView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:YasGMP.Wpf.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="400"
+             d:DesignWidth="600">
+    <DockPanel>
+        <ToolBar DockPanel.Dock="Top">
+            <ItemsControl ItemsSource="{Binding Toolbar}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <ToggleButton Content="{Binding Caption}"
+                                      Command="{Binding Command}"
+                                      IsChecked="{Binding IsChecked}"
+                                      Margin="0,0,4,0" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Separator />
+            <Button Content="CFL" Command="{Binding ShowCflCommand}" />
+            <controls:GoldenArrowButton Command="{Binding GoldenArrowCommand}" Margin="8,0,0,0" />
+        </ToolBar>
+        <Grid Margin="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <DockPanel Grid.Row="0" Margin="0,0,0,8">
+                <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0" />
+                <TextBox Width="220" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+            </DockPanel>
+            <DataGrid Grid.Row="1"
+                      ItemsSource="{Binding RecordsView}"
+                      SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True"
+                      CanUserAddRows="False"
+                      CanUserDeleteRows="False">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Code" Binding="{Binding Code}" Width="120" />
+                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="2*" />
+                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="140" />
+                    <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" FontStyle="Italic" Foreground="Gray" Margin="0,8,0,0" />
+        </Grid>
+    </DockPanel>
+</UserControl>

--- a/YasGMP.Wpf/Views/AssetsModuleView.xaml.cs
+++ b/YasGMP.Wpf/Views/AssetsModuleView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Views;
+
+public partial class AssetsModuleView : UserControl
+{
+    public AssetsModuleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YasGMP.Wpf/Views/AttachmentsModuleView.xaml
+++ b/YasGMP.Wpf/Views/AttachmentsModuleView.xaml
@@ -1,0 +1,58 @@
+<UserControl x:Class="YasGMP.Wpf.Views.AttachmentsModuleView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:YasGMP.Wpf.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="400"
+             d:DesignWidth="600">
+    <DockPanel>
+        <ToolBar DockPanel.Dock="Top">
+            <ItemsControl ItemsSource="{Binding Toolbar}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <ToggleButton Content="{Binding Caption}"
+                                      Command="{Binding Command}"
+                                      IsChecked="{Binding IsChecked}"
+                                      Margin="0,0,4,0" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Separator />
+            <Button Content="CFL" Command="{Binding ShowCflCommand}" />
+            <controls:GoldenArrowButton Command="{Binding GoldenArrowCommand}" Margin="8,0,0,0" />
+        </ToolBar>
+        <Grid Margin="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <DockPanel Grid.Row="0" Margin="0,0,0,8">
+                <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0" />
+                <TextBox Width="220" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+            </DockPanel>
+            <DataGrid Grid.Row="1"
+                      ItemsSource="{Binding RecordsView}"
+                      SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True"
+                      CanUserAddRows="False"
+                      CanUserDeleteRows="False">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Code" Binding="{Binding Code}" Width="120" />
+                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="2*" />
+                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="140" />
+                    <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" FontStyle="Italic" Foreground="Gray" Margin="0,8,0,0" />
+        </Grid>
+    </DockPanel>
+</UserControl>

--- a/YasGMP.Wpf/Views/AttachmentsModuleView.xaml.cs
+++ b/YasGMP.Wpf/Views/AttachmentsModuleView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Views;
+
+public partial class AttachmentsModuleView : UserControl
+{
+    public AttachmentsModuleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YasGMP.Wpf/Views/AuditModuleView.xaml
+++ b/YasGMP.Wpf/Views/AuditModuleView.xaml
@@ -1,0 +1,58 @@
+<UserControl x:Class="YasGMP.Wpf.Views.AuditModuleView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:YasGMP.Wpf.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="400"
+             d:DesignWidth="600">
+    <DockPanel>
+        <ToolBar DockPanel.Dock="Top">
+            <ItemsControl ItemsSource="{Binding Toolbar}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <ToggleButton Content="{Binding Caption}"
+                                      Command="{Binding Command}"
+                                      IsChecked="{Binding IsChecked}"
+                                      Margin="0,0,4,0" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Separator />
+            <Button Content="CFL" Command="{Binding ShowCflCommand}" />
+            <controls:GoldenArrowButton Command="{Binding GoldenArrowCommand}" Margin="8,0,0,0" />
+        </ToolBar>
+        <Grid Margin="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <DockPanel Grid.Row="0" Margin="0,0,0,8">
+                <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0" />
+                <TextBox Width="220" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+            </DockPanel>
+            <DataGrid Grid.Row="1"
+                      ItemsSource="{Binding RecordsView}"
+                      SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True"
+                      CanUserAddRows="False"
+                      CanUserDeleteRows="False">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Code" Binding="{Binding Code}" Width="120" />
+                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="2*" />
+                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="140" />
+                    <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" FontStyle="Italic" Foreground="Gray" Margin="0,8,0,0" />
+        </Grid>
+    </DockPanel>
+</UserControl>

--- a/YasGMP.Wpf/Views/AuditModuleView.xaml.cs
+++ b/YasGMP.Wpf/Views/AuditModuleView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Views;
+
+public partial class AuditModuleView : UserControl
+{
+    public AuditModuleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YasGMP.Wpf/Views/CalibrationModuleView.xaml
+++ b/YasGMP.Wpf/Views/CalibrationModuleView.xaml
@@ -1,0 +1,58 @@
+<UserControl x:Class="YasGMP.Wpf.Views.CalibrationModuleView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:YasGMP.Wpf.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="400"
+             d:DesignWidth="600">
+    <DockPanel>
+        <ToolBar DockPanel.Dock="Top">
+            <ItemsControl ItemsSource="{Binding Toolbar}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <ToggleButton Content="{Binding Caption}"
+                                      Command="{Binding Command}"
+                                      IsChecked="{Binding IsChecked}"
+                                      Margin="0,0,4,0" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Separator />
+            <Button Content="CFL" Command="{Binding ShowCflCommand}" />
+            <controls:GoldenArrowButton Command="{Binding GoldenArrowCommand}" Margin="8,0,0,0" />
+        </ToolBar>
+        <Grid Margin="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <DockPanel Grid.Row="0" Margin="0,0,0,8">
+                <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0" />
+                <TextBox Width="220" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+            </DockPanel>
+            <DataGrid Grid.Row="1"
+                      ItemsSource="{Binding RecordsView}"
+                      SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True"
+                      CanUserAddRows="False"
+                      CanUserDeleteRows="False">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Code" Binding="{Binding Code}" Width="120" />
+                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="2*" />
+                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="140" />
+                    <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" FontStyle="Italic" Foreground="Gray" Margin="0,8,0,0" />
+        </Grid>
+    </DockPanel>
+</UserControl>

--- a/YasGMP.Wpf/Views/CalibrationModuleView.xaml.cs
+++ b/YasGMP.Wpf/Views/CalibrationModuleView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Views;
+
+public partial class CalibrationModuleView : UserControl
+{
+    public CalibrationModuleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YasGMP.Wpf/Views/DashboardModuleView.xaml
+++ b/YasGMP.Wpf/Views/DashboardModuleView.xaml
@@ -1,0 +1,58 @@
+<UserControl x:Class="YasGMP.Wpf.Views.DashboardModuleView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:YasGMP.Wpf.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="400"
+             d:DesignWidth="600">
+    <DockPanel>
+        <ToolBar DockPanel.Dock="Top">
+            <ItemsControl ItemsSource="{Binding Toolbar}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <ToggleButton Content="{Binding Caption}"
+                                      Command="{Binding Command}"
+                                      IsChecked="{Binding IsChecked}"
+                                      Margin="0,0,4,0" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Separator />
+            <Button Content="CFL" Command="{Binding ShowCflCommand}" />
+            <controls:GoldenArrowButton Command="{Binding GoldenArrowCommand}" Margin="8,0,0,0" />
+        </ToolBar>
+        <Grid Margin="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <DockPanel Grid.Row="0" Margin="0,0,0,8">
+                <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0" />
+                <TextBox Width="220" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+            </DockPanel>
+            <DataGrid Grid.Row="1"
+                      ItemsSource="{Binding RecordsView}"
+                      SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True"
+                      CanUserAddRows="False"
+                      CanUserDeleteRows="False">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Code" Binding="{Binding Code}" Width="120" />
+                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="2*" />
+                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="140" />
+                    <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" FontStyle="Italic" Foreground="Gray" Margin="0,8,0,0" />
+        </Grid>
+    </DockPanel>
+</UserControl>

--- a/YasGMP.Wpf/Views/DashboardModuleView.xaml.cs
+++ b/YasGMP.Wpf/Views/DashboardModuleView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Views;
+
+public partial class DashboardModuleView : UserControl
+{
+    public DashboardModuleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YasGMP.Wpf/Views/QualityModuleView.xaml
+++ b/YasGMP.Wpf/Views/QualityModuleView.xaml
@@ -1,0 +1,58 @@
+<UserControl x:Class="YasGMP.Wpf.Views.QualityModuleView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:YasGMP.Wpf.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="400"
+             d:DesignWidth="600">
+    <DockPanel>
+        <ToolBar DockPanel.Dock="Top">
+            <ItemsControl ItemsSource="{Binding Toolbar}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <ToggleButton Content="{Binding Caption}"
+                                      Command="{Binding Command}"
+                                      IsChecked="{Binding IsChecked}"
+                                      Margin="0,0,4,0" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Separator />
+            <Button Content="CFL" Command="{Binding ShowCflCommand}" />
+            <controls:GoldenArrowButton Command="{Binding GoldenArrowCommand}" Margin="8,0,0,0" />
+        </ToolBar>
+        <Grid Margin="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <DockPanel Grid.Row="0" Margin="0,0,0,8">
+                <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0" />
+                <TextBox Width="220" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+            </DockPanel>
+            <DataGrid Grid.Row="1"
+                      ItemsSource="{Binding RecordsView}"
+                      SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True"
+                      CanUserAddRows="False"
+                      CanUserDeleteRows="False">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Code" Binding="{Binding Code}" Width="120" />
+                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="2*" />
+                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="140" />
+                    <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" FontStyle="Italic" Foreground="Gray" Margin="0,8,0,0" />
+        </Grid>
+    </DockPanel>
+</UserControl>

--- a/YasGMP.Wpf/Views/QualityModuleView.xaml.cs
+++ b/YasGMP.Wpf/Views/QualityModuleView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Views;
+
+public partial class QualityModuleView : UserControl
+{
+    public QualityModuleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YasGMP.Wpf/Views/SchedulingModuleView.xaml
+++ b/YasGMP.Wpf/Views/SchedulingModuleView.xaml
@@ -1,0 +1,58 @@
+<UserControl x:Class="YasGMP.Wpf.Views.SchedulingModuleView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:YasGMP.Wpf.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="400"
+             d:DesignWidth="600">
+    <DockPanel>
+        <ToolBar DockPanel.Dock="Top">
+            <ItemsControl ItemsSource="{Binding Toolbar}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <ToggleButton Content="{Binding Caption}"
+                                      Command="{Binding Command}"
+                                      IsChecked="{Binding IsChecked}"
+                                      Margin="0,0,4,0" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Separator />
+            <Button Content="CFL" Command="{Binding ShowCflCommand}" />
+            <controls:GoldenArrowButton Command="{Binding GoldenArrowCommand}" Margin="8,0,0,0" />
+        </ToolBar>
+        <Grid Margin="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <DockPanel Grid.Row="0" Margin="0,0,0,8">
+                <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0" />
+                <TextBox Width="220" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+            </DockPanel>
+            <DataGrid Grid.Row="1"
+                      ItemsSource="{Binding RecordsView}"
+                      SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True"
+                      CanUserAddRows="False"
+                      CanUserDeleteRows="False">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Code" Binding="{Binding Code}" Width="120" />
+                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="2*" />
+                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="140" />
+                    <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" FontStyle="Italic" Foreground="Gray" Margin="0,8,0,0" />
+        </Grid>
+    </DockPanel>
+</UserControl>

--- a/YasGMP.Wpf/Views/SchedulingModuleView.xaml.cs
+++ b/YasGMP.Wpf/Views/SchedulingModuleView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Views;
+
+public partial class SchedulingModuleView : UserControl
+{
+    public SchedulingModuleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YasGMP.Wpf/Views/SecurityModuleView.xaml
+++ b/YasGMP.Wpf/Views/SecurityModuleView.xaml
@@ -1,0 +1,58 @@
+<UserControl x:Class="YasGMP.Wpf.Views.SecurityModuleView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:YasGMP.Wpf.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="400"
+             d:DesignWidth="600">
+    <DockPanel>
+        <ToolBar DockPanel.Dock="Top">
+            <ItemsControl ItemsSource="{Binding Toolbar}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <ToggleButton Content="{Binding Caption}"
+                                      Command="{Binding Command}"
+                                      IsChecked="{Binding IsChecked}"
+                                      Margin="0,0,4,0" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Separator />
+            <Button Content="CFL" Command="{Binding ShowCflCommand}" />
+            <controls:GoldenArrowButton Command="{Binding GoldenArrowCommand}" Margin="8,0,0,0" />
+        </ToolBar>
+        <Grid Margin="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <DockPanel Grid.Row="0" Margin="0,0,0,8">
+                <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0" />
+                <TextBox Width="220" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+            </DockPanel>
+            <DataGrid Grid.Row="1"
+                      ItemsSource="{Binding RecordsView}"
+                      SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True"
+                      CanUserAddRows="False"
+                      CanUserDeleteRows="False">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Code" Binding="{Binding Code}" Width="120" />
+                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="2*" />
+                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="140" />
+                    <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" FontStyle="Italic" Foreground="Gray" Margin="0,8,0,0" />
+        </Grid>
+    </DockPanel>
+</UserControl>

--- a/YasGMP.Wpf/Views/SecurityModuleView.xaml.cs
+++ b/YasGMP.Wpf/Views/SecurityModuleView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Views;
+
+public partial class SecurityModuleView : UserControl
+{
+    public SecurityModuleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YasGMP.Wpf/Views/VendorsModuleView.xaml
+++ b/YasGMP.Wpf/Views/VendorsModuleView.xaml
@@ -1,0 +1,58 @@
+<UserControl x:Class="YasGMP.Wpf.Views.VendorsModuleView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:YasGMP.Wpf.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="400"
+             d:DesignWidth="600">
+    <DockPanel>
+        <ToolBar DockPanel.Dock="Top">
+            <ItemsControl ItemsSource="{Binding Toolbar}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <ToggleButton Content="{Binding Caption}"
+                                      Command="{Binding Command}"
+                                      IsChecked="{Binding IsChecked}"
+                                      Margin="0,0,4,0" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Separator />
+            <Button Content="CFL" Command="{Binding ShowCflCommand}" />
+            <controls:GoldenArrowButton Command="{Binding GoldenArrowCommand}" Margin="8,0,0,0" />
+        </ToolBar>
+        <Grid Margin="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <DockPanel Grid.Row="0" Margin="0,0,0,8">
+                <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0" />
+                <TextBox Width="220" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+            </DockPanel>
+            <DataGrid Grid.Row="1"
+                      ItemsSource="{Binding RecordsView}"
+                      SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True"
+                      CanUserAddRows="False"
+                      CanUserDeleteRows="False">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Code" Binding="{Binding Code}" Width="120" />
+                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="2*" />
+                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="140" />
+                    <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" FontStyle="Italic" Foreground="Gray" Margin="0,8,0,0" />
+        </Grid>
+    </DockPanel>
+</UserControl>

--- a/YasGMP.Wpf/Views/VendorsModuleView.xaml.cs
+++ b/YasGMP.Wpf/Views/VendorsModuleView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Views;
+
+public partial class VendorsModuleView : UserControl
+{
+    public VendorsModuleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YasGMP.Wpf/Views/WarehouseModuleView.xaml
+++ b/YasGMP.Wpf/Views/WarehouseModuleView.xaml
@@ -1,0 +1,58 @@
+<UserControl x:Class="YasGMP.Wpf.Views.WarehouseModuleView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:YasGMP.Wpf.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="400"
+             d:DesignWidth="600">
+    <DockPanel>
+        <ToolBar DockPanel.Dock="Top">
+            <ItemsControl ItemsSource="{Binding Toolbar}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <ToggleButton Content="{Binding Caption}"
+                                      Command="{Binding Command}"
+                                      IsChecked="{Binding IsChecked}"
+                                      Margin="0,0,4,0" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Separator />
+            <Button Content="CFL" Command="{Binding ShowCflCommand}" />
+            <controls:GoldenArrowButton Command="{Binding GoldenArrowCommand}" Margin="8,0,0,0" />
+        </ToolBar>
+        <Grid Margin="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <DockPanel Grid.Row="0" Margin="0,0,0,8">
+                <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0" />
+                <TextBox Width="220" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+            </DockPanel>
+            <DataGrid Grid.Row="1"
+                      ItemsSource="{Binding RecordsView}"
+                      SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True"
+                      CanUserAddRows="False"
+                      CanUserDeleteRows="False">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Code" Binding="{Binding Code}" Width="120" />
+                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="2*" />
+                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="140" />
+                    <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" FontStyle="Italic" Foreground="Gray" Margin="0,8,0,0" />
+        </Grid>
+    </DockPanel>
+</UserControl>

--- a/YasGMP.Wpf/Views/WarehouseModuleView.xaml.cs
+++ b/YasGMP.Wpf/Views/WarehouseModuleView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Views;
+
+public partial class WarehouseModuleView : UserControl
+{
+    public WarehouseModuleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YasGMP.Wpf/Views/WorkOrdersModuleView.xaml
+++ b/YasGMP.Wpf/Views/WorkOrdersModuleView.xaml
@@ -1,0 +1,58 @@
+<UserControl x:Class="YasGMP.Wpf.Views.WorkOrdersModuleView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:YasGMP.Wpf.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="400"
+             d:DesignWidth="600">
+    <DockPanel>
+        <ToolBar DockPanel.Dock="Top">
+            <ItemsControl ItemsSource="{Binding Toolbar}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <ToggleButton Content="{Binding Caption}"
+                                      Command="{Binding Command}"
+                                      IsChecked="{Binding IsChecked}"
+                                      Margin="0,0,4,0" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Separator />
+            <Button Content="CFL" Command="{Binding ShowCflCommand}" />
+            <controls:GoldenArrowButton Command="{Binding GoldenArrowCommand}" Margin="8,0,0,0" />
+        </ToolBar>
+        <Grid Margin="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <DockPanel Grid.Row="0" Margin="0,0,0,8">
+                <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0" />
+                <TextBox Width="220" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+            </DockPanel>
+            <DataGrid Grid.Row="1"
+                      ItemsSource="{Binding RecordsView}"
+                      SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True"
+                      CanUserAddRows="False"
+                      CanUserDeleteRows="False">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Code" Binding="{Binding Code}" Width="120" />
+                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="2*" />
+                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="140" />
+                    <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" FontStyle="Italic" Foreground="Gray" Margin="0,8,0,0" />
+        </Grid>
+    </DockPanel>
+</UserControl>

--- a/YasGMP.Wpf/Views/WorkOrdersModuleView.xaml.cs
+++ b/YasGMP.Wpf/Views/WorkOrdersModuleView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Views;
+
+public partial class WorkOrdersModuleView : UserControl
+{
+    public WorkOrdersModuleView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
- add AvalonDock-aware modules and inspector panes plus status bar and golden-arrow controls for the WPF shell
- introduce module registry, shell interaction services, and B1-style document base classes with module view models and views backed by DatabaseService data
- wire up CFL dialog infrastructure and update the main window/layout bootstrapping to use the new module documents

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3942d07cc8331a0e7dadd673dc03a