### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf.Tests/ServiceRegistrationTests.cs
+++ b/YasGMP.Wpf.Tests/ServiceRegistrationTests.cs
@@ -1,8 +1,12 @@
+using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using YasGMP.AppCore.DependencyInjection;
 using YasGMP.Services;
+using YasGMP.Wpf.Services;
+using YasGMP.Wpf.ViewModels.Modules;
 
 namespace YasGMP.Wpf.Tests;
 
@@ -26,5 +30,54 @@ public class ServiceRegistrationTests
         var second = provider.GetRequiredService<AuditService>();
 
         Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void WpfShellServices_ResolveAuditModuleViewModel()
+    {
+        const string connection = "Server=localhost;Database=unit_test;Uid=test;Pwd=test;";
+        var services = new ServiceCollection();
+
+        services.AddYasGmpCoreServices(core =>
+        {
+            core.UseConnectionString(connection);
+            core.UseDatabaseService<DatabaseService>((_, conn) => new DatabaseService(conn));
+
+            var svc = core.Services;
+            YasGmpCoreServiceGuards.EnsureAuditServiceSingleton(svc);
+            svc.AddSingleton<ICflDialogService, StubCflDialogService>();
+            svc.AddSingleton<IShellInteractionService, StubShellInteractionService>();
+            svc.AddSingleton<IModuleNavigationService, StubModuleNavigationService>();
+            svc.AddTransient<AuditModuleViewModel>();
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var descriptors = services.Where(d => d.ServiceType == typeof(AuditService)).ToList();
+        Assert.Single(descriptors);
+        Assert.Equal(ServiceLifetime.Singleton, descriptors[0].Lifetime);
+
+        var viewModel = provider.GetRequiredService<AuditModuleViewModel>();
+        Assert.NotNull(viewModel);
+    }
+
+    private sealed class StubCflDialogService : ICflDialogService
+    {
+        public Task<CflResult?> ShowAsync(CflRequest request) => Task.FromResult<CflResult?>(null);
+    }
+
+    private sealed class StubShellInteractionService : IShellInteractionService
+    {
+        public void UpdateStatus(string message) { }
+
+        public void UpdateInspector(InspectorContext context) { }
+    }
+
+    private sealed class StubModuleNavigationService : IModuleNavigationService
+    {
+        public ModuleDocumentViewModel OpenModule(string moduleKey, object? parameter = null)
+            => throw new NotSupportedException();
+
+        public void Activate(ModuleDocumentViewModel document) { }
     }
 }

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -68,6 +68,7 @@
 - 2025-10-18: Centralised the WPF host's `AuditService` registration through a guard helper so only the singleton remains; added DI coverage ensuring duplicate registrations are removed before building the provider.
 - 2025-10-19: B1 refresh status now pulls from the applied record count so overrides reflect the actual dataset after filtering; audit module retains zero/singular/plural messaging via `FormatLoadedStatus`.
 - 2025-10-20: Audit filters now centralize range normalization so date pickers can be left empty, clamp the start day to midnight, and expand the end day to its final tick; coverage asserts a date-only upper bound reaches the service as an end-of-day timestamp.
+- 2025-10-21: Confirmed the WPF host retains a singleton AuditService registration and added DI coverage ensuring AuditModuleViewModel resolves after the cleanup.
 - Next actionable slice once SDK access is restored: wire Assets attachments + signatures, then replicate CRUD pattern for Components.
 - 2025-09-26: Assets editor now drives MachineService CRUD + validation with mode-aware UI; run smoke harness once SDK restored.
 - 2025-09-27: Components module now surfaces a CRUD-capable editor using ComponentService with machine lookups; attachments/e-signature integration tracked under Batch B2.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -63,7 +63,7 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "fix(audit): normalize date range before querying",
+  "lastCommitSummary": "test(di): ensure audit module resolves after singleton cleanup",
   "notes": [
     "Need to restore/install dotnet 9 SDK to proceed with Batch 0 validation steps.",
     "tests/fixtures/hello.txt seeded for smoke harness bootstrap",
@@ -98,6 +98,7 @@
     "2025-10-17: Audit module date filters now accept null DatePicker inputs, default missing end dates to the start date, and expand the end boundary to the final tick of the day; WPF unit tests verify LastToFilter receives the end-of-day timestamp.",
     "2025-10-18: WPF host now routes AuditService registration through YasGmpCoreServiceGuards to strip transient duplicates before adding the singleton; DI tests assert duplicate descriptors are removed and the singleton instance is reused.",
     "2025-10-19: B1 refresh status messaging now reads from the post-apply record count so overrides (Audit) emit accurate zero/singular/plural strings validated by unit coverage.",
-    "2025-10-20: Audit module date normalization now centralizes range clamping so null DatePicker values fall back gracefully and date-only end bounds reach the service at the day's final tick with new WPF unit coverage."
+    "2025-10-20: Audit module date normalization now centralizes range clamping so null DatePicker values fall back gracefully and date-only end bounds reach the service at the day's final tick with new WPF unit coverage.",
+    "2025-10-21: Confirmed singleton AuditService registration remains in the WPF host and added DI coverage to ensure AuditModuleViewModel resolves after the cleanup."
   ]
 }


### PR DESCRIPTION
## Summary
- Added a WPF service registration test to ensure the AuditService remains singleton-scoped and that AuditModuleViewModel still resolves after the DI cleanup.
- Logged the AuditService registration confirmation and DI coverage in codex_plan.md and codex_progress.json.

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence).
- [ ] MAUI builds/runs unaffected.
- [ ] Shared AppCore extraction complete where required; adapters compiled.
- [ ] ModulesPane lists every module and opens feature-parity editors.
- [ ] B1 FormModes & command enablement wired across editors.
- [ ] CFL pickers + Golden Arrow navigation working.
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end.
- [ ] Warehouse ledger with running balance and alerts.
- [ ] Audit surfacing + e-signature prompts on critical saves.
- [ ] Attachments DB-backed with upload/preview/download.
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented.
- [ ] Smoke tests succeed and log output.
- [ ] `README_WPF_SHELL.md` and `/docs/WPF_MAPPING.md` kept current.


------
https://chatgpt.com/codex/tasks/task_e_68d6758e78688331994feaa3d11663b6