### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf.Tests/AuditModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/AuditModuleViewModelTests.cs
@@ -194,7 +194,7 @@ public class AuditModuleViewModelTests
     }
 
     [Fact]
-    public async Task RefreshAsync_FilterToBeforeFilterFrom_ClampsLowerBoundToUpperBound()
+    public async Task RefreshAsync_FilterToBeforeFilterFrom_QueriesAcrossFullRange()
     {
         var database = CreateDatabaseService();
         var auditService = new AuditService(database);
@@ -203,17 +203,20 @@ public class AuditModuleViewModelTests
         var navigation = new StubModuleNavigationService();
 
         var viewModel = new TestAuditModuleViewModel(database, auditService, cfl, shell, navigation, Array.Empty<AuditEntryDto>());
-        viewModel.FilterFrom = new DateTime(2025, 5, 10, 10, 30, 0);
-        viewModel.FilterTo = new DateTime(2025, 5, 1);
+        var later = new DateTime(2025, 5, 10, 10, 30, 0);
+        var earlier = new DateTime(2025, 5, 1);
+        viewModel.FilterFrom = later;
+        viewModel.FilterTo = earlier;
 
         await viewModel.RefreshAsync();
 
-        var expectedUpperBound = new DateTime(2025, 5, 1);
-        var expectedFrom = new DateTime(2025, 5, 10);
-        Assert.Equal(expectedFrom, viewModel.FilterFrom!.Value);
-        Assert.Equal(expectedUpperBound, viewModel.FilterTo!.Value);
-        Assert.Equal(expectedUpperBound, viewModel.LastFromFilter);
-        Assert.Equal(expectedUpperBound.Date.AddDays(1).AddTicks(-1), viewModel.LastToFilter);
+        var normalizedLater = later.Date;
+        var normalizedEarlier = earlier.Date;
+
+        Assert.Equal(normalizedLater, viewModel.FilterFrom!.Value);
+        Assert.Equal(normalizedEarlier, viewModel.FilterTo!.Value);
+        Assert.Equal(normalizedEarlier, viewModel.LastFromFilter);
+        Assert.Equal(normalizedLater.Date.AddDays(1).AddTicks(-1), viewModel.LastToFilter);
         Assert.True(viewModel.LastFromFilter <= viewModel.LastToFilter);
     }
 
@@ -227,22 +230,26 @@ public class AuditModuleViewModelTests
         var navigation = new StubModuleNavigationService();
 
         var viewModel = new TestAuditModuleViewModel(database, auditService, cfl, shell, navigation, Array.Empty<AuditEntryDto>());
-        viewModel.FilterFrom = new DateTime(2025, 8, 10, 8, 30, 0);
-        viewModel.FilterTo = new DateTime(2025, 8, 5);
+        var later = new DateTime(2025, 8, 10, 8, 30, 0);
+        var earlier = new DateTime(2025, 8, 5);
+        viewModel.FilterFrom = later;
+        viewModel.FilterTo = earlier;
 
         await viewModel.RefreshAsync();
 
         // User adjusts only the upper bound to an even earlier day without touching FilterFrom.
-        viewModel.FilterTo = new DateTime(2025, 7, 20);
+        var evenEarlier = new DateTime(2025, 7, 20);
+        viewModel.FilterTo = evenEarlier;
 
         await viewModel.RefreshAsync();
 
-        var expectedUpperBound = new DateTime(2025, 7, 20);
-        var expectedFrom = new DateTime(2025, 8, 10);
-        Assert.Equal(expectedFrom, viewModel.FilterFrom!.Value);
-        Assert.Equal(expectedUpperBound, viewModel.FilterTo!.Value);
-        Assert.Equal(expectedUpperBound, viewModel.LastFromFilter);
-        Assert.Equal(expectedUpperBound.Date.AddDays(1).AddTicks(-1), viewModel.LastToFilter);
+        var normalizedLater = later.Date;
+        var normalizedEvenEarlier = evenEarlier.Date;
+
+        Assert.Equal(normalizedLater, viewModel.FilterFrom!.Value);
+        Assert.Equal(normalizedEvenEarlier, viewModel.FilterTo!.Value);
+        Assert.Equal(normalizedEvenEarlier, viewModel.LastFromFilter);
+        Assert.Equal(normalizedLater.Date.AddDays(1).AddTicks(-1), viewModel.LastToFilter);
         Assert.True(viewModel.LastFromFilter <= viewModel.LastToFilter);
     }
 
@@ -266,7 +273,7 @@ public class AuditModuleViewModelTests
         Assert.Equal(originalFrom, viewModel.FilterFrom!.Value);
         Assert.Equal(earlierUpperBound, viewModel.FilterTo!.Value);
         Assert.Equal(earlierUpperBound, viewModel.LastFromFilter);
-        Assert.Equal(earlierUpperBound.Date.AddDays(1).AddTicks(-1), viewModel.LastToFilter);
+        Assert.Equal(originalFrom.AddDays(1).AddTicks(-1), viewModel.LastToFilter);
         Assert.True(viewModel.LastFromFilter <= viewModel.LastToFilter);
     }
 

--- a/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
@@ -149,13 +149,11 @@ public sealed partial class AuditModuleViewModel : DataDrivenModuleDocumentViewM
         var normalizedTo = to?.Date
             ?? (from.HasValue ? normalizedFrom : today);
 
