### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.AppCore/DependencyInjection/YasGmpCoreServiceCollectionExtensions.cs
+++ b/YasGMP.AppCore/DependencyInjection/YasGmpCoreServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 using YasGMP.Data;
 
@@ -230,6 +231,29 @@ namespace YasGMP.AppCore.DependencyInjection
             }
 
             return services;
+        }
+    }
+
+    /// <summary>
+    /// Guard helpers that ensure shared YasGMP services are registered with the expected lifetimes.
+    /// </summary>
+    public static class YasGmpCoreServiceGuards
+    {
+        /// <summary>
+        /// Removes any pre-existing registrations for <see cref="AuditService"/> and re-adds it as a singleton.
+        /// </summary>
+        /// <remarks>
+        /// Some hosts accidentally registered <see cref="AuditService"/> multiple times (e.g. transient + singleton).
+        /// This guard normalises the registration so dependents always resolve the singleton instance.
+        /// </remarks>
+        /// <param name="services">Service collection to normalise.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is null.</exception>
+        public static void EnsureAuditServiceSingleton(IServiceCollection services)
+        {
+            if (services is null) throw new ArgumentNullException(nameof(services));
+
+            services.RemoveAll<AuditService>();
+            services.AddSingleton<AuditService>();
         }
     }
 }

--- a/YasGMP.Wpf.Tests/ServiceRegistrationTests.cs
+++ b/YasGMP.Wpf.Tests/ServiceRegistrationTests.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using YasGMP.AppCore.DependencyInjection;
+using YasGMP.Services;
+
+namespace YasGMP.Wpf.Tests;
+
+public class ServiceRegistrationTests
+{
+    [Fact]
+    public void EnsureAuditServiceSingleton_ReplacesPreviousRegistrations()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new DatabaseService("Server=localhost;Database=unit_test;Uid=test;Pwd=test;"));
+        services.AddTransient<AuditService>();
+
+        YasGmpCoreServiceGuards.EnsureAuditServiceSingleton(services);
+
+        var descriptors = services.Where(d => d.ServiceType == typeof(AuditService)).ToList();
+        Assert.Single(descriptors);
+        Assert.Equal(ServiceLifetime.Singleton, descriptors[0].Lifetime);
+
+        using var provider = services.BuildServiceProvider();
+        var first = provider.GetRequiredService<AuditService>();
+        var second = provider.GetRequiredService<AuditService>();
+
+        Assert.Same(first, second);
+    }
+}

--- a/YasGMP.Wpf.Tests/YasGMP.Wpf.Tests.csproj
+++ b/YasGMP.Wpf.Tests/YasGMP.Wpf.Tests.csproj
@@ -10,7 +10,11 @@
     <PackageReference Include="xunit" Version="2.7.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\YasGMP.AppCore\YasGMP.AppCore.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\YasGMP.Wpf\ViewModels\Modules\AssetsModuleViewModel.cs" Link="Wpf\Modules\AssetsModuleViewModel.cs" />

--- a/YasGMP.Wpf/App.xaml.cs
+++ b/YasGMP.Wpf/App.xaml.cs
@@ -43,6 +43,7 @@ namespace YasGMP.Wpf
                         core.UseDatabaseService<DatabaseService>((_, conn) => new DatabaseService(conn));
 
                         var svc = core.Services;
+                        YasGmpCoreServiceGuards.EnsureAuditServiceSingleton(svc);
                         svc.AddSingleton<IUserSession, UserSession>();
                         svc.AddSingleton<IPlatformService, WpfPlatformService>();
                         svc.AddSingleton<IAuthContext, WpfAuthContext>();
@@ -51,7 +52,6 @@ namespace YasGMP.Wpf
                         svc.AddSingleton<IFilePicker, WpfFilePicker>();
                         svc.AddSingleton<IAttachmentService, AttachmentService>();
                         svc.AddSingleton<ICflDialogService, CflDialogService>();
