### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf.Tests/AuditModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/AuditModuleViewModelTests.cs
@@ -68,8 +68,8 @@ public class AuditModuleViewModelTests
         Assert.Equal("qa", viewModel.LastUserFilter);
         Assert.Equal("work_orders", viewModel.LastEntityFilter);
         Assert.Equal("UPDATE", viewModel.LastActionFilter);
-        Assert.Equal(viewModel.FilterFrom, viewModel.LastFromFilter);
-        var expectedTo = viewModel.FilterTo.Date.AddDays(1).AddTicks(-1);
+        Assert.Equal(viewModel.FilterFrom!.Value, viewModel.LastFromFilter);
+        var expectedTo = viewModel.FilterTo!.Value.Date.AddDays(1).AddTicks(-1);
         Assert.Equal(expectedTo, viewModel.LastToFilter);
     }
 
@@ -166,6 +166,26 @@ public class AuditModuleViewModelTests
 
         Assert.Equal(new DateTime(2025, 4, 5), viewModel.LastFromFilter);
         Assert.Equal(new DateTime(2025, 4, 7).Date.AddDays(1).AddTicks(-1), viewModel.LastToFilter);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_FilterToUnset_DefaultsToFilterFromEndOfDay()
+    {
+        var database = CreateDatabaseService();
+        var auditService = new AuditService(database);
+        var cfl = new StubCflDialogService();
+        var shell = new StubShellInteractionService();
+        var navigation = new StubModuleNavigationService();
+
+        var viewModel = new TestAuditModuleViewModel(database, auditService, cfl, shell, navigation, Array.Empty<AuditEntryDto>());
+        viewModel.FilterFrom = new DateTime(2025, 5, 1, 9, 30, 0);
+        viewModel.FilterTo = null;
+
+        await viewModel.RefreshAsync();
+
+        var expectedFrom = new DateTime(2025, 5, 1);
+        Assert.Equal(expectedFrom, viewModel.LastFromFilter);
+        Assert.Equal(expectedFrom.AddDays(1).AddTicks(-1), viewModel.LastToFilter);
     }
 
     private static DatabaseService CreateDatabaseService()

--- a/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
@@ -31,12 +31,10 @@ public sealed partial class AuditModuleViewModel : DataDrivenModuleDocumentViewM
 
     protected override async Task<IReadOnlyList<ModuleRecord>> LoadAsync(object? parameter)
     {
-        var normalizedFromDate = FilterFrom.Date;
+        var effectiveFilterFrom = NormalizeDateInput(FilterFrom, DateTime.Today);
+        var effectiveFilterTo = NormalizeDateInput(FilterTo, effectiveFilterFrom);
 
-        var effectiveFilterTo = FilterTo == default
-            ? FilterFrom
-            : FilterTo;
-
+        var normalizedFromDate = effectiveFilterFrom.Date;
         var normalizedToDate = effectiveFilterTo.Date;
 
         if (normalizedToDate < normalizedFromDate)
@@ -119,10 +117,10 @@ public sealed partial class AuditModuleViewModel : DataDrivenModuleDocumentViewM
     private string? _selectedAction;
 
     [ObservableProperty]
-    private DateTime _filterFrom;
+    private DateTime? _filterFrom;
 
     [ObservableProperty]
-    private DateTime _filterTo;
+    private DateTime? _filterTo;
 
     private readonly AuditService _auditService;
 
@@ -133,6 +131,16 @@ public sealed partial class AuditModuleViewModel : DataDrivenModuleDocumentViewM
         DateTime from,
         DateTime to)
         => await _auditService.GetFilteredAudits(user, entity, action, from, to).ConfigureAwait(false);
+
+    private static DateTime NormalizeDateInput(DateTime? value, DateTime fallback)
+    {
+        if (!value.HasValue || value.Value == DateTime.MinValue)
+        {
+            return fallback;
+        }
+
+        return value.Value;
+    }
 
     protected override bool MatchesSearch(ModuleRecord record, string searchText)
         => base.MatchesSearch(record, searchText)

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -1,10 +1,10 @@
 # Codex Plan — WPF Shell & Full Integration
 
 ## Current Compile Status
-- [ ] Dotnet SDKs detected and recorded *(blocked: `dotnet` CLI not available in container PATH`; `dotnet --info` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-28, 2025-09-29, and 2025-10-14 → **command not found**)*
-- [ ] Solution restores *(pending SDK availability; `dotnet restore` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, and 2025-10-14 → **command not found**)*
-- [ ] MAUI builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, and 2025-10-14 → **command not found**)*
-- [ ] WPF builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, and 2025-10-14 → **command not found**)*
+- [ ] Dotnet SDKs detected and recorded *(blocked: `dotnet` CLI not available in container PATH`; `dotnet --info` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-28, 2025-09-29, 2025-10-14, and 2025-10-17 → **command not found**)*
+- [ ] Solution restores *(pending SDK availability; `dotnet restore` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, and 2025-10-17 → **command not found**)*
+- [ ] MAUI builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, and 2025-10-17 → **command not found**)*
+- [ ] WPF builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, and 2025-10-17 → **command not found**)*
 
 ## Decisions & Pins
 - Preferred WPF target: **net9.0-windows10.0.19041.0** (retain once .NET 9 SDK is installed).
