### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf.Tests/AuditModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/AuditModuleViewModelTests.cs
@@ -194,6 +194,28 @@ public class AuditModuleViewModelTests
     }
 
     [Fact]
+    public async Task RefreshAsync_FilterToBeforeFilterFrom_PreservesUpperBound()
+    {
+        var database = CreateDatabaseService();
+        var auditService = new AuditService(database);
+        var cfl = new StubCflDialogService();
+        var shell = new StubShellInteractionService();
+        var navigation = new StubModuleNavigationService();
+
+        var viewModel = new TestAuditModuleViewModel(database, auditService, cfl, shell, navigation, Array.Empty<AuditEntryDto>());
+        viewModel.FilterFrom = new DateTime(2025, 5, 10, 10, 30, 0);
+        viewModel.FilterTo = new DateTime(2025, 5, 1);
+
+        await viewModel.RefreshAsync();
+
+        Assert.Equal(new DateTime(2025, 5, 10), viewModel.FilterFrom!.Value);
+        Assert.Equal(new DateTime(2025, 5, 1), viewModel.FilterTo!.Value);
+        Assert.Equal(new DateTime(2025, 5, 1), viewModel.LastFromFilter);
+        Assert.Equal(new DateTime(2025, 5, 1).Date.AddDays(1).AddTicks(-1), viewModel.LastToFilter);
+        Assert.True(viewModel.LastFromFilter <= viewModel.LastToFilter);
+    }
+
+    [Fact]
     public async Task RefreshAsync_FilterToUnset_DefaultsToFilterFromEndOfDay()
     {
         var database = CreateDatabaseService();

--- a/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
@@ -145,18 +145,19 @@ public sealed partial class AuditModuleViewModel : DataDrivenModuleDocumentViewM
     {
         var today = DateTime.Today;
 
-        var normalizedFrom = (from?.Date ?? today.AddDays(-30));
+        var normalizedFrom = from?.Date ?? today.AddDays(-30);
         var normalizedToCandidate = to?.Date
             ?? (from.HasValue ? normalizedFrom : today);
 
-        if (normalizedToCandidate < normalizedFrom)
+        var queryTo = normalizedToCandidate.Date.AddDays(1).AddTicks(-1);
+        var queryFrom = normalizedFrom;
+
+        if (queryFrom > queryTo)
         {
-            (normalizedFrom, normalizedToCandidate) = (normalizedToCandidate, normalizedFrom);
+            queryFrom = normalizedToCandidate.Date;
         }
 
-        var normalizedTo = normalizedToCandidate.Date.AddDays(1).AddTicks(-1);
-
-        return (normalizedFrom, normalizedTo, normalizedFrom, normalizedToCandidate);
+        return (queryFrom, queryTo, normalizedFrom, normalizedToCandidate);
     }
 
     protected override bool MatchesSearch(ModuleRecord record, string searchText)

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -73,6 +73,7 @@
 - 2025-10-23: Audit filters now normalize nullable DatePicker inputs with unspecified kinds, persisting sanitized start/end dates in the view-model while expanding the service-bound end date to the day's final tick; `dotnet --info`/restore/build attempts still fail because the CLI remains unavailable in the container.
 - 2025-10-24: WPF host now registers `AuditService` directly as a singleton (removing the stray transient), and DI coverage confirms `AuditModuleViewModel` resolves with the singleton; `dotnet restore`/`dotnet build` retries continue to fail with **command not found** until the SDK is installed.
 - 2025-10-25: Audit module now surfaces HasResults/HasError flags, highlights offline/error status text in the view, and relabels the inspector reason column; `dotnet` CLI is still unavailable so restore/build attempts continue to fail.
+- 2025-10-26: Audit filters now preserve the user-selected end date even when it predates the start picker, clamping the query's start bound to the chosen end day and covering the regression with WPF tests.
 - Next actionable slice once SDK access is restored: wire Assets attachments + signatures, then replicate CRUD pattern for Components.
 - 2025-09-26: Assets editor now drives MachineService CRUD + validation with mode-aware UI; run smoke harness once SDK restored.
 - 2025-09-27: Components module now surfaces a CRUD-capable editor using ComponentService with machine lookups; attachments/e-signature integration tracked under Batch B2.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -104,6 +104,7 @@
     "2025-10-22: B1 FormatLoadedStatus now clamps negative counts while the Audit override maps <=0 results to the no-audit message; WPF tests continue to assert the singular/plural/zero wording through RefreshAsync.",
     "2025-10-23: Audit module now normalizes nullable DatePicker inputs (including DateTimeKind.Unspecified) before querying AuditService, persists sanitized filter values, and remains blocked on dotnet restore/build due to the missing CLI.",
     "2025-10-24: WPF host now registers AuditService as a singleton directly (removing the transient duplicate) and DI tests confirm AuditModuleViewModel resolves; dotnet restore/build retries still fail with 'command not found'.",
-    "2025-10-25: Audit module now tracks HasResults/HasError flags, applies error highlighting in the view, and renames the inspector reason column; dotnet CLI remains unavailable so restore/build stay blocked."
+    "2025-10-25: Audit module now tracks HasResults/HasError flags, applies error highlighting in the view, and renames the inspector reason column; dotnet CLI remains unavailable so restore/build stay blocked.",
+    "2025-10-26: Audit filters now preserve a user-specified end date even when it predates the start picker by clamping the service query's start bound to that day and adding WPF regression coverage for the upper-bound behavior."
   ]
 }


### PR DESCRIPTION
## Summary
- keep the audit module’s date normalization from swapping the user-selected end date while still clamping the query range
- add a regression test that verifies reversed date pickers honor the `FilterTo` upper bound when querying the audit service
- document the preserved upper-bound behavior in the running plan/progress trackers

## Testing
- dotnet test YasGMP.Wpf.Tests/YasGMP.Wpf.Tests.csproj *(fails: `dotnet` CLI is unavailable in the container PATH)*

## Acceptance Checklist
- [ ] WPF project builds/runs (blocked: `dotnet` CLI unavailable in container)
- [ ] MAUI builds/runs unaffected (blocked: `dotnet` CLI unavailable in container)
- [ ] Smoke tests executed (blocked: `dotnet` CLI unavailable in container)
- [x] Audit surfacing updated with preserved filter upper bound regression coverage

------
https://chatgpt.com/codex/tasks/task_e_68d68af465148331961d94b4be618ab8