### PR TITLE
Abstract MAUI dependencies from shared viewmodels

### DIFF
--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -183,6 +183,10 @@ namespace YasGMP
 
                 // Core Services
                 services.AddSingleton<IPlatformService, MauiPlatformService>();
+                services.AddSingleton<IUiDispatcher, MauiUiDispatcher>();
+                services.AddSingleton<IDialogService, MauiDialogService>();
+                services.AddSingleton<IFilePicker, MauiFilePicker>();
+                services.AddSingleton<IUserSession, MauiUserSession>();
                 services.AddSingleton<AuditService>();
                 services.AddSingleton<AuthService>();
                 services.AddSingleton<IAuthContext>(sp => sp.GetRequiredService<AuthService>());

--- a/Services/Platform/MauiFilePicker.cs
+++ b/Services/Platform/MauiFilePicker.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Storage;
+using YasGMP.Services;
+
+namespace YasGMP.Services.Platform
+{
+    /// <summary>MAUI wrapper for the built-in <see cref="FilePicker"/>.</summary>
+    public sealed class MauiFilePicker : IFilePicker
+    {
+        public async Task<IReadOnlyList<PickedFile>> PickFilesAsync(FilePickerRequest request, CancellationToken cancellationToken = default)
+        {
+            request ??= new FilePickerRequest();
+
+            var options = new PickOptions
+            {
+                PickerTitle = request.Title
+            };
+
+            if (request.FileTypes != null)
+            {
+                var fileType = ConvertFileTypes(request.FileTypes);
+                if (fileType != null)
+                    options.FileTypes = fileType;
+            }
+
+            if (request.AllowMultiple)
+            {
+                var results = await FilePicker.Default.PickMultipleAsync(options, cancellationToken).ConfigureAwait(false);
+                return results?.Select(ToPickedFile).ToList() ?? Array.Empty<PickedFile>();
+            }
+            else
+            {
+                var result = await FilePicker.Default.PickAsync(options, cancellationToken).ConfigureAwait(false);
+                if (result == null)
+                    return Array.Empty<PickedFile>();
+
+                return new[] { ToPickedFile(result) };
+            }
+        }
+
+        private static PickedFile ToPickedFile(FileResult result)
+        {
+            return new PickedFile(
+                result.FileName,
+                result.ContentType ?? "application/octet-stream",
+                () => result.OpenReadAsync(),
+                result.FileInfo?.Length);
+        }
+
+        private static FilePickerFileType? ConvertFileTypes(IReadOnlyDictionary<string, string[]> fileTypes)
+        {
+            if (fileTypes.Count == 0)
+                return null;
+
+            var map = new Dictionary<DevicePlatform, IEnumerable<string>>();
+
+            foreach (var pair in fileTypes)
+            {
+                if (Enum.TryParse<DevicePlatform>(pair.Key, true, out var platform))
+                {
+                    map[platform] = pair.Value;
+                }
+            }
+
+            return map.Count == 0 ? null : new FilePickerFileType(map);
+        }
+    }
+}

--- a/Services/Platform/MauiUiDispatcher.cs
+++ b/Services/Platform/MauiUiDispatcher.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.ApplicationModel;
+using YasGMP.Services;
+
+namespace YasGMP.Services.Platform
+{
+    /// <summary>MAUI implementation of <see cref="IUiDispatcher"/> backed by <see cref="MainThread"/>.</summary>
+    public sealed class MauiUiDispatcher : IUiDispatcher
+    {
+        public bool IsDispatchRequired => !MainThread.IsMainThread;
+
+        public Task InvokeAsync(Action action) => MainThread.InvokeOnMainThreadAsync(action);
+
+        public Task<T> InvokeAsync<T>(Func<T> func) => MainThread.InvokeOnMainThreadAsync(func);
+
+        public Task InvokeAsync(Func<Task> asyncAction) => MainThread.InvokeOnMainThreadAsync(asyncAction);
+
+        public void BeginInvoke(Action action) => MainThread.BeginInvokeOnMainThread(action);
+    }
+}