@@ -64,6 +64,7 @@
 - 2025-10-13: WPF host now keeps a single AuditService singleton registration aligned with MAUI; attempted `dotnet restore`/`dotnet build` still fail because the CLI is unavailable in the container.
 - 2025-10-15: Audit filters now clamp the start date to midnight, expand the end date to the day's final tick, and auto-swap reversed ranges; WPF coverage verifies date-only `FilterTo` inputs reach the end-of-day timestamp.
 - 2025-10-16: B1 refresh path now pushes counts through `FormatLoadedStatus`, letting Audit override emit zero/singular/plural status text; tests assert the audit-specific messaging via `RefreshAsync`.
+- 2025-10-17: Audit filters now treat null DatePicker inputs as optional bounds, default the end date to the selected start day, and extend it to the day's final tick; WPF unit coverage verifies `LastToFilter` captures the end-of-day timestamp for calendar-only inputs.
 - Next actionable slice once SDK access is restored: wire Assets attachments + signatures, then replicate CRUD pattern for Components.
 - 2025-09-26: Assets editor now drives MachineService CRUD + validation with mode-aware UI; run smoke harness once SDK restored.
 - 2025-09-27: Components module now surfaces a CRUD-capable editor using ComponentService with machine lookups; attachments/e-signature integration tracked under Batch B2.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -12,7 +12,8 @@
       "2025-09-28: Batch 0 retry again hit 'command not found' for dotnet --info/restore/build in container.",
       "2025-10-09: dotnet --info still fails with 'command not found' inside the container; restore/build remain blocked.",
       "2025-10-11: dotnet --version/restore/build attempts still hit 'command not found' inside the container.",
-      "2025-10-14: dotnet --info/restore/build attempted again; CLI remains unavailable in container."
+      "2025-10-14: dotnet --info/restore/build attempted again; CLI remains unavailable in container.",
+      "2025-10-17: dotnet --info/restore/build retried; CLI still missing so commands exit with 'command not found'."
     ]
   },
   "batches": [
@@ -93,6 +94,7 @@
     "2025-10-13: WPF host now keeps a single AuditService singleton aligned with MAUI; attempted dotnet restore/build still fail because the CLI is unavailable in the container.",
     "2025-10-14: dotnet restore/build retried for MAUI + WPF targets; CLI still missing so commands exit with 'command not found'.",
     "2025-10-15: Audit filters now clamp start/end days, auto-swap reversed ranges, and include WPF coverage for date-only end-of-day normalization.",
-    "2025-10-16: B1 refresh now calls FormatLoadedStatus with the loaded count so Audit overrides can emit zero/singular/plural strings; unit tests assert the formatted audit status messages."
+    "2025-10-16: B1 refresh now calls FormatLoadedStatus with the loaded count so Audit overrides can emit zero/singular/plural strings; unit tests assert the formatted audit status messages.",
+    "2025-10-17: Audit module date filters now accept null DatePicker inputs, default missing end dates to the start date, and expand the end boundary to the final tick of the day; WPF unit tests verify LastToFilter receives the end-of-day timestamp."
   ]
 }


### PR DESCRIPTION
## Summary
- Normalize audit module date filters so the start day clamps to midnight, the end day expands to the final tick, and null DatePicker inputs default to the selected range before querying audits.
- Extend the WPF audit view-model tests to assert end-of-day `LastToFilter` values for calendar-only inputs and to cover scenarios where the end date is left unset.
- Update the Codex plan/progress logs with the latest `.NET` CLI blocking status and the new audit filter behavior.

## Testing
- `dotnet restore yasgmp.sln` *(fails: `dotnet` CLI unavailable in container)*
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj -c Release` *(fails: `dotnet` CLI unavailable in container)*
- `dotnet build yasgmp.csproj -c Release` *(fails: `dotnet` CLI unavailable in container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence).
- [ ] MAUI builds/runs unaffected.
- [ ] Shared AppCore extraction complete where required; adapters compiled.
- [ ] ModulesPane lists every module and opens feature-parity editors.
- [ ] B1 FormModes & command enablement wired across editors.
- [ ] CFL pickers + Golden Arrow navigation working.
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end.
- [ ] Warehouse ledger with running balance and alerts.
- [ ] Audit surfacing + e-signature prompts on critical saves.
- [ ] Attachments DB-backed with upload/preview/download.
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented.
- [ ] Smoke tests succeed and log output.
- [ ] `README_WPF_SHELL.md` and `/docs/WPF_MAPPING.md` kept current.

------
https://chatgpt.com/codex/tasks/task_e_68d6686ffe2c83319106a4d9dab53592