### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.AppCore/Services/ExternalServicerService.cs
+++ b/YasGMP.AppCore/Services/ExternalServicerService.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using MySqlConnector;
 using YasGMP.Models;
 
 namespace YasGMP.Services
@@ -36,19 +34,7 @@ namespace YasGMP.Services
         /// <summary>Returns the external servicer by ID or <c>null</c> when not found.</summary>
         public async Task<ExternalServicer?> TryGetByIdAsync(int id, CancellationToken token = default)
         {
-            const string sql = @"SELECT
-    id, name, code, registration_number, contact_person, email, phone, address,
-    type, status, cooperation_start, cooperation_end, comment, digital_signature, note
-FROM external_contractors WHERE id=@id LIMIT 1";
-
-            var table = await _db.ExecuteSelectAsync(sql, new[] { new MySqlParameter("@id", id) }, token)
-                .ConfigureAwait(false);
-            if (table.Rows.Count == 0)
-            {
-                return null;
-            }
-
-            return MapToServicer(table.Rows[0]);
+            return await _db.GetExternalServicerByIdAsync(id, token).ConfigureAwait(false);
         }
 
         public async Task<int> CreateAsync(ExternalServicer servicer, int actorUserId, CancellationToken token = default)
@@ -108,31 +94,5 @@ FROM external_contractors WHERE id=@id LIMIT 1";
                 ExtraNotes = contractor.Note
             };
 
-        private static ExternalServicer MapToServicer(DataRow row)
-        {
-            string S(string column) => row.Table.Columns.Contains(column) ? row[column]?.ToString() ?? string.Empty : string.Empty;
-            DateTime? D(string column) => row.Table.Columns.Contains(column) && row[column] != DBNull.Value
-                ? Convert.ToDateTime(row[column], CultureInfo.InvariantCulture)
-                : (DateTime?)null;
-
-            return new ExternalServicer
-            {
-                Id = row.Table.Columns.Contains("id") && row["id"] != DBNull.Value ? Convert.ToInt32(row["id"], CultureInfo.InvariantCulture) : 0,
-                Name = S("name"),
-                Code = S("code"),
-                VatOrId = S("registration_number"),
-                ContactPerson = S("contact_person"),
-                Email = S("email"),
-                Phone = S("phone"),
-                Address = S("address"),
-                Type = S("type"),
-                Status = S("status"),
-                CooperationStart = D("cooperation_start"),
-                CooperationEnd = D("cooperation_end"),
-                Comment = S("comment"),
-                DigitalSignature = S("digital_signature"),
-                ExtraNotes = S("note")
-            };
-        }
     }
 }

