### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf.Tests/AuditModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/AuditModuleViewModelTests.cs
@@ -209,8 +209,9 @@ public class AuditModuleViewModelTests
         await viewModel.RefreshAsync();
 
         var expectedUpperBound = new DateTime(2025, 5, 1);
+        var expectedFrom = new DateTime(2025, 5, 10);
+        Assert.Equal(expectedFrom, viewModel.FilterFrom!.Value);
         Assert.Equal(expectedUpperBound, viewModel.FilterTo!.Value);
-        Assert.Equal(expectedUpperBound, viewModel.FilterFrom!.Value);
         Assert.Equal(expectedUpperBound, viewModel.LastFromFilter);
         Assert.Equal(expectedUpperBound.Date.AddDays(1).AddTicks(-1), viewModel.LastToFilter);
         Assert.True(viewModel.LastFromFilter <= viewModel.LastToFilter);
@@ -237,10 +238,35 @@ public class AuditModuleViewModelTests
         await viewModel.RefreshAsync();
 
         var expectedUpperBound = new DateTime(2025, 7, 20);
+        var expectedFrom = new DateTime(2025, 8, 10);
+        Assert.Equal(expectedFrom, viewModel.FilterFrom!.Value);
         Assert.Equal(expectedUpperBound, viewModel.FilterTo!.Value);
-        Assert.Equal(expectedUpperBound, viewModel.FilterFrom!.Value);
         Assert.Equal(expectedUpperBound, viewModel.LastFromFilter);
         Assert.Equal(expectedUpperBound.Date.AddDays(1).AddTicks(-1), viewModel.LastToFilter);
+        Assert.True(viewModel.LastFromFilter <= viewModel.LastToFilter);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_DefaultFilterFrom_SetEarlierFilterTo_PreservesUpperBound()
+    {
+        var database = CreateDatabaseService();
+        var auditService = new AuditService(database);
+        var cfl = new StubCflDialogService();
+        var shell = new StubShellInteractionService();
+        var navigation = new StubModuleNavigationService();
+
+        var viewModel = new TestAuditModuleViewModel(database, auditService, cfl, shell, navigation, Array.Empty<AuditEntryDto>());
+
+        var originalFrom = viewModel.FilterFrom!.Value.Date;
+        var earlierUpperBound = originalFrom.AddDays(-5);
+        viewModel.FilterTo = earlierUpperBound;
+
+        await viewModel.RefreshAsync();
+
+        Assert.Equal(originalFrom, viewModel.FilterFrom!.Value);
+        Assert.Equal(earlierUpperBound, viewModel.FilterTo!.Value);
+        Assert.Equal(earlierUpperBound, viewModel.LastFromFilter);
+        Assert.Equal(earlierUpperBound.Date.AddDays(1).AddTicks(-1), viewModel.LastToFilter);
         Assert.True(viewModel.LastFromFilter <= viewModel.LastToFilter);
     }
 

--- a/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
@@ -146,18 +146,18 @@ public sealed partial class AuditModuleViewModel : DataDrivenModuleDocumentViewM
         var today = DateTime.Today;
 
         var normalizedFrom = from?.Date ?? today.AddDays(-30);
-        var normalizedToCandidate = to?.Date
+        var normalizedTo = to?.Date
             ?? (from.HasValue ? normalizedFrom : today);
 
-        var effectiveFilterTo = normalizedToCandidate;
-        var effectiveFilterFrom = normalizedFrom > effectiveFilterTo
-            ? effectiveFilterTo
-            : normalizedFrom;
+        var queryFrom = normalizedFrom;
+        if (normalizedFrom > normalizedTo)
+        {
+            queryFrom = normalizedTo;
+        }
 
-        var queryFrom = effectiveFilterFrom;
-        var queryTo = effectiveFilterTo.Date.AddDays(1).AddTicks(-1);
+        var queryTo = normalizedTo.Date.AddDays(1).AddTicks(-1);
 
