### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf.Tests/AuditModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/AuditModuleViewModelTests.cs
@@ -49,7 +49,7 @@ public class AuditModuleViewModelTests
         viewModel.FilterFrom = new DateTime(2025, 1, 1);
         viewModel.FilterTo = new DateTime(2025, 1, 31);
 
-        await viewModel.InitializeAsync(null);
+        await viewModel.RefreshAsync();
 
         Assert.Single(viewModel.Records);
         var record = viewModel.Records.First();
@@ -82,7 +82,7 @@ public class AuditModuleViewModelTests
 
         var viewModel = new TestAuditModuleViewModel(database, auditService, cfl, shell, navigation, Array.Empty<AuditEntryDto>());
 
-        await viewModel.InitializeAsync(null);
+        await viewModel.RefreshAsync();
 
         Assert.Empty(viewModel.Records);
         Assert.Equal("No audit entries match the current filters.", viewModel.StatusMessage);
@@ -106,7 +106,7 @@ public class AuditModuleViewModelTests
 
         var viewModel = new TestAuditModuleViewModel(database, auditService, cfl, shell, navigation, audits);
 
-        await viewModel.InitializeAsync(null);
+        await viewModel.RefreshAsync();
 
         Assert.Equal(2, viewModel.Records.Count);
         Assert.Equal("Loaded 2 audit entries.", viewModel.StatusMessage);
@@ -137,7 +137,7 @@ public class AuditModuleViewModelTests
         viewModel.FilterFrom = new DateTime(2025, 3, 10, 14, 30, 0);
         viewModel.FilterTo = new DateTime(2025, 3, 15);
 
-        await viewModel.InitializeAsync(null);
+        await viewModel.RefreshAsync();
 
         Assert.Equal(new DateTime(2025, 3, 10), viewModel.LastFromFilter);
         Assert.Equal(new DateTime(2025, 3, 15).Date.AddDays(1).AddTicks(-1), viewModel.LastToFilter);

--- a/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
@@ -190,7 +190,7 @@ public sealed partial class AuditModuleViewModel : DataDrivenModuleDocumentViewM
             relatedParameter: null);
     }
 