--- a/Services/Platform/MauiUserSession.cs
+++ b/Services/Platform/MauiUserSession.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.Maui.Controls;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Services.Interfaces;
+
+namespace YasGMP.Services.Platform
+{
+    /// <summary>Bridges MAUI application session state with <see cref="IUserSession"/>.</summary>
+    public sealed class MauiUserSession : IUserSession
+    {
+        private readonly IAuthContext _authContext;
+
+        public MauiUserSession(IAuthContext authContext)
+        {
+            _authContext = authContext ?? throw new ArgumentNullException(nameof(authContext));
+        }
+
+        private static App? TryGetApp() => Application.Current as App;
+
+        public User? CurrentUser => _authContext.CurrentUser ?? TryGetApp()?.LoggedUser;
+
+        public int? UserId => CurrentUser?.Id;
+
+        public string? Username => CurrentUser?.Username;
+
+        public string? FullName => CurrentUser?.FullName ?? CurrentUser?.Username;
+
+        public string SessionId => _authContext.CurrentSessionId ?? TryGetApp()?.SessionId ?? string.Empty;
+    }
+}

--- a/ViewModels/CalibrationEditDialogViewModel.cs
+++ b/ViewModels/CalibrationEditDialogViewModel.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using System.Windows.Input;
-using Microsoft.Maui.Controls;
 using YasGMP.Common;
 using YasGMP.Models;
 using YasGMP.Services;
