### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
@@ -31,8 +31,20 @@ public sealed partial class AuditModuleViewModel : DataDrivenModuleDocumentViewM
 
     protected override async Task<IReadOnlyList<ModuleRecord>> LoadAsync(object? parameter)
     {
-        var normalizedFrom = FilterFrom;
-        var normalizedTo = FilterTo < FilterFrom ? FilterFrom : FilterTo;
+        var normalizedFrom = FilterFrom.Date;
+
+        var effectiveFilterTo = FilterTo;
+        if (effectiveFilterTo == default)
+        {
+            effectiveFilterTo = FilterFrom;
+        }
+
+        if (effectiveFilterTo < FilterFrom)
+        {
+            effectiveFilterTo = FilterFrom;
+        }
+
+        var normalizedTo = effectiveFilterTo.Date.AddDays(1).AddTicks(-1);
 
         var actionFilter = string.Equals(SelectedAction, "All", StringComparison.OrdinalIgnoreCase)
             ? string.Empty

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -60,6 +60,7 @@
 - 2025-10-09: External Servicer service now delegates CRUD to `DatabaseServiceExternalServicersExtensions`; regression tests assert create/update/delete hit `external_contractors`. Restore/build remain blocked until the .NET CLI is available in the container.
 - 2025-10-10: Audit module now surfaces AuditService-backed filtering (user/entity/action/date) with richer inspector columns and WPF unit coverage; `dotnet --info` still reports `command not found` inside the container.
 - 2025-10-11: B1 form base now exposes FormatLoadedMessage, letting the Audit module emit entry-specific status text without collection hooks; tests cover singular/plural/no-result messages.
+- 2025-10-12: Audit module filters now normalize date ranges to inclusive day boundaries and backfill empty end dates so AuditService always receives valid bounds; unit tests cover the end-of-day behavior.
 - Next actionable slice once SDK access is restored: wire Assets attachments + signatures, then replicate CRUD pattern for Components.
 - 2025-09-26: Assets editor now drives MachineService CRUD + validation with mode-aware UI; run smoke harness once SDK restored.
 - 2025-09-27: Components module now surfaces a CRUD-capable editor using ComponentService with machine lookups; attachments/e-signature integration tracked under Batch B2.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -61,7 +61,7 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "fix(audit): format status messages via hook",
+  "lastCommitSummary": "fix(audit): normalize date filter bounds",
   "notes": [
     "Need to restore/install dotnet 9 SDK to proceed with Batch 0 validation steps.",
     "tests/fixtures/hello.txt seeded for smoke harness bootstrap",
@@ -87,6 +87,7 @@
     "2025-10-08: External Servicers module now has a dedicated adapter, WPF document, CFL picker, golden-arrow navigation, and unit/smoke harness coverage.",
     "2025-10-09: External Servicer database extensions now drive CRUD (list/load/save/delete) with unit tests asserting `external_contractors` access.",
     "2025-10-10: Audit module now surfaces AuditService-backed filtering with richer inspector columns and WPF coverage; dotnet --info still fails with 'command not found'.",
-    "2025-10-11: B1 base now formats loaded status via a virtual hook so Audit module can emit singular/plural/no-results messaging validated by unit tests."
+    "2025-10-11: B1 base now formats loaded status via a virtual hook so Audit module can emit singular/plural/no-results messaging validated by unit tests.",
+    "2025-10-12: Audit module now normalizes filter dates to inclusive ranges and defaults missing end dates; WPF tests assert the end-of-day conversion."
   ]
 }


### PR DESCRIPTION
## Summary
- normalize audit date filters to pass inclusive day ranges and guard against unset end dates
- extend audit view model tests to cover end-of-day normalization and adjust expectations
- log the date filter work in the Codex plan/progress trackers

## Testing
- `dotnet restore` *(fails: dotnet CLI not available in container)*
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj` *(fails: dotnet CLI not available in container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence) *(blocked: dotnet CLI unavailable in container)*
- [ ] MAUI builds/runs unaffected *(blocked: dotnet CLI unavailable in container)*
- [ ] Shared AppCore extraction complete where required; adapters compiled
- [ ] ModulesPane lists every module and opens feature-parity editors
- [ ] B1 FormModes & command enablement wired across editors
- [ ] CFL pickers + Golden Arrow navigation working
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end
- [ ] Warehouse ledger with running balance and alerts
- [ ] Audit surfacing + e-signature prompts on critical saves
- [ ] Attachments DB-backed with upload/preview/download
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented
- [ ] Smoke tests succeed and log output *(blocked: dotnet CLI unavailable in container)*
- [ ] `README_WPF_SHELL.md` and `/docs/WPF_MAPPING.md` kept current

------
https://chatgpt.com/codex/tasks/task_e_68d65bd666408331904deb8bd82191f8