-    protected override string FormatLoadedMessage(int count)
+    protected override string FormatLoadedStatus(int count)
     {
         if (count == 0)
         {

--- a/YasGMP.Wpf/ViewModels/Modules/B1FormDocumentViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/B1FormDocumentViewModel.cs
@@ -173,7 +173,7 @@ public abstract partial class B1FormDocumentViewModel : DocumentViewModel
            || (!string.IsNullOrWhiteSpace(record.Description) && record.Description.Contains(searchText, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>Formats the status message after records have been loaded.</summary>
-    protected virtual string FormatLoadedMessage(int count) => $"Loaded {count} record(s).";
+    protected virtual string FormatLoadedStatus(int count) => $"Loaded {count} record(s).";
 
     partial void OnModeChanged(FormMode value)
     {
@@ -261,7 +261,7 @@ public abstract partial class B1FormDocumentViewModel : DocumentViewModel
             StatusMessage = $"Loading {Title} records...";
             var records = await LoadAsync(parameter).ConfigureAwait(false);
             ApplyRecords(records);
-            StatusMessage = FormatLoadedMessage(Records.Count);
+            StatusMessage = FormatLoadedStatus(Records.Count);
         }
         catch (Exception ex)
         {

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -1,10 +1,10 @@
 # Codex Plan — WPF Shell & Full Integration
 
 ## Current Compile Status
-- [ ] Dotnet SDKs detected and recorded *(blocked: `dotnet` CLI not available in container PATH`; `dotnet --info` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-28, and 2025-09-29 → **command not found**)*
-- [ ] Solution restores *(pending SDK availability; `dotnet restore` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, and 2025-09-29 → **command not found**)*
-- [ ] MAUI builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, and 2025-09-29 → **command not found**)*
-- [ ] WPF builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, and 2025-09-29 → **command not found**)*
+- [ ] Dotnet SDKs detected and recorded *(blocked: `dotnet` CLI not available in container PATH`; `dotnet --info` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-28, 2025-09-29, and 2025-10-14 → **command not found**)*
+- [ ] Solution restores *(pending SDK availability; `dotnet restore` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, and 2025-10-14 → **command not found**)*
+- [ ] MAUI builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, and 2025-10-14 → **command not found**)*
+- [ ] WPF builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, and 2025-10-14 → **command not found**)*
 
 ## Decisions & Pins
 - Preferred WPF target: **net9.0-windows10.0.19041.0** (retain once .NET 9 SDK is installed).
@@ -59,7 +59,7 @@
 - 2025-10-08: External Servicers module now mirrors MAUI CRUD with a dedicated adapter, WPF view, CFL picker, golden-arrow navigation, and unit/smoke coverage updates.
 - 2025-10-09: External Servicer service now delegates CRUD to `DatabaseServiceExternalServicersExtensions`; regression tests assert create/update/delete hit `external_contractors`. Restore/build remain blocked until the .NET CLI is available in the container.
 - 2025-10-10: Audit module now surfaces AuditService-backed filtering (user/entity/action/date) with richer inspector columns and WPF unit coverage; `dotnet --info` still reports `command not found` inside the container.
-- 2025-10-11: B1 form base now exposes FormatLoadedMessage, letting the Audit module emit entry-specific status text without collection hooks; tests cover singular/plural/no-result messages.
+- 2025-10-11: B1 form base now exposes FormatLoadedStatus, letting the Audit module emit entry-specific status text without collection hooks; tests cover singular/plural/no-result messages.
 - 2025-10-12: Audit module filters now normalize date ranges to inclusive day boundaries and backfill empty end dates so AuditService always receives valid bounds; unit tests cover the end-of-day behavior.
 - 2025-10-13: WPF host now keeps a single AuditService singleton registration aligned with MAUI; attempted `dotnet restore`/`dotnet build` still fail because the CLI is unavailable in the container.
 - Next actionable slice once SDK access is restored: wire Assets attachments + signatures, then replicate CRUD pattern for Components.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -11,7 +11,8 @@
       "2025-09-27: dotnet --info/dotnet restore/dotnet build all continue to fail with 'command not found'.",
       "2025-09-28: Batch 0 retry again hit 'command not found' for dotnet --info/restore/build in container.",
       "2025-10-09: dotnet --info still fails with 'command not found' inside the container; restore/build remain blocked.",
-      "2025-10-11: dotnet --version/restore/build attempts still hit 'command not found' inside the container."
+      "2025-10-11: dotnet --version/restore/build attempts still hit 'command not found' inside the container.",
+      "2025-10-14: dotnet --info/restore/build attempted again; CLI remains unavailable in container."
     ]
   },
   "batches": [
@@ -87,8 +88,9 @@
     "2025-10-08: External Servicers module now has a dedicated adapter, WPF document, CFL picker, golden-arrow navigation, and unit/smoke harness coverage.",
     "2025-10-09: External Servicer database extensions now drive CRUD (list/load/save/delete) with unit tests asserting `external_contractors` access.",
     "2025-10-10: Audit module now surfaces AuditService-backed filtering with richer inspector columns and WPF coverage; dotnet --info still fails with 'command not found'.",
-    "2025-10-11: B1 base now formats loaded status via a virtual hook so Audit module can emit singular/plural/no-results messaging validated by unit tests.",
+    "2025-10-11: B1 base now formats loaded status via a virtual hook (FormatLoadedStatus) so Audit module can emit singular/plural/no-results messaging validated by unit tests.",
     "2025-10-12: Audit module now normalizes filter dates to inclusive ranges and defaults missing end dates; WPF tests assert the end-of-day conversion.",
-    "2025-10-13: WPF host now keeps a single AuditService singleton aligned with MAUI; attempted dotnet restore/build still fail because the CLI is unavailable in the container."
+    "2025-10-13: WPF host now keeps a single AuditService singleton aligned with MAUI; attempted dotnet restore/build still fail because the CLI is unavailable in the container.",
+    "2025-10-14: dotnet restore/build retried for MAUI + WPF targets; CLI still missing so commands exit with 'command not found'."
   ]
 }


### PR DESCRIPTION
## Summary
- expose a virtual FormatLoadedStatus hook in the B1 form base and route refresh status updates through it
- have the Audit module override the formatter for singular/plural messaging and validate via the refresh path in tests
- record the latest dotnet CLI command failures in codex plan/progress artifacts

## Testing
- dotnet restore *(fails: `dotnet` not available in container PATH)*
- dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj *(fails: `dotnet` not available in container PATH)*
- dotnet build yasgmp.csproj -f net9.0-windows10.0.19041.0 *(fails: `dotnet` not available in container PATH)*


------
https://chatgpt.com/codex/tasks/task_e_68d660077c2083319877392523345a91