@@ -12,65 +12,76 @@ using YasGMP.Services;
 namespace YasGMP.ViewModels
 {
     /// <summary>
-    /// <b>CalibrationEditDialogViewModel</b> – ViewModel for adding/editing calibrations
-    /// with rich validation, audit metadata, and dialog completion callbacks.
-    /// Designed for GMP/Annex 11/21 CFR Part 11 compliant flows.
+    /// View-model for adding or editing calibrations. Performs validation and populates audit metadata.
     /// </summary>
-    public class CalibrationEditDialogViewModel : INotifyPropertyChanged
+    public sealed class CalibrationEditDialogViewModel : INotifyPropertyChanged
     {
-        /// <summary>
-        /// Initializes a new instance of <see cref="CalibrationEditDialogViewModel"/>.
-        /// </summary>
-        /// <param name="calibration">The calibration to edit/add (required).</param>
-        /// <param name="components">All available components (nullable allowed; replaced by empty list).</param>
-        /// <param name="suppliers">All available suppliers (nullable allowed; replaced by empty list).</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="calibration"/> is null.</exception>
-        public CalibrationEditDialogViewModel(
-            Calibration calibration,
-            List<MachineComponent>? components,
-            List<Supplier>? suppliers)
-        {
-            Calibration = calibration ?? throw new ArgumentNullException(nameof(calibration));
-            Components  = components ?? new List<MachineComponent>();
-            Suppliers   = suppliers  ?? new List<Supplier>();
-
-            // Preselect, tolerating "no match" (null).
-            _selectedComponent = Components.FirstOrDefault(c => c.Id == Calibration.ComponentId);
-            _selectedSupplier  = Suppliers.FirstOrDefault(s => s.Id == Calibration.SupplierId);
-
-            // Ensure we always have a signature string.
-            Calibration.DigitalSignature = string.IsNullOrWhiteSpace(Calibration.DigitalSignature)
-                ? (((App?)Application.Current)?.LoggedUser?.FullName ?? "Nepoznat korisnik")
-                : Calibration.DigitalSignature;
-
-            SaveCommand   = new Command(OnSave);
-            CancelCommand = new Command(OnCancel);
-        }
-
-        #region === Bindable Model & Lookups ===
-
-        /// <summary>
-        /// Gets or sets the <see cref="Calibration"/> entity being edited.
-        /// Never null after construction.
-        /// </summary>
-        public Calibration Calibration { get; set; }
-
-        /// <summary>
-        /// Gets the list of all available machine components for the picker binding.
-        /// </summary>
-        public List<MachineComponent> Components { get; }
-
-        /// <summary>
-        /// Gets the list of all available suppliers for the picker binding.
-        /// </summary>
-        public List<Supplier> Suppliers { get; }
+        private readonly IDialogService _dialogService;
+        private readonly IUserSession _userSession;
+        private readonly IPlatformService _platformService;
 
         private MachineComponent? _selectedComponent;
-        /// <summary>
-        /// Gets or sets the currently selected machine component in the dialog.
-        /// Nullable to allow the UI to represent "no selection".
-        /// Updates <see cref="Calibration.ComponentId"/> when set.
-        /// </summary>
+        private Supplier? _selectedSupplier;
+
+        public Calibration Calibration { get; }
+        public List<MachineComponent> Components { get; }
+        public List<Supplier> Suppliers { get; }
+
+        public ICommand SaveCommand { get; }
+        public ICommand CancelCommand { get; }
+
+        public event Action<bool, Calibration?>? DialogResult;
+
+        public CalibrationEditDialogViewModel()
+            : this(
+                  new Calibration(),
+                  new List<MachineComponent>(),
+                  new List<Supplier>(),
+                  ServiceLocator.GetRequiredService<IUserSession>(),
+                  ServiceLocator.GetRequiredService<IDialogService>(),
+                  ServiceLocator.GetRequiredService<IPlatformService>())
+        {
+        }
+
+        public CalibrationEditDialogViewModel(
+            Calibration calibration,
+            List<MachineComponent> components,
+            List<Supplier> suppliers)
+            : this(
+                  calibration,
+                  components,
+                  suppliers,
+                  ServiceLocator.GetRequiredService<IUserSession>(),
+                  ServiceLocator.GetRequiredService<IDialogService>(),
+                  ServiceLocator.GetRequiredService<IPlatformService>())
+        {
+        }
+
+        public CalibrationEditDialogViewModel(
+            Calibration calibration,
+            List<MachineComponent> components,
+            List<Supplier> suppliers,
+            IUserSession userSession,
+            IDialogService dialogService,
+            IPlatformService platformService)
+        {
+            Calibration = calibration ?? throw new ArgumentNullException(nameof(calibration));
+            Components = components ?? new List<MachineComponent>();
+            Suppliers = suppliers ?? new List<Supplier>();
+            _userSession = userSession ?? throw new ArgumentNullException(nameof(userSession));
+            _dialogService = dialogService ?? throw new ArgumentNullException(nameof(dialogService));
+            _platformService = platformService ?? throw new ArgumentNullException(nameof(platformService));
+
+            _selectedComponent = Components.FirstOrDefault(c => c.Id == Calibration.ComponentId);
+            _selectedSupplier = Suppliers.FirstOrDefault(s => s.Id == Calibration.SupplierId);
+
+            if (string.IsNullOrWhiteSpace(Calibration.DigitalSignature))
+                Calibration.DigitalSignature = ResolveSignature();
+
+            SaveCommand = new AsyncDelegateCommand(OnSaveAsync);
+            CancelCommand = new DelegateCommand(OnCancel);
+        }
+
         public MachineComponent? SelectedComponent
         {
             get => _selectedComponent;
@@ -79,18 +90,12 @@ namespace YasGMP.ViewModels
                 if (!ReferenceEquals(_selectedComponent, value))
                 {
                     _selectedComponent = value;
-                    Calibration.ComponentId = value?.Id ?? 0; // keep 0-as-unset pattern used elsewhere
+                    Calibration.ComponentId = value?.Id ?? 0;
                     OnPropertyChanged();
                 }
             }
         }
 
-        private Supplier? _selectedSupplier;
-        /// <summary>
-        /// Gets or sets the currently selected supplier in the dialog.
-        /// Nullable to allow the UI to represent "no selection".
-        /// Updates <see cref="Calibration.SupplierId"/> when set.
-        /// </summary>
         public Supplier? SelectedSupplier
         {
             get => _selectedSupplier;
@@ -99,111 +104,65 @@ namespace YasGMP.ViewModels
                 if (!ReferenceEquals(_selectedSupplier, value))
                 {
                     _selectedSupplier = value;
-                    Calibration.SupplierId = value?.Id ?? 0; // keep 0-as-unset pattern used elsewhere
+                    Calibration.SupplierId = value?.Id ?? 0;
                     OnPropertyChanged();
                 }
             }
         }
 
-        #endregion
+        public event PropertyChangedEventHandler? PropertyChanged;
 
