### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf.Tests/AuditModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/AuditModuleViewModelTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using YasGMP.Models.DTO;
+using YasGMP.Services;
+using YasGMP.Wpf.Services;
+using YasGMP.Wpf.ViewModels.Modules;
+
+namespace YasGMP.Wpf.Tests;
+
+public class AuditModuleViewModelTests
+{
+    [Fact]
+    public async Task InitializeAsync_LoadsAuditEntries_WithInspectorDetails()
+    {
+        var database = CreateDatabaseService();
+        var auditService = new AuditService(database);
+        var cfl = new StubCflDialogService();
+        var shell = new StubShellInteractionService();
+        var navigation = new StubModuleNavigationService();
+
+        var sampleTimestamp = new DateTime(2025, 1, 15, 8, 30, 0, DateTimeKind.Utc);
+        var audits = new[]
+        {
+            new AuditEntryDto
+            {
+                Id = 42,
+                Entity = "work_orders",
+                EntityId = "77",
+                Action = "UPDATE",
+                Timestamp = sampleTimestamp,
+                Username = "qa.user",
+                UserId = 9,
+                IpAddress = "10.0.0.5",
+                DeviceInfo = "OS=Windows; Host=QA-WS",
+                DigitalSignature = "qa-signature",
+                SignatureHash = "AABBCCDDEE",
+                Note = "Status changed to CLOSED",
+                Status = "audit"
+            }
+        };
+
+        var viewModel = new TestAuditModuleViewModel(database, auditService, cfl, shell, navigation, audits);
+        viewModel.FilterUser = "qa";
+        viewModel.FilterEntity = "work_orders";
+        viewModel.SelectedAction = "UPDATE";
+        viewModel.FilterFrom = new DateTime(2025, 1, 1);
+        viewModel.FilterTo = new DateTime(2025, 1, 31);
+
+        await viewModel.InitializeAsync(null);
+
+        Assert.Single(viewModel.Records);
+        var record = viewModel.Records.First();
+        Assert.Equal("work_orders #77", record.Title);
+        Assert.Equal("UPDATE", record.Code);
+        Assert.Equal("audit", record.Status);
+        Assert.Equal("Status changed to CLOSED", record.Description);
+        Assert.Equal("qa.user (#9)", record.InspectorFields[1].Value);
+        Assert.Equal("10.0.0.5", record.InspectorFields[4].Value);
+        Assert.Equal("qa-signature", record.InspectorFields[7].Value);
+        Assert.Equal("AABBCCDDEE", record.InspectorFields[8].Value);
+        Assert.Equal("Loaded 1 audit entry.", viewModel.StatusMessage);
+
+        Assert.Equal("qa", viewModel.LastUserFilter);
+        Assert.Equal("work_orders", viewModel.LastEntityFilter);
+        Assert.Equal("UPDATE", viewModel.LastActionFilter);
+        Assert.Equal(viewModel.FilterFrom, viewModel.LastFromFilter);
+        Assert.Equal(viewModel.FilterTo, viewModel.LastToFilter);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_NoAudits_SetsEmptyStatusMessage()
+    {
+        var database = CreateDatabaseService();
+        var auditService = new AuditService(database);
+        var cfl = new StubCflDialogService();
+        var shell = new StubShellInteractionService();
+        var navigation = new StubModuleNavigationService();
+
+        var viewModel = new TestAuditModuleViewModel(database, auditService, cfl, shell, navigation, Array.Empty<AuditEntryDto>());
+
+        await viewModel.InitializeAsync(null);
+
+        Assert.Empty(viewModel.Records);
+        Assert.Equal("No audit entries match the current filters.", viewModel.StatusMessage);
+        Assert.Equal(string.Empty, viewModel.LastActionFilter);
+    }
+
+    private static DatabaseService CreateDatabaseService()
+        => new("Server=localhost;Database=unit_test;Uid=test;Pwd=test;");
+
+    private sealed class TestAuditModuleViewModel : AuditModuleViewModel
+    {
+        private readonly IReadOnlyList<AuditEntryDto> _entries;
+
+        public TestAuditModuleViewModel(
+            DatabaseService databaseService,
+            AuditService auditService,
+            ICflDialogService cflDialogService,
+            IShellInteractionService shellInteraction,
+            IModuleNavigationService navigation,
+            IReadOnlyList<AuditEntryDto> entries)
+            : base(databaseService, auditService, cflDialogService, shellInteraction, navigation)
+        {
+            _entries = entries;
+        }
+
+        public string? LastUserFilter { get; private set; }
+        public string? LastEntityFilter { get; private set; }
+        public string LastActionFilter { get; private set; } = string.Empty;
+        public DateTime LastFromFilter { get; private set; }
+        public DateTime LastToFilter { get; private set; }
+
+        protected override Task<IReadOnlyList<AuditEntryDto>> QueryAuditsAsync(
+            string user,
+            string entity,
+            string action,
+            DateTime from,
+            DateTime to)
+        {
+            LastUserFilter = user;
+            LastEntityFilter = entity;
+            LastActionFilter = action;
+            LastFromFilter = from;
+            LastToFilter = to;
+            return Task.FromResult(_entries);
+        }
+    }
+
+    private sealed class StubCflDialogService : ICflDialogService
+    {
+        public Task<CflResult?> ShowAsync(CflRequest request) => Task.FromResult<CflResult?>(null);
+    }
+
+    private sealed class StubShellInteractionService : IShellInteractionService
+    {
+        public void UpdateInspector(InspectorContext context) { }
+        public void UpdateStatus(string message) { }
+    }
+
+    private sealed class StubModuleNavigationService : IModuleNavigationService
+    {
+        public void Activate(ModuleDocumentViewModel document) { }
+        public ModuleDocumentViewModel OpenModule(string moduleKey, object? parameter = null)
+            => throw new NotSupportedException();
+    }
+}

--- a/YasGMP.Wpf/App.xaml.cs
+++ b/YasGMP.Wpf/App.xaml.cs
@@ -84,6 +84,7 @@ namespace YasGMP.Wpf
                         svc.AddTransient<IUserService, UserService>();
                         svc.AddTransient<IUserCrudService, UserCrudServiceAdapter>();
                         svc.AddTransient<IScheduledJobCrudService, ScheduledJobCrudServiceAdapter>();
+                        svc.AddTransient<AuditService>();
                         svc.AddSingleton<ShellInteractionService>();
                         svc.AddSingleton<IModuleNavigationService>(sp => sp.GetRequiredService<ShellInteractionService>());
                         svc.AddSingleton<IShellInteractionService>(sp => sp.GetRequiredService<ShellInteractionService>());

--- a/YasGMP.Wpf/Views/AuditModuleView.xaml
+++ b/YasGMP.Wpf/Views/AuditModuleView.xaml
@@ -34,10 +34,46 @@
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
-            <DockPanel Grid.Row="0" Margin="0,0,0,8">
-                <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0" />
-                <TextBox Width="220" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
-            </DockPanel>
+            <StackPanel Grid.Row="0" Margin="0,0,0,8">
+                <WrapPanel Margin="0,0,0,8">
+                    <StackPanel Width="200" Margin="0,0,12,0">
+                        <TextBlock Text="User" FontWeight="SemiBold" />
+                        <TextBox Text="{Binding FilterUser, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
+                    <StackPanel Width="200" Margin="0,0,12,0">
+                        <TextBlock Text="Entity" FontWeight="SemiBold" />
+                        <TextBox Text="{Binding FilterEntity, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
+                    <StackPanel Width="180" Margin="0,0,12,0">
+                        <TextBlock Text="Action" FontWeight="SemiBold" />
+                        <ComboBox ItemsSource="{Binding ActionOptions}"
+                                  SelectedItem="{Binding SelectedAction, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
+                    <StackPanel Width="180" Margin="0,0,12,0">
+                        <TextBlock Text="From" FontWeight="SemiBold" />
+                        <DatePicker SelectedDate="{Binding FilterFrom, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
+                    <StackPanel Width="180" Margin="0,0,12,0">
+                        <TextBlock Text="To" FontWeight="SemiBold" />
+                        <DatePicker SelectedDate="{Binding FilterTo, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
+                </WrapPanel>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="220" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0" />
+                    <TextBox Grid.Column="1" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+                    <Button Grid.Column="2"
+                            Content="Apply Filters"
+                            Command="{Binding RefreshCommand}"
+                            Margin="12,0,0,0"
+                            Padding="12,4" />
+                </Grid>
+            </StackPanel>
             <DataGrid Grid.Row="1"
                       ItemsSource="{Binding RecordsView}"
                       SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
@@ -46,10 +82,16 @@
                       CanUserAddRows="False"
                       CanUserDeleteRows="False">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Header="Code" Binding="{Binding Code}" Width="120" />
-                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="2*" />
-                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="140" />
-                    <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" />
+                    <DataGridTextColumn Header="Timestamp" Binding="{Binding InspectorFields[0].Value}" Width="160" />
+                    <DataGridTextColumn Header="User" Binding="{Binding InspectorFields[1].Value}" Width="200" />
+                    <DataGridTextColumn Header="Entity" Binding="{Binding Title}" Width="200" />
+                    <DataGridTextColumn Header="Action" Binding="{Binding Code}" Width="120" />
+                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="120" />
+                    <DataGridTextColumn Header="IP Address" Binding="{Binding InspectorFields[4].Value}" Width="160" />
+                    <DataGridTextColumn Header="Device" Binding="{Binding InspectorFields[5].Value}" Width="2*" />
+                    <DataGridTextColumn Header="Digital Signature" Binding="{Binding InspectorFields[7].Value}" Width="200" />
+                    <DataGridTextColumn Header="Signature Hash" Binding="{Binding InspectorFields[8].Value}" Width="200" />
+                    <DataGridTextColumn Header="Note" Binding="{Binding Description}" Width="2*" />
                 </DataGrid.Columns>
             </DataGrid>
             <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" FontStyle="Italic" Foreground="Gray" Margin="0,8,0,0" />

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -29,7 +29,7 @@
   - Scheduled Jobs — [x] done *(mode-aware editor with execute/acknowledge tooling and attachment workflow; signature/audit surfacing tracked under Batch B2)*
   - Users/Roles — [x] done *(Security module now exposes a CRUD-capable user/role editor with CFL, toolbar modes, and role assignment management; signature prompts queued for Batch B2)*
   - Suppliers/External Servicers — [x] done *(Suppliers module ships with attachments + CFL; External Servicers cockpit now live with mode-aware CRUD and navigation)*
-  - Audit/API Audit — [ ] todo
+  - Audit/API Audit — [~] in-progress *(WPF audit trail now pulls filtered entries via AuditService with expanded inspector grid and filters.)*
   - Documents/Attachments — [ ] todo
   - Dashboard/Reports — [ ] todo
   - Settings/Admin — [ ] todo
@@ -58,6 +58,7 @@
 - 2025-10-07: Suppliers module now leverages ISupplierCrudService with a mode-aware editor, attachments via AttachmentService, CFL/golden-arrow integration, and unit coverage; External Servicers remain queued for follow-up.
 - 2025-10-08: External Servicers module now mirrors MAUI CRUD with a dedicated adapter, WPF view, CFL picker, golden-arrow navigation, and unit/smoke coverage updates.
 - 2025-10-09: External Servicer service now delegates CRUD to `DatabaseServiceExternalServicersExtensions`; regression tests assert create/update/delete hit `external_contractors`. Restore/build remain blocked until the .NET CLI is available in the container.
+- 2025-10-10: Audit module now surfaces AuditService-backed filtering (user/entity/action/date) with richer inspector columns and WPF unit coverage; `dotnet --info` still reports `command not found` inside the container.
 - Next actionable slice once SDK access is restored: wire Assets attachments + signatures, then replicate CRUD pattern for Components.
 - 2025-09-26: Assets editor now drives MachineService CRUD + validation with mode-aware UI; run smoke harness once SDK restored.
 - 2025-09-27: Components module now surfaces a CRUD-capable editor using ComponentService with machine lookups; attachments/e-signature integration tracked under Batch B2.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -34,14 +34,14 @@
     "UsersRoles": "done",
     "Suppliers": "done",
     "ExternalServicers": "done",
-    "Audit": "pending",
+    "Audit": "in-progress",
     "ApiAudit": "pending",
     "Attachments": "pending",
     "Dashboard": "pending",
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "fix(external-servicers): route CRUD through db extensions",
+  "lastCommitSummary": "feat(audit): load WPF audit trail via audit service",
 
   "notes": [
     "Need to restore/install dotnet 9 SDK to proceed with Batch 0 validation steps.",
@@ -66,7 +66,8 @@
     "2025-10-06: Security (Users/Roles) module now leverages IUserCrudService with RBAC role assignment management, CFL, and unit coverage; signature/audit surfacing will follow under Batch B2.",
       "2025-10-07: Suppliers module now uses ISupplierCrudService with attachments, CFL, and mode-aware editor coverage; External Servicers remain a follow-up task.",
       "2025-10-08: External Servicers module now has a dedicated adapter, WPF document, CFL picker, golden-arrow navigation, and unit/smoke harness coverage.",
-      "2025-10-09: External Servicer database extensions now drive CRUD (list/load/save/delete) with unit tests asserting `external_contractors` access."
+      "2025-10-09: External Servicer database extensions now drive CRUD (list/load/save/delete) with unit tests asserting `external_contractors` access.",
+      "2025-10-10: Audit module now surfaces AuditService-backed filtering with richer inspector columns and WPF coverage; dotnet --info still fails with 'command not found'."
   ]
 
 }


### PR DESCRIPTION
## Summary
- load the WPF audit module through `AuditService.GetFilteredAudits` and surface inspector metadata for users, IPs, devices, and signatures
- expose user/entity/action/date filters with updated grid columns in `AuditModuleView`
- register the audit service, add WPF unit tests for the audit trail mapping, and update codex plan/progress docs

## Testing
- `dotnet --info` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d65260b4e483319ac64110c198adb3