-                        svc.AddSingleton<AuditService>();
                         svc.AddSingleton<IRBACService, RBACService>();
                         svc.AddSingleton<WorkOrderAuditService>();
                         svc.AddTransient<ICapaAuditService, CapaAuditService>();

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -65,6 +65,7 @@
 - 2025-10-15: Audit filters now clamp the start date to midnight, expand the end date to the day's final tick, and auto-swap reversed ranges; WPF coverage verifies date-only `FilterTo` inputs reach the end-of-day timestamp.
 - 2025-10-16: B1 refresh path now pushes counts through `FormatLoadedStatus`, letting Audit override emit zero/singular/plural status text; tests assert the audit-specific messaging via `RefreshAsync`.
 - 2025-10-17: Audit filters now treat null DatePicker inputs as optional bounds, default the end date to the selected start day, and extend it to the day's final tick; WPF unit coverage verifies `LastToFilter` captures the end-of-day timestamp for calendar-only inputs.
+- 2025-10-18: Centralised the WPF host's `AuditService` registration through a guard helper so only the singleton remains; added DI coverage ensuring duplicate registrations are removed before building the provider.
 - Next actionable slice once SDK access is restored: wire Assets attachments + signatures, then replicate CRUD pattern for Components.
 - 2025-09-26: Assets editor now drives MachineService CRUD + validation with mode-aware UI; run smoke harness once SDK restored.
 - 2025-09-27: Components module now surfaces a CRUD-capable editor using ComponentService with machine lookups; attachments/e-signature integration tracked under Batch B2.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -95,6 +95,7 @@
     "2025-10-14: dotnet restore/build retried for MAUI + WPF targets; CLI still missing so commands exit with 'command not found'.",
     "2025-10-15: Audit filters now clamp start/end days, auto-swap reversed ranges, and include WPF coverage for date-only end-of-day normalization.",
     "2025-10-16: B1 refresh now calls FormatLoadedStatus with the loaded count so Audit overrides can emit zero/singular/plural strings; unit tests assert the formatted audit status messages.",
-    "2025-10-17: Audit module date filters now accept null DatePicker inputs, default missing end dates to the start date, and expand the end boundary to the final tick of the day; WPF unit tests verify LastToFilter receives the end-of-day timestamp."
+    "2025-10-17: Audit module date filters now accept null DatePicker inputs, default missing end dates to the start date, and expand the end boundary to the final tick of the day; WPF unit tests verify LastToFilter receives the end-of-day timestamp.",
+    "2025-10-18: WPF host now routes AuditService registration through YasGmpCoreServiceGuards to strip transient duplicates before adding the singleton; DI tests assert duplicate descriptors are removed and the singleton instance is reused."
   ]
 }


### PR DESCRIPTION
## Summary
- normalize AuditService DI by introducing a shared guard that removes redundant registrations before adding the singleton
- update the WPF host to consume the guard so the shell always resolves the singleton instance and add coverage ensuring duplicates are stripped
- document the change in codex plan/progress to capture the new guard and test

## Testing
- `dotnet restore` *(fails: dotnet CLI unavailable in container)*
- `dotnet build yasgmp.sln -c Debug` *(fails: dotnet CLI unavailable in container)*
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj -c Debug` *(fails: dotnet CLI unavailable in container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence) *(blocked: dotnet CLI unavailable in container)*
- [ ] MAUI builds/runs unaffected *(blocked: dotnet CLI unavailable in container)*
- [ ] Shared AppCore extraction complete where required; adapters compiled *(no change this batch)*
- [ ] ModulesPane lists every module and opens feature-parity editors *(no change this batch)*
- [ ] B1 FormModes & command enablement wired across editors *(no change this batch)*
- [ ] CFL pickers + Golden Arrow navigation working *(no change this batch)*
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end *(no change this batch)*
- [ ] Warehouse ledger with running balance and alerts *(no change this batch)*
- [ ] Audit surfacing + e-signature prompts on critical saves *(no change this batch)*
- [ ] Attachments DB-backed with upload/preview/download *(no change this batch)*
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented *(tracked in docs; no change this batch)*
- [ ] Smoke tests succeed and log output *(blocked until dotnet CLI is available)*
- [ ] README_WPF_SHELL.md and /docs/WPF_MAPPING.md kept current *(no change required this batch)*

------
https://chatgpt.com/codex/tasks/task_e_68d66ab086cc83318a148c35b0d6ef28