-        var queryFrom = normalizedFrom;
-        if (normalizedFrom > normalizedTo)
-        {
-            queryFrom = normalizedTo;
-        }
+        var earlier = normalizedFrom <= normalizedTo ? normalizedFrom : normalizedTo;
+        var later = normalizedFrom >= normalizedTo ? normalizedFrom : normalizedTo;
 
-        var queryTo = normalizedTo.Date.AddDays(1).AddTicks(-1);
+        var queryFrom = earlier;
+        var queryTo = later.Date.AddDays(1).AddTicks(-1);
 
         return (queryFrom, queryTo, normalizedFrom, normalizedTo);
     }

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -76,6 +76,7 @@
 - 2025-10-26: Audit filters now preserve the user-selected end date even when it predates the start picker, clamping the query's start bound to the chosen end day and covering the regression with WPF tests.
 - 2025-10-27: Audit filters now clamp the lower bound when the upper bound is moved earlier while preserving the user's selected end day; WPF regression coverage verifies both persisted filters and query arguments.
 - 2025-10-28: Audit filters now keep the user's "To" picker intact while ordering the query bounds when the upper date precedes the lower; WPF coverage adds a default-from regression asserting the service respects the earlier upper bound.
+- 2025-10-29: Audit filters now order query bounds by min/max so inverted ranges still span the full window while preserving the user's "To" picker; WPF regression coverage asserts the service receives the later bound's end-of-day timestamp.
 - Next actionable slice once SDK access is restored: wire Assets attachments + signatures, then replicate CRUD pattern for Components.
 - 2025-09-26: Assets editor now drives MachineService CRUD + validation with mode-aware UI; run smoke harness once SDK restored.
 - 2025-09-27: Components module now surfaces a CRUD-capable editor using ComponentService with machine lookups; attachments/e-signature integration tracked under Batch B2.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -65,7 +65,7 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "fix: preserve audit upper bounds when ordering queries",
+  "lastCommitSummary": "fix: order audit query bounds while preserving filters",
   "notes": [
     "Need to restore/install dotnet 9 SDK to proceed with Batch 0 validation steps.",
     "tests/fixtures/hello.txt seeded for smoke harness bootstrap",
@@ -108,6 +108,7 @@
     "2025-10-25: Audit module now tracks HasResults/HasError flags, applies error highlighting in the view, and renames the inspector reason column; dotnet CLI remains unavailable so restore/build stay blocked.",
     "2025-10-26: Audit filters now preserve a user-specified end date even when it predates the start picker by clamping the service query's start bound to that day and adding WPF regression coverage for the upper-bound behavior.",
     "2025-10-27: Audit filters now clamp the lower bound when the upper bound is moved earlier while keeping the selected end date intact; new WPF regression test ensures persisted filters and query arguments align.",
-    "2025-10-28: Audit filters now retain the user's To picker while reordering the query bounds if the upper date precedes the lower; tests cover both existing From overrides and default-from scenarios."
+    "2025-10-28: Audit filters now retain the user's To picker while reordering the query bounds if the upper date precedes the lower; tests cover both existing From overrides and default-from scenarios.",
+    "2025-10-29: Audit module now orders inverted date ranges by min/max while preserving the user-selected To value; WPF tests assert the later bound reaches AuditService at end-of-day."
   ]
 }


### PR DESCRIPTION
## Summary
- order the audit query bounds via min/max so inverted ranges expand to the full window while the UI keeps the user-selected dates
- update the AuditModuleViewModel WPF tests to assert the later bound feeds the service at end-of-day and that both filters persist
- record the regression fix in codex_plan.md and codex_progress.json

## Testing
- `dotnet restore yasgmp.sln` *(fails: dotnet CLI is not installed in the container)*
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj` *(fails: dotnet CLI is not installed in the container)*
- `dotnet test YasGMP.Wpf.Tests/YasGMP.Wpf.Tests.csproj --filter AuditModuleViewModelTests` *(fails: dotnet CLI is not installed in the container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence) *(blocked: dotnet CLI missing in container)*
- [ ] MAUI builds/runs unaffected *(blocked: dotnet CLI missing in container)*
- [ ] Shared AppCore extraction complete where required; adapters compiled *(blocked: dotnet CLI missing in container)*
- [ ] ModulesPane lists every module and opens feature-parity editors *(blocked: awaiting full build/test pass)*
- [ ] B1 FormModes & command enablement wired across editors *(status unchanged in this batch)*
- [ ] CFL pickers + Golden Arrow navigation working *(status unchanged in this batch)*
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end *(status unchanged in this batch)*
- [ ] Warehouse ledger with running balance and alerts *(status unchanged in this batch)*
- [ ] Audit surfacing + e-signature prompts on critical saves *(status unchanged in this batch)*
- [ ] Attachments DB-backed with upload/preview/download *(status unchanged in this batch)*
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented *(status unchanged in this batch)*
- [ ] Smoke tests succeed and log output *(blocked: dotnet CLI missing in container)*
- [ ] README_WPF_SHELL.md and /docs/WPF_MAPPING.md kept current *(status unchanged in this batch)*

------
https://chatgpt.com/codex/tasks/task_e_68da177addcc833185b77cfe330ea527