### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
@@ -203,7 +203,7 @@ public sealed partial class AuditModuleViewModel : DataDrivenModuleDocumentViewM
     protected override string FormatLoadedStatus(int count)
         => count switch
         {
-            0 => "No audit entries match the current filters.",
+            <= 0 => "No audit entries match the current filters.",
             1 => "Loaded 1 audit entry.",
             _ => $"Loaded {count} audit entries."
         };

--- a/YasGMP.Wpf/ViewModels/Modules/B1FormDocumentViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/B1FormDocumentViewModel.cs
@@ -173,7 +173,15 @@ public abstract partial class B1FormDocumentViewModel : DocumentViewModel
            || (!string.IsNullOrWhiteSpace(record.Description) && record.Description.Contains(searchText, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>Formats the status message after records have been loaded.</summary>
-    protected virtual string FormatLoadedStatus(int count) => $"Loaded {count} record(s).";
+    protected virtual string FormatLoadedStatus(int count)
+    {
+        if (count < 0)
+        {
+            count = 0;
+        }
+
+        return $"Loaded {count} record(s).";
+    }
 
     partial void OnModeChanged(FormMode value)
     {

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -69,6 +69,7 @@
 - 2025-10-19: B1 refresh status now pulls from the applied record count so overrides reflect the actual dataset after filtering; audit module retains zero/singular/plural messaging via `FormatLoadedStatus`.
 - 2025-10-20: Audit filters now centralize range normalization so date pickers can be left empty, clamp the start day to midnight, and expand the end day to its final tick; coverage asserts a date-only upper bound reaches the service as an end-of-day timestamp.
 - 2025-10-21: Confirmed the WPF host retains a singleton AuditService registration and added DI coverage ensuring AuditModuleViewModel resolves after the cleanup.
+- 2025-10-22: Hardened B1 status formatting to clamp negative counts and kept the Audit override routing zero-or-less results to the empty audit message; unit tests continue to assert the singular/plural/no-result wording via RefreshAsync.
 - Next actionable slice once SDK access is restored: wire Assets attachments + signatures, then replicate CRUD pattern for Components.
 - 2025-09-26: Assets editor now drives MachineService CRUD + validation with mode-aware UI; run smoke harness once SDK restored.
 - 2025-09-27: Components module now surfaces a CRUD-capable editor using ComponentService with machine lookups; attachments/e-signature integration tracked under Batch B2.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -99,6 +99,7 @@
     "2025-10-18: WPF host now routes AuditService registration through YasGmpCoreServiceGuards to strip transient duplicates before adding the singleton; DI tests assert duplicate descriptors are removed and the singleton instance is reused.",
     "2025-10-19: B1 refresh status messaging now reads from the post-apply record count so overrides (Audit) emit accurate zero/singular/plural strings validated by unit coverage.",
     "2025-10-20: Audit module date normalization now centralizes range clamping so null DatePicker values fall back gracefully and date-only end bounds reach the service at the day's final tick with new WPF unit coverage.",
-    "2025-10-21: Confirmed singleton AuditService registration remains in the WPF host and added DI coverage to ensure AuditModuleViewModel resolves after the cleanup."
+    "2025-10-21: Confirmed singleton AuditService registration remains in the WPF host and added DI coverage to ensure AuditModuleViewModel resolves after the cleanup.",
+    "2025-10-22: B1 FormatLoadedStatus now clamps negative counts while the Audit override maps <=0 results to the no-audit message; WPF tests continue to assert the singular/plural/zero wording through RefreshAsync."
   ]
 }


### PR DESCRIPTION
## Summary
- Clamp the base B1 status formatter so negative counts fall back to zero while keeping the default wording.
- Keep the audit override aligned so zero-or-less results emit the empty audit message with the same singular/plural handling.
- Document the status-formatting update in the Codex plan and progress tracking files.

## Testing
- `dotnet restore` *(fails: `dotnet` CLI not available in container PATH)*
- `dotnet build yasgmp.sln` *(fails: `dotnet` CLI not available in container PATH)*
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj -f net9.0-windows10.0.19041.0` *(fails: `dotnet` CLI not available in container PATH)*
- `dotnet build yasgmp.csproj -f net9.0-windows10.0.19041.0` *(fails: `dotnet` CLI not available in container PATH)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence).
- [ ] MAUI builds/runs unaffected.
- [ ] Shared AppCore extraction complete where required; adapters compiled.
- [ ] ModulesPane lists every module and opens feature-parity editors.
- [ ] B1 FormModes & command enablement wired across editors.
- [ ] CFL pickers + Golden Arrow navigation working.
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end.
- [ ] Warehouse ledger with running balance and alerts.
- [ ] Audit surfacing + e-signature prompts on critical saves.
- [ ] Attachments DB-backed with upload/preview/download.
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented.
- [ ] Smoke tests succeed and log output.
- [ ] `README_WPF_SHELL.md` and `/docs/WPF_MAPPING.md` kept current.


------
https://chatgpt.com/codex/tasks/task_e_68d67a89cc8c8331bbd8126981e10922