### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf/Views/AuditModuleView.xaml
+++ b/YasGMP.Wpf/Views/AuditModuleView.xaml
@@ -91,10 +91,21 @@
                     <DataGridTextColumn Header="Device" Binding="{Binding InspectorFields[5].Value}" Width="2*" />
                     <DataGridTextColumn Header="Digital Signature" Binding="{Binding InspectorFields[7].Value}" Width="200" />
                     <DataGridTextColumn Header="Signature Hash" Binding="{Binding InspectorFields[8].Value}" Width="200" />
-                    <DataGridTextColumn Header="Note" Binding="{Binding Description}" Width="2*" />
+                    <DataGridTextColumn Header="Reason" Binding="{Binding Description}" Width="2*" />
                 </DataGrid.Columns>
             </DataGrid>
-            <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" FontStyle="Italic" Foreground="Gray" Margin="0,8,0,0" />
+            <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" FontStyle="Italic" Margin="0,8,0,0">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="Foreground" Value="Gray" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding HasError}" Value="True">
+                                <Setter Property="Foreground" Value="Firebrick" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
         </Grid>
     </DockPanel>
 </UserControl>

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -29,7 +29,7 @@
   - Scheduled Jobs — [x] done *(mode-aware editor with execute/acknowledge tooling and attachment workflow; signature/audit surfacing tracked under Batch B2)*
   - Users/Roles — [x] done *(Security module now exposes a CRUD-capable user/role editor with CFL, toolbar modes, and role assignment management; signature prompts queued for Batch B2)*
   - Suppliers/External Servicers — [x] done *(Suppliers module ships with attachments + CFL; External Servicers cockpit now live with mode-aware CRUD and navigation)*
-  - Audit/API Audit — [~] in-progress *(WPF audit trail now pulls filtered entries via AuditService with expanded inspector grid and filters.)*
+  - Audit/API Audit — [~] in-progress *(WPF audit trail now pulls filtered entries via AuditService with expanded inspector grid, filters, and explicit empty/error status flags.)*
   - Documents/Attachments — [ ] todo
   - Dashboard/Reports — [ ] todo
   - Settings/Admin — [ ] todo
@@ -72,6 +72,7 @@
 - 2025-10-22: Hardened B1 status formatting to clamp negative counts and kept the Audit override routing zero-or-less results to the empty audit message; unit tests continue to assert the singular/plural/no-result wording via RefreshAsync.
 - 2025-10-23: Audit filters now normalize nullable DatePicker inputs with unspecified kinds, persisting sanitized start/end dates in the view-model while expanding the service-bound end date to the day's final tick; `dotnet --info`/restore/build attempts still fail because the CLI remains unavailable in the container.
 - 2025-10-24: WPF host now registers `AuditService` directly as a singleton (removing the stray transient), and DI coverage confirms `AuditModuleViewModel` resolves with the singleton; `dotnet restore`/`dotnet build` retries continue to fail with **command not found** until the SDK is installed.
+- 2025-10-25: Audit module now surfaces HasResults/HasError flags, highlights offline/error status text in the view, and relabels the inspector reason column; `dotnet` CLI is still unavailable so restore/build attempts continue to fail.
 - Next actionable slice once SDK access is restored: wire Assets attachments + signatures, then replicate CRUD pattern for Components.
 - 2025-09-26: Assets editor now drives MachineService CRUD + validation with mode-aware UI; run smoke harness once SDK restored.
 - 2025-09-27: Components module now surfaces a CRUD-capable editor using ComponentService with machine lookups; attachments/e-signature integration tracked under Batch B2.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -103,6 +103,7 @@
     "2025-10-21: Confirmed singleton AuditService registration remains in the WPF host and added DI coverage to ensure AuditModuleViewModel resolves after the cleanup.",
     "2025-10-22: B1 FormatLoadedStatus now clamps negative counts while the Audit override maps <=0 results to the no-audit message; WPF tests continue to assert the singular/plural/zero wording through RefreshAsync.",
     "2025-10-23: Audit module now normalizes nullable DatePicker inputs (including DateTimeKind.Unspecified) before querying AuditService, persists sanitized filter values, and remains blocked on dotnet restore/build due to the missing CLI.",
-    "2025-10-24: WPF host now registers AuditService as a singleton directly (removing the transient duplicate) and DI tests confirm AuditModuleViewModel resolves; dotnet restore/build retries still fail with 'command not found'."
+    "2025-10-24: WPF host now registers AuditService as a singleton directly (removing the transient duplicate) and DI tests confirm AuditModuleViewModel resolves; dotnet restore/build retries still fail with 'command not found'.",
+    "2025-10-25: Audit module now tracks HasResults/HasError flags, applies error highlighting in the view, and renames the inspector reason column; dotnet CLI remains unavailable so restore/build stay blocked."
   ]
 }


### PR DESCRIPTION
## Summary
- add audit-module flags for empty/error states while continuing to query AuditService with the filter inputs
- update the audit view with the reason column and error-aware status styling
- extend WPF unit coverage for audit data plus fallback scenarios and refresh plan/progress docs

## Testing
- dotnet restore *(fails: `dotnet` CLI not available in container)*
- dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj *(fails: `dotnet` CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d68555ebac8331baf1793d52f3b84c