-        return (queryFrom, queryTo, effectiveFilterFrom, effectiveFilterTo);
+        return (queryFrom, queryTo, normalizedFrom, normalizedTo);
     }
 
     protected override bool MatchesSearch(ModuleRecord record, string searchText)

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -75,6 +75,7 @@
 - 2025-10-25: Audit module now surfaces HasResults/HasError flags, highlights offline/error status text in the view, and relabels the inspector reason column; `dotnet` CLI is still unavailable so restore/build attempts continue to fail.
 - 2025-10-26: Audit filters now preserve the user-selected end date even when it predates the start picker, clamping the query's start bound to the chosen end day and covering the regression with WPF tests.
 - 2025-10-27: Audit filters now clamp the lower bound when the upper bound is moved earlier while preserving the user's selected end day; WPF regression coverage verifies both persisted filters and query arguments.
+- 2025-10-28: Audit filters now keep the user's "To" picker intact while ordering the query bounds when the upper date precedes the lower; WPF coverage adds a default-from regression asserting the service respects the earlier upper bound.
 - Next actionable slice once SDK access is restored: wire Assets attachments + signatures, then replicate CRUD pattern for Components.
 - 2025-09-26: Assets editor now drives MachineService CRUD + validation with mode-aware UI; run smoke harness once SDK restored.
 - 2025-09-27: Components module now surfaces a CRUD-capable editor using ComponentService with machine lookups; attachments/e-signature integration tracked under Batch B2.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -65,7 +65,7 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "test: clamp audit filters to user-selected upper bounds",
+  "lastCommitSummary": "fix: preserve audit upper bounds when ordering queries",
   "notes": [
     "Need to restore/install dotnet 9 SDK to proceed with Batch 0 validation steps.",
     "tests/fixtures/hello.txt seeded for smoke harness bootstrap",
@@ -107,6 +107,7 @@
     "2025-10-24: WPF host now registers AuditService as a singleton directly (removing the transient duplicate) and DI tests confirm AuditModuleViewModel resolves; dotnet restore/build retries still fail with 'command not found'.",
     "2025-10-25: Audit module now tracks HasResults/HasError flags, applies error highlighting in the view, and renames the inspector reason column; dotnet CLI remains unavailable so restore/build stay blocked.",
     "2025-10-26: Audit filters now preserve a user-specified end date even when it predates the start picker by clamping the service query's start bound to that day and adding WPF regression coverage for the upper-bound behavior.",
-    "2025-10-27: Audit filters now clamp the lower bound when the upper bound is moved earlier while keeping the selected end date intact; new WPF regression test ensures persisted filters and query arguments align."
+    "2025-10-27: Audit filters now clamp the lower bound when the upper bound is moved earlier while keeping the selected end date intact; new WPF regression test ensures persisted filters and query arguments align.",
+    "2025-10-28: Audit filters now retain the user's To picker while reordering the query bounds if the upper date precedes the lower; tests cover both existing From overrides and default-from scenarios."
   ]
 }


### PR DESCRIPTION
## Summary
- keep the audit module's date normalization from rewriting the user's To picker while still ordering the query bounds when the upper date precedes the lower
- extend the WPF audit view-model tests to cover the preserved To selection and the default-from scenario
- document the regression coverage and range-ordering work in the Codex plan/progress trackers

## Testing
- `dotnet restore` *(fails: command not found in container)*
- `dotnet build yasgmp.sln -c Debug -f net9.0-windows10.0.19041.0` *(fails: command not found in container)*
- `dotnet build yasgmp.sln -c Debug -f net9.0-windows10.0.19041.0` *(fails: command not found in container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence).
- [ ] MAUI builds/runs unaffected.
- [ ] Shared AppCore extraction complete where required; adapters compiled.
- [ ] ModulesPane lists every module and opens feature-parity editors.
- [ ] B1 FormModes & command enablement wired across editors.
- [ ] CFL pickers + Golden Arrow navigation working.
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end.
- [ ] Warehouse ledger with running balance and alerts.
- [ ] Audit surfacing + e-signature prompts on critical saves.
- [ ] Attachments DB-backed with upload/preview/download.
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented.
- [ ] Smoke tests succeed and log output.
- [ ] `README_WPF_SHELL.md` and `/docs/WPF_MAPPING.md` kept current.

------
https://chatgpt.com/codex/tasks/task_e_68da152f01308331912c22bf4e73ff42