--- a/YasGMP.Tests/ExternalServicerDatabaseExtensionsTests.cs
+++ b/YasGMP.Tests/ExternalServicerDatabaseExtensionsTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using YasGMP.Models;
+using YasGMP.Services;
+
+namespace YasGMP.Tests
+{
+    public class ExternalServicerDatabaseExtensionsTests
+    {
+        private const string ConnectionString = "Server=localhost;Database=test;Uid=root;Pwd=secret;";
+
+        [Fact]
+        public async Task InsertOrUpdateExternalServicerAsync_Insert_UsesExternalContractorsTable()
+        {
+            var db = new DatabaseService(ConnectionString);
+            var executedSql = new List<string>();
+            Dictionary<string, object?>? capturedParams = null;
+
+            db.ExecuteNonQueryOverride = (sql, parameters, _) =>
+            {
+                executedSql.Add(sql);
+                capturedParams = parameters?.ToDictionary(p => p.ParameterName, p => p.Value);
+                return Task.FromResult(1);
+            };
+
+            db.ExecuteScalarOverride = (sql, _, _) =>
+            {
+                executedSql.Add(sql);
+                return Task.FromResult<object?>(42);
+            };
+
+            var servicer = new ExternalServicer
+            {
+                Name = "ACME Labs",
+                ExtraNotes = "Note",
+                Comment = "Comment"
+            };
+
+            try
+            {
+                var id = await db.InsertOrUpdateExternalServicerAsync(servicer, update: false).ConfigureAwait(false);
+
+                Assert.Equal(42, id);
+                Assert.Equal(42, servicer.Id);
+                Assert.Contains(executedSql, sql => sql.Contains("INSERT INTO external_contractors", StringComparison.OrdinalIgnoreCase));
+                Assert.NotNull(capturedParams);
+                Assert.Equal("Note", capturedParams!["@note"]);
+                Assert.Equal("Comment", capturedParams!["@comm"]);
+            }
+            finally
+            {
+                db.ResetTestOverrides();
+            }
+        }
+
+        [Fact]
+        public async Task InsertOrUpdateExternalServicerAsync_Update_UsesExternalContractorsTable()
+        {
+            var db = new DatabaseService(ConnectionString);
+            var executedSql = new List<string>();
+            Dictionary<string, object?>? capturedParams = null;
+
+            db.ExecuteNonQueryOverride = (sql, parameters, _) =>
+            {
+                executedSql.Add(sql);
+                capturedParams = parameters?.ToDictionary(p => p.ParameterName, p => p.Value);
+                return Task.FromResult(1);
+            };
+
+            var servicer = new ExternalServicer
+            {
+                Id = 7,
+                Name = "ACME Labs",
+                ExtraNotes = "Note",
+                Comment = "Comment"
+            };
+
+            try
+            {
+                await db.InsertOrUpdateExternalServicerAsync(servicer, update: true).ConfigureAwait(false);
+
+                var updateSql = Assert.Single(executedSql);
+                Assert.Contains("UPDATE external_contractors", updateSql, StringComparison.OrdinalIgnoreCase);
+                Assert.NotNull(capturedParams);
+                Assert.Equal(7, capturedParams!["@id"]);
+                Assert.Equal("Note", capturedParams!["@note"]);
+                Assert.Equal("Comment", capturedParams!["@comm"]);
+            }
+            finally
+            {
+                db.ResetTestOverrides();
+            }
+        }
+
+        [Fact]
+        public async Task DeleteExternalServicerAsync_UsesExternalContractorsTable()
+        {
+            var db = new DatabaseService(ConnectionString);
+            var executedSql = new List<string>();
+            Dictionary<string, object?>? capturedParams = null;
+
+            db.ExecuteNonQueryOverride = (sql, parameters, _) =>
+            {
+                executedSql.Add(sql);
+                capturedParams = parameters?.ToDictionary(p => p.ParameterName, p => p.Value);
+                return Task.FromResult(1);
+            };
+
+            try
+            {
+                await db.DeleteExternalServicerAsync(9).ConfigureAwait(false);
+
+                var deleteSql = Assert.Single(executedSql);
+                Assert.Contains("DELETE FROM external_contractors", deleteSql, StringComparison.OrdinalIgnoreCase);
+                Assert.NotNull(capturedParams);
+                Assert.Equal(9, capturedParams!["@id"]);
+            }
+            finally
+            {
+                db.ResetTestOverrides();
+            }
+        }
+    }
+}

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -35,7 +35,7 @@
   - Settings/Admin — [ ] todo
 
 - **Open Issues / Blockers**
-  - `dotnet` executable not found. Install/expose **.NET 9 SDK** and **Windows 10 SDK (19041+)** on the host; if building inside a container, expose host `dotnet` or install within the container. Run `scripts/bootstrap-dotnet9.ps1` to verify and pin via `global.json`. *(2025-09-25 & 2025-09-27 retries confirmed `dotnet --info` continues to fail with **command not found**.)*
+- `dotnet` executable not found. Install/expose **.NET 9 SDK** and **Windows 10 SDK (19041+)** on the host; if building inside a container, expose host `dotnet` or install within the container. Run `scripts/bootstrap-dotnet9.ps1` to verify and pin via `global.json`. *(2025-09-25 & 2025-09-27 retries confirmed `dotnet --info` continues to fail with **command not found**; 2025-10-09 recheck still reports the command missing.)*
   - Pending inventory of MAUI assets/services/modules; schedule once SDK issue is resolved.
   - Smoke automation is blocked until SDK + Windows tooling are installed.
   - Work Orders editor still requires e-signature prompt + inspector audit surfacing once Batch B2 unblocks the shared services.
@@ -57,6 +57,7 @@
 - 2025-10-06: Users/Roles (Security) module now reuses the shared user/RBAC services through a new adapter, exposing a mode-aware editor with CFL, role assignments, and unit coverage; signature/audit surfacing remains queued for Batch B2.
 - 2025-10-07: Suppliers module now leverages ISupplierCrudService with a mode-aware editor, attachments via AttachmentService, CFL/golden-arrow integration, and unit coverage; External Servicers remain queued for follow-up.
 - 2025-10-08: External Servicers module now mirrors MAUI CRUD with a dedicated adapter, WPF view, CFL picker, golden-arrow navigation, and unit/smoke coverage updates.
