### PR TITLE
Dock inspector pane alongside documents

### DIFF
--- a/YasGMP.Wpf/MainWindow.xaml
+++ b/YasGMP.Wpf/MainWindow.xaml
@@ -95,9 +95,9 @@
                                                           ContentId="YasGmp.Shell.Modules"
                                                           Content="{Binding ModulesPane}" />
                             </adLayout:LayoutAnchorablePane>
-                            <adLayout:LayoutPanel Orientation="Vertical">
+                            <adLayout:LayoutPanel Orientation="Horizontal">
                                 <adLayout:LayoutDocumentPane />
-                                <adLayout:LayoutAnchorablePane DockHeight="220">
+                                <adLayout:LayoutAnchorablePane DockWidth="320">
                                     <adLayout:LayoutAnchorable Title="Inspector"
                                                               ContentId="YasGmp.Shell.Inspector"
                                                               Content="{Binding InspectorPane}" />

--- a/YasGMP.Wpf/ViewModels/MainWindowViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/MainWindowViewModel.cs
@@ -41,7 +41,7 @@ public partial class MainWindowViewModel : ObservableObject
     /// <summary>Left-hand navigation pane listing modules.</summary>
     public ModulesPaneViewModel ModulesPane { get; }
 
-    /// <summary>Inspector pane rendered along the bottom of the shell.</summary>
+    /// <summary>Inspector pane rendered along the right side of the shell.</summary>
     public InspectorPaneViewModel InspectorPane { get; }
 
     /// <summary>Status bar data context.</summary>


### PR DESCRIPTION
## Summary
- change the shell layout so the document pane and inspector sit side by side with the inspector docked to a fixed width
- update the inspector pane documentation comment to describe its new right-hand placement

## Testing
- dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a7385240833187eea59a36b04c0d