-        #region === Commands & Dialog Result ===
-
-        /// <summary>Gets the command that validates and saves the calibration.</summary>
-        public ICommand SaveCommand { get; }
-
-        /// <summary>Gets the command that cancels the dialog without saving.</summary>
-        public ICommand CancelCommand { get; }
-
-        /// <summary>
-        /// Raised when the dialog completes.
-        /// <list type="bullet">
-        /// <item><description><c>bool</c> — <c>true</c> if saved, <c>false</c> if cancelled.</description></item>
-        /// <item><description><see cref="Calibration"/> — the saved entity; <c>null</c> when cancelled.</description></item>
-        /// </list>
-        /// </summary>
-        public event Action<bool, Calibration?>? DialogResult;
-
-        #endregion
-
-        #region === Save / Cancel ===
-
-        /// <summary>
-        /// Performs full validation, sets audit metadata, and completes the dialog on save.
-        /// All UI dialogs are invoked through <see cref="SafeNavigator"/> to guarantee UI-thread execution,
-        /// preventing WinUI <c>COMException 0x8001010E</c>.
-        /// </summary>
-        private async void OnSave()
+        private async Task OnSaveAsync()
         {
-            // Sanitize string fields (trim, limit length where appropriate).
             Calibration.CertDoc = (Calibration.CertDoc ?? string.Empty).Trim();
-            Calibration.Result  = (Calibration.Result  ?? string.Empty).Trim();
+            Calibration.Result = (Calibration.Result ?? string.Empty).Trim();
             Calibration.Comment = (Calibration.Comment ?? string.Empty).Trim();
-
-            // --- Validation ---
 
             if (Calibration.ComponentId <= 0)
             {
-                await SafeNavigator.ShowAlertAsync("Greška", "Odaberite komponentu.", "U redu");
+                await _dialogService.ShowAlertAsync("Greška", "Odaberite komponentu.", "U redu").ConfigureAwait(false);
                 return;
             }
 
             if (Calibration.SupplierId <= 0)
             {
-                await SafeNavigator.ShowAlertAsync("Greška", "Odaberite servisera ili laboratorij.", "U redu");
+                await _dialogService.ShowAlertAsync("Greška", "Odaberite servisera ili laboratorij.", "U redu").ConfigureAwait(false);
                 return;
             }
 
             if (Calibration.CalibrationDate == default)
             {
-                await SafeNavigator.ShowAlertAsync("Greška", "Unesite datum kalibracije.", "U redu");
+                await _dialogService.ShowAlertAsync("Greška", "Unesite datum kalibracije.", "U redu").ConfigureAwait(false);
                 return;
             }
 
             if (Calibration.NextDue <= Calibration.CalibrationDate)
             {
-                var proceed = await SafeNavigator.ConfirmAsync(
-                    "Upozorenje",
-                    "Rok sljedeće kalibracije je isti ili prije datuma kalibracije. Želite li nastaviti?",
-                    "Da", "Ne");
+                var proceed = await _dialogService
+                    .ShowConfirmationAsync("Upozorenje", "Rok sljedeće kalibracije je isti ili prije datuma kalibracije. Želite li nastaviti?", "Da", "Ne")
+                    .ConfigureAwait(false);
                 if (!proceed) return;
             }
 
             if (Calibration.CertDoc.Length > 128)
             {
-                await SafeNavigator.ShowAlertAsync("Greška", "Broj certifikata je predugačak (max 128 znakova).", "U redu");
+                await _dialogService.ShowAlertAsync("Greška", "Broj certifikata je predugačak (max 128 znakova).", "U redu").ConfigureAwait(false);
                 return;
             }
 
-            // --- Audit / metadata ---
-            Calibration.LastModified     = DateTime.Now;
-            Calibration.LastModifiedById = (((App?)Application.Current)?.LoggedUser?.Id) ?? 0;
-            Calibration.SourceIp         = ServiceLocator.GetService<IPlatformService>()?.GetLocalIpAddress() ?? string.Empty;
-            Calibration.DigitalSignature = (((App?)Application.Current)?.LoggedUser?.FullName) ?? "Nepoznat korisnik";
+            Calibration.LastModified = DateTime.Now;
+            Calibration.LastModifiedById = _userSession.UserId ?? 0;
+            Calibration.SourceIp = _platformService.GetLocalIpAddress();
+            Calibration.DigitalSignature = ResolveSignature();
 
-            // Complete dialog (success).
             DialogResult?.Invoke(true, Calibration);
         }
 
-        /// <summary>
-        /// Cancels the dialog and notifies the parent.
-        /// </summary>
         private void OnCancel() => DialogResult?.Invoke(false, null);
 
-        #endregion
+        private string ResolveSignature() => _userSession.FullName ?? _userSession.Username ?? "Nepoznat korisnik";
 
-        #region === INotifyPropertyChanged ===
-
-        /// <inheritdoc />
-        public event PropertyChangedEventHandler? PropertyChanged;
-
-        /// <summary>
-        /// Raises <see cref="PropertyChanged"/> for data binding updates.
-        /// </summary>
-        /// <param name="name">The name of the changed property (optional due to <see cref="CallerMemberNameAttribute"/>).</param>
-        protected void OnPropertyChanged([CallerMemberName] string? name = null) =>
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
-
-        #endregion
+        private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName ?? string.Empty));
     }
 }