+- 2025-10-09: External Servicer service now delegates CRUD to `DatabaseServiceExternalServicersExtensions`; regression tests assert create/update/delete hit `external_contractors`. Restore/build remain blocked until the .NET CLI is available in the container.
 - Next actionable slice once SDK access is restored: wire Assets attachments + signatures, then replicate CRUD pattern for Components.
 - 2025-09-26: Assets editor now drives MachineService CRUD + validation with mode-aware UI; run smoke harness once SDK restored.
 - 2025-09-27: Components module now surfaces a CRUD-capable editor using ComponentService with machine lookups; attachments/e-signature integration tracked under Batch B2.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -9,7 +9,8 @@
       "2025-09-25: Batch 0 retry confirmed `dotnet --info` still returns 'command not found'.",
       "2025-09-26: Batch 0 retry confirmed `dotnet --info` still returns 'command not found'.",
       "2025-09-27: dotnet --info/dotnet restore/dotnet build all continue to fail with 'command not found'.",
-      "2025-09-28: Batch 0 retry again hit 'command not found' for dotnet --info/restore/build in container."
+      "2025-09-28: Batch 0 retry again hit 'command not found' for dotnet --info/restore/build in container.",
+      "2025-10-09: dotnet --info still fails with 'command not found' inside the container; restore/build remain blocked."
     ]
   },
   "batches": [
@@ -40,7 +41,7 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "feat(suppliers): add CRUD editor",
+  "lastCommitSummary": "fix(external-servicers): route CRUD through db extensions",
 
   "notes": [
     "Need to restore/install dotnet 9 SDK to proceed with Batch 0 validation steps.",
@@ -64,7 +65,8 @@
     "2025-10-05: Scheduled Jobs module now exposes a CRUD-capable editor with execute/acknowledge commands, CFL hooks, and attachment uploads via the new IScheduledJobCrudService adapter; signature/audit prompts remain queued for Batch B2.",
     "2025-10-06: Security (Users/Roles) module now leverages IUserCrudService with RBAC role assignment management, CFL, and unit coverage; signature/audit surfacing will follow under Batch B2.",
       "2025-10-07: Suppliers module now uses ISupplierCrudService with attachments, CFL, and mode-aware editor coverage; External Servicers remain a follow-up task.",
-      "2025-10-08: External Servicers module now has a dedicated adapter, WPF document, CFL picker, golden-arrow navigation, and unit/smoke harness coverage."
+      "2025-10-08: External Servicers module now has a dedicated adapter, WPF document, CFL picker, golden-arrow navigation, and unit/smoke harness coverage.",
+      "2025-10-09: External Servicer database extensions now drive CRUD (list/load/save/delete) with unit tests asserting `external_contractors` access."
   ]
 
 }


### PR DESCRIPTION
## Summary
- routed `ExternalServicerService` through the `DatabaseServiceExternalServicersExtensions` helpers for list/load/save/delete flows and kept audit logging intact
- expanded the external servicer database extensions with note persistence, by-id lookups for both `ExternalServicer`/`ExternalContractor`, and updated model mapping
- added unit coverage proving create/update/delete hit the `external_contractors` table via the extension methods and recorded the refactor/SKD blocker in Codex docs

## Testing
- `dotnet restore yasgmp.sln` *(fails: `dotnet` CLI is not available in the container)*
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj -f net9.0-windows10.0.19041.0` *(fails: `dotnet` CLI is not available in the container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence). *(Blocked: `dotnet` CLI unavailable in container)*
- [ ] MAUI builds/runs unaffected. *(Blocked: `dotnet` CLI unavailable in container)*
- [ ] Shared AppCore extraction complete where required; adapters compiled. *(Tracked in docs; unchanged this batch)*
- [ ] ModulesPane lists every module and opens feature-parity editors. *(Tracked in docs; unchanged this batch)*
- [ ] B1 FormModes & command enablement wired across editors. *(Tracked in docs; unchanged this batch)*
- [ ] CFL pickers + Golden Arrow navigation working. *(Tracked in docs; unchanged this batch)*
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end. *(Tracked in docs; unchanged this batch)*
- [ ] Warehouse ledger with running balance and alerts. *(Tracked in docs; unchanged this batch)*
- [ ] Audit surfacing + e-signature prompts on critical saves. *(Tracked in docs; unchanged this batch)*
- [ ] Attachments DB-backed with upload/preview/download. *(Tracked in docs; unchanged this batch)*
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented. *(Tracked in docs; unchanged this batch)*
- [ ] Smoke tests succeed and log output. *(Blocked: `dotnet` CLI unavailable in container)*
- [ ] `README_WPF_SHELL.md` and `/docs/WPF_MAPPING.md` kept current. *(Tracked in docs; unchanged this batch)*

------
https://chatgpt.com/codex/tasks/task_e_68d64d5da40c8331abeaabaf781c2c12