### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf.Tests/AuditModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/AuditModuleViewModelTests.cs
@@ -143,6 +143,25 @@ public class AuditModuleViewModelTests
         Assert.Equal(new DateTime(2025, 3, 15).Date.AddDays(1).AddTicks(-1), viewModel.LastToFilter);
     }
 
+    [Fact]
+    public async Task RefreshAsync_FilterToDateOnly_NormalizesToEndOfDay()
+    {
+        var database = CreateDatabaseService();
+        var auditService = new AuditService(database);
+        var cfl = new StubCflDialogService();
+        var shell = new StubShellInteractionService();
+        var navigation = new StubModuleNavigationService();
+
+        var viewModel = new TestAuditModuleViewModel(database, auditService, cfl, shell, navigation, Array.Empty<AuditEntryDto>());
+        viewModel.FilterFrom = new DateTime(2025, 4, 5, 13, 45, 0);
+        viewModel.FilterTo = new DateTime(2025, 4, 7);
+
+        await viewModel.RefreshAsync();
+
+        Assert.Equal(new DateTime(2025, 4, 5), viewModel.LastFromFilter);
+        Assert.Equal(new DateTime(2025, 4, 7).Date.AddDays(1).AddTicks(-1), viewModel.LastToFilter);
+    }
+
     private static DatabaseService CreateDatabaseService()
         => new("Server=localhost;Database=unit_test;Uid=test;Pwd=test;");
 

--- a/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
@@ -31,20 +31,21 @@ public sealed partial class AuditModuleViewModel : DataDrivenModuleDocumentViewM
 
     protected override async Task<IReadOnlyList<ModuleRecord>> LoadAsync(object? parameter)
     {
-        var normalizedFrom = FilterFrom.Date;
+        var normalizedFromDate = FilterFrom.Date;
 
-        var effectiveFilterTo = FilterTo;
-        if (effectiveFilterTo == default)
+        var effectiveFilterTo = FilterTo == default
+            ? FilterFrom
+            : FilterTo;
+
+        var normalizedToDate = effectiveFilterTo.Date;
+
+        if (normalizedToDate < normalizedFromDate)
         {
-            effectiveFilterTo = FilterFrom;
+            (normalizedFromDate, normalizedToDate) = (normalizedToDate, normalizedFromDate);
         }
 
-        if (effectiveFilterTo < FilterFrom)
-        {
-            effectiveFilterTo = FilterFrom;
-        }
-
-        var normalizedTo = effectiveFilterTo.Date.AddDays(1).AddTicks(-1);
+        var normalizedFrom = normalizedFromDate;
+        var normalizedTo = normalizedToDate.AddDays(1).AddTicks(-1);
 
         var actionFilter = string.Equals(SelectedAction, "All", StringComparison.OrdinalIgnoreCase)
             ? string.Empty

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -62,6 +62,7 @@
 - 2025-10-11: B1 form base now exposes FormatLoadedStatus, letting the Audit module emit entry-specific status text without collection hooks; tests cover singular/plural/no-result messages.
 - 2025-10-12: Audit module filters now normalize date ranges to inclusive day boundaries and backfill empty end dates so AuditService always receives valid bounds; unit tests cover the end-of-day behavior.
 - 2025-10-13: WPF host now keeps a single AuditService singleton registration aligned with MAUI; attempted `dotnet restore`/`dotnet build` still fail because the CLI is unavailable in the container.
+- 2025-10-15: Audit filters now clamp the start date to midnight, expand the end date to the day's final tick, and auto-swap reversed ranges; WPF coverage verifies date-only `FilterTo` inputs reach the end-of-day timestamp.
 - Next actionable slice once SDK access is restored: wire Assets attachments + signatures, then replicate CRUD pattern for Components.
 - 2025-09-26: Assets editor now drives MachineService CRUD + validation with mode-aware UI; run smoke harness once SDK restored.
 - 2025-09-27: Components module now surfaces a CRUD-capable editor using ComponentService with machine lookups; attachments/e-signature integration tracked under Batch B2.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -62,7 +62,7 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "fix(di): dedupe AuditService registration",
+  "lastCommitSummary": "fix(audit): normalize filter range boundaries",
   "notes": [
     "Need to restore/install dotnet 9 SDK to proceed with Batch 0 validation steps.",
     "tests/fixtures/hello.txt seeded for smoke harness bootstrap",
@@ -91,6 +91,7 @@
     "2025-10-11: B1 base now formats loaded status via a virtual hook (FormatLoadedStatus) so Audit module can emit singular/plural/no-results messaging validated by unit tests.",
     "2025-10-12: Audit module now normalizes filter dates to inclusive ranges and defaults missing end dates; WPF tests assert the end-of-day conversion.",
     "2025-10-13: WPF host now keeps a single AuditService singleton aligned with MAUI; attempted dotnet restore/build still fail because the CLI is unavailable in the container.",
-    "2025-10-14: dotnet restore/build retried for MAUI + WPF targets; CLI still missing so commands exit with 'command not found'."
+    "2025-10-14: dotnet restore/build retried for MAUI + WPF targets; CLI still missing so commands exit with 'command not found'.",
+    "2025-10-15: Audit filters now clamp start/end days, auto-swap reversed ranges, and include WPF coverage for date-only end-of-day normalization."
   ]
 }


### PR DESCRIPTION
## Summary
- normalize the audit module's date filters by clamping `FilterFrom` to midnight, expanding `FilterTo` to the day's final tick, and swapping reversed ranges
- ensure a missing `FilterTo` falls back to `FilterFrom` before querying and add WPF coverage for date-only end dates reaching the end of day
- document the audit filter refinement in codex planning/progress logs

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build yasgmp.sln -c Debug` *(fails: command not found)*
- `dotnet build yasgmp.csproj -c Debug` *(fails: command not found)*
- `dotnet test YasGMP.Wpf.Tests/YasGMP.Wpf.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d661fd2a6c83318ba381d811d00e05