--- a/ViewModels/MachineViewModel.cs
+++ b/ViewModels/MachineViewModel.cs
@@ -7,7 +7,6 @@ using System.Windows.Input;
 using System.Linq;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.Maui.Storage;
 using CommunityToolkit.Mvvm.Input;
 using YasGMP.Models;
 using YasGMP.Services;
@@ -33,6 +32,7 @@ namespace YasGMP.ViewModels
         private readonly AuthService _authService = null!;
         private readonly CodeGeneratorService _codeService = null!;
         private readonly QRCodeService _qrService = null!;
+        private readonly IPlatformService _platformService = null!;
 
         private ObservableCollection<Machine> _machines = new();
         private ObservableCollection<Machine> _filteredMachines = new();
@@ -60,12 +60,14 @@ namespace YasGMP.ViewModels
             DatabaseService dbService,
             AuthService authService,
             CodeGeneratorService codeService,
-            QRCodeService qrService)
+            QRCodeService qrService,
+            IPlatformService platformService)
         {
             _dbService   = dbService   ?? throw new ArgumentNullException(nameof(dbService));
             _authService = authService ?? throw new ArgumentNullException(nameof(authService));
             _codeService = codeService ?? throw new ArgumentNullException(nameof(codeService));
             _qrService   = qrService   ?? throw new ArgumentNullException(nameof(qrService));
+            _platformService = platformService ?? throw new ArgumentNullException(nameof(platformService));
 
             _currentSessionId = _authService.CurrentSessionId  ?? string.Empty;
             _currentDeviceInfo = _authService.CurrentDeviceInfo ?? string.Empty;
@@ -369,7 +371,7 @@ namespace YasGMP.ViewModels
             if (string.IsNullOrWhiteSpace(machine.QrCode))
             {
                 using var stream = _qrService.GeneratePng(machine.Code);
-                var dir = FileSystem.AppDataDirectory;
+                var dir = _platformService.GetAppDataDirectory();
                 Directory.CreateDirectory(dir);
                 var path = Path.Combine(dir, $"{machine.Code}.png");
                 using var fs = File.Create(path);

--- a/YasGMP.AppCore/Common/DelegateCommand.cs
+++ b/YasGMP.AppCore/Common/DelegateCommand.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace YasGMP.Common
+{
+    /// <summary>
+    /// Basic <see cref="ICommand"/> implementation that executes the provided delegates.
+    /// </summary>
+    public sealed class DelegateCommand : ICommand
+    {
+        private readonly Action _execute;
+        private readonly Func<bool>? _canExecute;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DelegateCommand"/> class.
+        /// </summary>
+        public DelegateCommand(Action execute, Func<bool>? canExecute = null)
+        {
+            _execute    = execute    ?? throw new ArgumentNullException(nameof(execute));
+            _canExecute = canExecute;
+        }
+
+        /// <inheritdoc />
+        public bool CanExecute(object? parameter) => _canExecute?.Invoke() ?? true;
+
+        /// <inheritdoc />
+        public void Execute(object? parameter) => _execute();
+
+        /// <inheritdoc />
+        public event EventHandler? CanExecuteChanged;
+
+        /// <summary>Signals that <see cref="CanExecute(object?)"/> should be re-evaluated.</summary>
+        public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Async-friendly command implementation that prevents concurrent execution.
+    /// </summary>
+    public sealed class AsyncDelegateCommand : ICommand
+    {
+        private readonly Func<Task> _executeAsync;
+        private readonly Func<bool>? _canExecute;
+        private bool _isExecuting;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncDelegateCommand"/> class.
+        /// </summary>
+        public AsyncDelegateCommand(Func<Task> executeAsync, Func<bool>? canExecute = null)
+        {
+            _executeAsync = executeAsync ?? throw new ArgumentNullException(nameof(executeAsync));
+            _canExecute   = canExecute;
+        }
+
+        /// <inheritdoc />
+        public bool CanExecute(object? parameter)
+        {
+            if (_isExecuting)
+                return false;
+
+            return _canExecute?.Invoke() ?? true;
+        }
+
+        /// <inheritdoc />
+        public async void Execute(object? parameter)
+        {
+            if (!CanExecute(parameter))
+                return;
+
+            _isExecuting = true;
+            RaiseCanExecuteChanged();
+
+            try
+            {
+                await _executeAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _isExecuting = false;
+                RaiseCanExecuteChanged();
+            }
+        }
+
+        /// <inheritdoc />
+        public event EventHandler? CanExecuteChanged;
+
+        /// <summary>Signals that <see cref="CanExecute(object?)"/> should be re-evaluated.</summary>
+        public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/YasGMP.AppCore/Services/CalibrationDialogRequest.cs
+++ b/YasGMP.AppCore/Services/CalibrationDialogRequest.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using YasGMP.Models;
+
+namespace YasGMP.Services
+{
+    /// <summary>
+    /// Payload passed to <see cref="IDialogService"/> when opening the calibration editor.
+    /// </summary>
+    public sealed class CalibrationDialogRequest
+    {
+        public CalibrationDialogRequest(Calibration calibration, IReadOnlyList<MachineComponent> components, IReadOnlyList<Supplier> suppliers)
+        {
+            Calibration = calibration;
+            Components = components;
+            Suppliers = suppliers;
+        }
+
+        public Calibration Calibration { get; }
+
+        public IReadOnlyList<MachineComponent> Components { get; }
+
+        public IReadOnlyList<Supplier> Suppliers { get; }
+    }
+}

--- a/YasGMP.AppCore/Services/CapaDialogRequest.cs
+++ b/YasGMP.AppCore/Services/CapaDialogRequest.cs
@@ -1,0 +1,17 @@
+using YasGMP.Models;
+
+namespace YasGMP.Services
+{
+    /// <summary>
+    /// Payload for CAPA editor dialogs.
+    /// </summary>
+    public sealed class CapaDialogRequest
+    {
+        public CapaDialogRequest(CapaCase? capaCase)
+        {
+            CapaCase = capaCase;
+        }
+
+        public CapaCase? CapaCase { get; }
+    }
+}

--- a/YasGMP.AppCore/Services/DialogIds.cs
+++ b/YasGMP.AppCore/Services/DialogIds.cs
@@ -1,0 +1,11 @@
+namespace YasGMP.Services
+{
+    /// <summary>
+    /// Well-known dialog identifiers used by <see cref="IDialogService"/>.
+    /// </summary>
+    public static class DialogIds
+    {
+        public const string CapaEdit = "dialogs.capa.edit";
+        public const string CalibrationEdit = "dialogs.calibration.edit";
+    }
+}

--- a/YasGMP.AppCore/Services/IDialogService.cs
+++ b/YasGMP.AppCore/Services/IDialogService.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace YasGMP.Services
+{
+    /// <summary>
+    /// Platform-agnostic dialog helpers for alerts, confirmations and modal editors.
+    /// </summary>
+    public interface IDialogService
+    {
+        Task ShowAlertAsync(string title, string message, string cancel);
+
+        Task<bool> ShowConfirmationAsync(string title, string message, string accept, string cancel);
+
+        Task<string?> ShowActionSheetAsync(string title, string cancel, string? destruction, params string[] buttons);
+
+        Task<T?> ShowDialogAsync<T>(string dialogId, object? parameter = null, CancellationToken cancellationToken = default);
+    }
+}

--- a/YasGMP.AppCore/Services/IFilePicker.cs
+++ b/YasGMP.AppCore/Services/IFilePicker.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace YasGMP.Services
+{
+    /// <summary>
+    /// Cross-platform abstraction for picking files from the local device.
+    /// </summary>
+    public interface IFilePicker
+    {
+        Task<IReadOnlyList<PickedFile>> PickFilesAsync(FilePickerRequest request, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>Parameters that control the file picking UI.</summary>
+    public sealed record FilePickerRequest(bool AllowMultiple = false, IReadOnlyDictionary<string, string[]>? FileTypes = null, string? Title = null);
+
+    /// <summary>Represents a user-picked file.</summary>
+    public sealed record PickedFile(string FileName, string ContentType, Func<Task<Stream>> OpenReadAsync, long? FileSize = null);
+}

--- a/YasGMP.AppCore/Services/IUiDispatcher.cs
+++ b/YasGMP.AppCore/Services/IUiDispatcher.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+
+namespace YasGMP.Services
+{
+    /// <summary>
+    /// Abstraction for marshaling work onto the UI thread.
+    /// </summary>
+    public interface IUiDispatcher
+    {
+        /// <summary>Gets a value indicating whether the current thread differs from the UI thread.</summary>
+        bool IsDispatchRequired { get; }
+
+        /// <summary>Synchronously schedules <paramref name="action"/> on the UI thread.</summary>
+        Task InvokeAsync(Action action);
+
+        /// <summary>Executes the provided function on the UI thread and returns its result.</summary>
+        Task<T> InvokeAsync<T>(Func<T> func);
+
+        /// <summary>Executes the asynchronous delegate on the UI thread.</summary>
+        Task InvokeAsync(Func<Task> asyncAction);
+
+        /// <summary>Queues an action to the UI thread without awaiting completion.</summary>
+        void BeginInvoke(Action action);
+    }
+}

--- a/YasGMP.AppCore/Services/IUserSession.cs
+++ b/YasGMP.AppCore/Services/IUserSession.cs
@@ -1,0 +1,25 @@
+using YasGMP.Models;
+
+namespace YasGMP.Services
+{
+    /// <summary>
+    /// Exposes information about the interactive user session for UI-facing components.
+    /// </summary>
+    public interface IUserSession
+    {
+        /// <summary>Currently authenticated user, if available.</summary>
+        User? CurrentUser { get; }
+
+        /// <summary>Convenience accessor for the current user's identifier.</summary>
+        int? UserId { get; }
+
+        /// <summary>Convenience accessor for the username/login.</summary>
+        string? Username { get; }
+
+        /// <summary>Convenience accessor for the display name (full name preferred).</summary>
+        string? FullName { get; }
+
+        /// <summary>Opaque identifier for the logical session (shared with audit logging).</summary>
+        string SessionId { get; }
+    }
+}

--- a/YasGMP.Wpf/App.xaml.cs
+++ b/YasGMP.Wpf/App.xaml.cs
@@ -46,6 +46,9 @@ namespace YasGMP.Wpf
                         svc.AddSingleton<IUserSession, UserSession>();
                         svc.AddSingleton<IPlatformService, WpfPlatformService>();
                         svc.AddSingleton<IAuthContext, WpfAuthContext>();
+                        svc.AddSingleton<IUiDispatcher, WpfUiDispatcher>();
+                        svc.AddSingleton<IDialogService, WpfDialogService>();
+                        svc.AddSingleton<IFilePicker, WpfFilePicker>();
                         svc.AddSingleton<ICflDialogService, CflDialogService>();
                         svc.AddSingleton<ShellInteractionService>();
                         svc.AddSingleton<IModuleNavigationService>(sp => sp.GetRequiredService<ShellInteractionService>());

--- a/YasGMP.Wpf/Services/DockLayoutPersistenceService.cs
+++ b/YasGMP.Wpf/Services/DockLayoutPersistenceService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using MySqlConnector;
+using YasGMP.Services;
 
 namespace YasGMP.Wpf.Services
 {

--- a/YasGMP.Wpf/Services/UserSession.cs
+++ b/YasGMP.Wpf/Services/UserSession.cs
@@ -1,24 +1,28 @@
+using System;
 using Microsoft.Extensions.Configuration;
+using YasGMP.Models;
+using YasGMP.Services;
 
 namespace YasGMP.Wpf.Services
 {
-    /// <summary>Lightweight user context used for per-user layout persistence.</summary>
-    public interface IUserSession
-    {
-        int UserId { get; }
-        string Username { get; }
-    }
-
+    /// <summary>Simple WPF shell user session implementing the shared <see cref="IUserSession"/> contract.</summary>
     public sealed class UserSession : IUserSession
     {
         public UserSession(IConfiguration configuration)
         {
             UserId = configuration.GetValue<int?>("Shell:UserId") ?? 1;
             Username = configuration["Shell:Username"] ?? "wpf-shell";
+            SessionId = Guid.NewGuid().ToString("N");
         }
 
-        public int UserId { get; }
+        public User? CurrentUser => null;
 
-        public string Username { get; }
+        public int? UserId { get; }
+
+        public string? Username { get; }
+
+        public string? FullName => Username;
+
+        public string SessionId { get; }
     }
 }

--- a/YasGMP.Wpf/Services/WpfDialogService.cs
+++ b/YasGMP.Wpf/Services/WpfDialogService.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using YasGMP.Services;
+
+namespace YasGMP.Wpf.Services
+{
+    /// <summary>Minimal WPF dialog service using <see cref="MessageBox"/>.</summary>
+    public sealed class WpfDialogService : IDialogService
+    {
+        public Task ShowAlertAsync(string title, string message, string cancel)
+        {
+            MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Information);
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> ShowConfirmationAsync(string title, string message, string accept, string cancel)
+        {
+            var result = MessageBox.Show(message, title, MessageBoxButton.YesNo, MessageBoxImage.Question);
+            return Task.FromResult(result == MessageBoxResult.Yes);
+        }
+
+        public Task<string?> ShowActionSheetAsync(string title, string cancel, string? destruction, params string[] buttons)
+        {
+            // Not supported in the WPF shell; return null.
+            return Task.FromResult<string?>(null);
+        }
+
+        public Task<T?> ShowDialogAsync<T>(string dialogId, object? parameter = null, CancellationToken cancellationToken = default)
+        {
+            // The WPF shell uses dedicated modules for editing; modal dialogs are not yet implemented.
+            throw new NotSupportedException($"Dialog '{dialogId}' is not available in the WPF shell.");
+        }
+    }
+}

--- a/YasGMP.Wpf/Services/WpfFilePicker.cs
+++ b/YasGMP.Wpf/Services/WpfFilePicker.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Win32;
+using YasGMP.Services;
+
+namespace YasGMP.Wpf.Services
+{
+    /// <summary>WPF implementation of <see cref="IFilePicker"/> using <see cref="OpenFileDialog"/>.</summary>
+    public sealed class WpfFilePicker : IFilePicker
+    {
+        public Task<IReadOnlyList<PickedFile>> PickFilesAsync(FilePickerRequest request, CancellationToken cancellationToken = default)
+        {
+            request ??= new FilePickerRequest();
+
+            var dialog = new OpenFileDialog
+            {
+                Multiselect = request.AllowMultiple,
+                Title = request.Title
+            };
+
+            if (request.FileTypes != null && request.FileTypes.TryGetValue("Windows", out var patterns))
+            {
+                dialog.Filter = string.Join("|", patterns);
+            }
+
+            var result = dialog.ShowDialog();
+            if (result != true)
+            {
+                return Task.FromResult<IReadOnlyList<PickedFile>>(new List<PickedFile>());
+            }
+
+            var files = new List<PickedFile>();
+            foreach (var file in dialog.FileNames)
+            {
+                var info = new FileInfo(file);
+                files.Add(new PickedFile(
+                    info.Name,
+                    "application/octet-stream",
+                    () => Task.FromResult<Stream>(File.OpenRead(file)),
+                    info.Exists ? info.Length : null));
+            }
+
+            return Task.FromResult<IReadOnlyList<PickedFile>>(files);
+        }
+    }
+}

--- a/YasGMP.Wpf/Services/WpfUiDispatcher.cs
+++ b/YasGMP.Wpf/Services/WpfUiDispatcher.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Threading;
+using YasGMP.Services;
+
+namespace YasGMP.Wpf.Services
+{
+    /// <summary>WPF implementation of <see cref="IUiDispatcher"/> backed by the application dispatcher.</summary>
+    public sealed class WpfUiDispatcher : IUiDispatcher
+    {
+        private static Dispatcher CurrentDispatcher => Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
+
+        public bool IsDispatchRequired => !CurrentDispatcher.CheckAccess();
+
+        public Task InvokeAsync(Action action)
+        {
+            if (!IsDispatchRequired)
+            {
+                action();
+                return Task.CompletedTask;
+            }
+
+            return CurrentDispatcher.InvokeAsync(action).Task;
+        }
+
+        public Task<T> InvokeAsync<T>(Func<T> func)
+        {
+            if (!IsDispatchRequired)
+                return Task.FromResult(func());
+
+            return CurrentDispatcher.InvokeAsync(func).Task;
+        }
+
+        public async Task InvokeAsync(Func<Task> asyncAction)
+        {
+            if (!IsDispatchRequired)
+            {
+                await asyncAction().ConfigureAwait(false);
+                return;
+            }
+
+            await CurrentDispatcher.InvokeAsync(asyncAction).Task.Unwrap().ConfigureAwait(false);
+        }
+
+        public void BeginInvoke(Action action)
+        {
+            CurrentDispatcher.BeginInvoke(action);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add shared `IUserSession`, `IUiDispatcher`, `IDialogService`, and `IFilePicker` abstractions with MAUI and WPF implementations
- refactor CAPA and calibration view-models (and dialogs) to use new services via constructor injection and shared command helpers
- register the new services in both heads and route machine QR generation through the platform storage service

## Testing
- `dotnet build` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c1661d8c833187f8d0cb065399aa