### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf/App.xaml.cs
+++ b/YasGMP.Wpf/App.xaml.cs
@@ -51,6 +51,7 @@ namespace YasGMP.Wpf
                         svc.AddSingleton<IDialogService, WpfDialogService>();
                         svc.AddSingleton<IFilePicker, WpfFilePicker>();
                         svc.AddSingleton<IAttachmentService, AttachmentService>();
+                        svc.AddSingleton<IAttachmentWorkflowService, AttachmentWorkflowService>();
                         svc.AddSingleton<ICflDialogService, CflDialogService>();
                         svc.AddSingleton<IRBACService, RBACService>();
                         svc.AddSingleton<WorkOrderAuditService>();

--- a/YasGMP.Wpf/Services/AttachmentStatusFormatter.cs
+++ b/YasGMP.Wpf/Services/AttachmentStatusFormatter.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace YasGMP.Wpf.Services;
+
+/// <summary>
+/// Shared helper that produces consistent status messages for attachment uploads.
+/// </summary>
+public static class AttachmentStatusFormatter
+{
+    public static string Format(int processed, int deduplicated)
+    {
+        if (processed <= 0)
+        {
+            return "No attachments were processed.";
+        }
+
+        if (processed == 1)
+        {
+            return deduplicated == 1
+                ? "Linked existing attachment (deduplicated)."
+                : "Attachment uploaded successfully.";
+        }
+
+        if (deduplicated == 0)
+        {
+            return $"Uploaded {processed} attachments successfully.";
+        }
+
+        if (deduplicated == processed)
+        {
+            return $"Linked {processed} existing attachments (deduplicated).";
+        }
+
+        var newCount = processed - deduplicated;
+        return $"Processed {processed} attachments ({newCount} new, {deduplicated} deduplicated).";
+    }
+}

--- a/YasGMP.Wpf/Services/AttachmentWorkflowService.cs
+++ b/YasGMP.Wpf/Services/AttachmentWorkflowService.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Services.Interfaces;
+
+namespace YasGMP.Wpf.Services;
+
+/// <summary>
+/// Provides a WPF-friendly workflow facade for attachment operations that mirrors the MAUI behaviour.
+/// </summary>
+public interface IAttachmentWorkflowService
+{
+    /// <summary>Indicates whether envelope encryption is currently enabled.</summary>
+    bool IsEncryptionEnabled { get; }
+
+    /// <summary>Logical key identifier used when encryption is active.</summary>
+    string EncryptionKeyId { get; }
+
+    /// <summary>
+    /// Uploads an attachment, applying deduplication, retention persistence and audit logging.
+    /// Returns metadata about the processed attachment and deduplication outcome.
+    /// </summary>
+    Task<AttachmentWorkflowUploadResult> UploadAsync(Stream content, AttachmentUploadRequest request, CancellationToken token = default);
+
+    /// <summary>Streams an attachment to the provided destination stream.</summary>
+    Task<AttachmentStreamResult> DownloadAsync(int attachmentId, Stream destination, AttachmentReadRequest? request = null, CancellationToken token = default);
+
+    /// <summary>Loads attachment links for the specified entity.</summary>
+    Task<IReadOnlyList<AttachmentLinkWithAttachment>> GetLinksForEntityAsync(string entityType, int entityId, CancellationToken token = default);
+
+    /// <summary>Returns attachment rows projected through the legacy helper for browse screens.</summary>
+    Task<IReadOnlyList<Attachment>> GetAttachmentSummariesAsync(string? entityFilter, string? typeFilter, string? searchTerm, CancellationToken token = default);
+
+    /// <summary>Removes a persisted link by its primary key.</summary>
+    Task RemoveLinkAsync(int linkId, CancellationToken token = default);
+
+    /// <summary>Removes a persisted link by tuple.</summary>
+    Task RemoveLinkAsync(string entityType, int entityId, int attachmentId, CancellationToken token = default);
+
+    /// <summary>Looks up an attachment by hash.</summary>
+    Task<Attachment?> FindByHashAsync(string sha256, CancellationToken token = default);
+
+    /// <summary>Looks up an attachment by hash and size.</summary>
+    Task<Attachment?> FindByHashAndSizeAsync(string sha256, long fileSize, CancellationToken token = default);
+}
+
+/// <summary>
+/// Concrete workflow that composes the EF-backed attachment service with legacy DatabaseService helpers.
+/// </summary>
+public sealed class AttachmentWorkflowService : IAttachmentWorkflowService
+{
+    private readonly IAttachmentService _attachmentService;
+    private readonly DatabaseService _databaseService;
+    private readonly AttachmentEncryptionOptions _encryptionOptions;
+
+    public AttachmentWorkflowService(
+        IAttachmentService attachmentService,
+        DatabaseService databaseService,
+        AttachmentEncryptionOptions encryptionOptions)
+    {
+        _attachmentService = attachmentService ?? throw new ArgumentNullException(nameof(attachmentService));
+        _databaseService = databaseService ?? throw new ArgumentNullException(nameof(databaseService));
+        _encryptionOptions = encryptionOptions ?? throw new ArgumentNullException(nameof(encryptionOptions));
+    }
+
+    public bool IsEncryptionEnabled => !string.IsNullOrWhiteSpace(_encryptionOptions.KeyMaterial);
+
+    public string EncryptionKeyId => string.IsNullOrWhiteSpace(_encryptionOptions.KeyId)
+        ? "default"
+        : _encryptionOptions.KeyId!;
+
+    public async Task<AttachmentWorkflowUploadResult> UploadAsync(Stream content, AttachmentUploadRequest request, CancellationToken token = default)
+    {
+        if (content is null) throw new ArgumentNullException(nameof(content));
+        if (request is null) throw new ArgumentNullException(nameof(request));
+
+        await using var prepared = await PrepareStreamAsync(content, token).ConfigureAwait(false);
+        Attachment? existing = null;
+        if (!string.IsNullOrWhiteSpace(prepared.Hash))
+        {
+            existing = await _attachmentService
+                .FindByHashAndSizeAsync(prepared.Hash, prepared.Length, token)
+                .ConfigureAwait(false);
+        }
+
+        var upload = await _attachmentService
+            .UploadAsync(prepared.Stream, request, token)
+            .ConfigureAwait(false);
+
+        bool deduplicated = existing is not null && upload.Attachment.Id == existing.Id;
+
+        return new AttachmentWorkflowUploadResult(upload, prepared.Hash, prepared.Length, deduplicated, existing);
+    }
+
+    public Task<AttachmentStreamResult> DownloadAsync(int attachmentId, Stream destination, AttachmentReadRequest? request = null, CancellationToken token = default)
+    {
+        if (destination is null) throw new ArgumentNullException(nameof(destination));
+        return _attachmentService.StreamContentAsync(attachmentId, destination, request, token);
+    }
+
+    public Task<IReadOnlyList<AttachmentLinkWithAttachment>> GetLinksForEntityAsync(string entityType, int entityId, CancellationToken token = default)
+        => _attachmentService.GetLinksForEntityAsync(entityType, entityId, token);
+
+    public async Task<IReadOnlyList<Attachment>> GetAttachmentSummariesAsync(string? entityFilter, string? typeFilter, string? searchTerm, CancellationToken token = default)
+    {
+        var rows = await _databaseService
+            .GetAttachmentsFilteredAsync(entityFilter, typeFilter, searchTerm, token)
+            .ConfigureAwait(false);
+        return rows;
+    }
+
+    public Task RemoveLinkAsync(int linkId, CancellationToken token = default)
+        => _attachmentService.RemoveLinkAsync(linkId, token);
+
+    public Task RemoveLinkAsync(string entityType, int entityId, int attachmentId, CancellationToken token = default)
+        => _attachmentService.RemoveLinkAsync(entityType, entityId, attachmentId, token);
+
+    public Task<Attachment?> FindByHashAsync(string sha256, CancellationToken token = default)
+        => _attachmentService.FindByHashAsync(sha256, token);
+
+    public Task<Attachment?> FindByHashAndSizeAsync(string sha256, long fileSize, CancellationToken token = default)
+        => _attachmentService.FindByHashAndSizeAsync(sha256, fileSize, token);
+
+    private static async Task<PreparedStream> PrepareStreamAsync(Stream content, CancellationToken token)
+    {
+        if (content.CanSeek)
+        {
+            content.Seek(0, SeekOrigin.Begin);
+            using var sha = SHA256.Create();
+            var buffer = ArrayPool<byte>.Shared.Rent(128 * 1024);
+            try
+            {
+                long total = 0;
+                int read;
+                while ((read = await content.ReadAsync(buffer.AsMemory(0, buffer.Length), token).ConfigureAwait(false)) > 0)
+                {
+                    sha.TransformBlock(buffer, 0, read, null, 0);
+                    total += read;
+                }
+
+                sha.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                content.Seek(0, SeekOrigin.Begin);
+                var hash = sha.Hash is null ? string.Empty : Convert.ToHexString(sha.Hash);
+                return new PreparedStream(content, hash, total, null);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+        else
+        {
+            var memory = new MemoryStream();
+            using var sha = SHA256.Create();
+            var buffer = ArrayPool<byte>.Shared.Rent(128 * 1024);
+            try
+            {
+                long total = 0;
+                int read;
+                while ((read = await content.ReadAsync(buffer.AsMemory(0, buffer.Length), token).ConfigureAwait(false)) > 0)
+                {
+                    sha.TransformBlock(buffer, 0, read, null, 0);
+                    await memory.WriteAsync(buffer.AsMemory(0, read), token).ConfigureAwait(false);
+                    total += read;
+                }
+
+                sha.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                memory.Seek(0, SeekOrigin.Begin);
+                var hash = sha.Hash is null ? string.Empty : Convert.ToHexString(sha.Hash);
+                return new PreparedStream(memory, hash, total, memory);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+    }
+
+    private sealed class PreparedStream : IAsyncDisposable
+    {
+        public PreparedStream(Stream stream, string hash, long length, Stream? owned)
+        {
+            Stream = stream;
+            Hash = hash;
+            Length = length;
+            _owned = owned;
+        }
+
+        public Stream Stream { get; }
+        public string Hash { get; }
+        public long Length { get; }
+        private readonly Stream? _owned;
+
+        public ValueTask DisposeAsync()
+        {
+            _owned?.Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+}
+
+/// <summary>
+/// Result returned by <see cref="IAttachmentWorkflowService.UploadAsync"/> exposing deduplication context.
+/// </summary>
+/// <param name="Upload">The underlying upload result from the AppCore service.</param>
+/// <param name="Sha256">Hex encoded SHA-256 hash calculated for the payload.</param>
+/// <param name="FileSize">Total bytes processed.</param>
+/// <param name="Deduplicated">True when an existing attachment was re-used.</param>
+/// <param name="Existing">The existing attachment matched by hash, if any.</param>
+public sealed record AttachmentWorkflowUploadResult(
+    AttachmentUploadResult Upload,
+    string Sha256,
+    long FileSize,
+    bool Deduplicated,
+    Attachment? Existing)
+{
+    /// <summary>Convenience accessor for the persisted attachment metadata.</summary>
+    public Attachment Attachment => Upload.Attachment;
+
+    /// <summary>Convenience accessor for the link created as part of the upload.</summary>
+    public AttachmentLink Link => Upload.Link;
+
+    /// <summary>Captured retention policy persisted for the attachment.</summary>
+    public RetentionPolicy Retention => Upload.Retention;
+}

--- a/YasGMP.Wpf/ViewModels/Modules/CalibrationModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/CalibrationModuleViewModel.cs
@@ -22,7 +22,7 @@ public sealed partial class CalibrationModuleViewModel : DataDrivenModuleDocumen
     private readonly IComponentCrudService _componentService;
     private readonly IAuthContext _authContext;
     private readonly IFilePicker _filePicker;
-    private readonly IAttachmentService _attachmentService;
+    private readonly IAttachmentWorkflowService _attachmentWorkflow;
 
     private Calibration? _loadedCalibration;
     private CalibrationEditor? _snapshot;
@@ -36,7 +36,7 @@ public sealed partial class CalibrationModuleViewModel : DataDrivenModuleDocumen
         IComponentCrudService componentService,
         IAuthContext authContext,
         IFilePicker filePicker,
-        IAttachmentService attachmentService,
+        IAttachmentWorkflowService attachmentWorkflow,
         ICflDialogService cflDialogService,
         IShellInteractionService shellInteraction,
         IModuleNavigationService navigation)
@@ -46,7 +46,7 @@ public sealed partial class CalibrationModuleViewModel : DataDrivenModuleDocumen
         _componentService = componentService ?? throw new ArgumentNullException(nameof(componentService));
         _authContext = authContext ?? throw new ArgumentNullException(nameof(authContext));
         _filePicker = filePicker ?? throw new ArgumentNullException(nameof(filePicker));
-        _attachmentService = attachmentService ?? throw new ArgumentNullException(nameof(attachmentService));
+        _attachmentWorkflow = attachmentWorkflow ?? throw new ArgumentNullException(nameof(attachmentWorkflow));
 
         Editor = CalibrationEditor.CreateEmpty();
         ComponentOptions = new ObservableCollection<ComponentOption>();
@@ -457,7 +457,8 @@ public sealed partial class CalibrationModuleViewModel : DataDrivenModuleDocumen
                 return;
             }
 
-            var uploads = 0;
+            var processed = 0;
+            var deduplicated = 0;
             var uploadedBy = _authContext.CurrentUser?.Id;
 
             foreach (var file in files)
@@ -476,13 +477,15 @@ public sealed partial class CalibrationModuleViewModel : DataDrivenModuleDocumen
                     Notes = $"WPF:{ModuleKey}:{DateTime.UtcNow:O}"
                 };
 
-                await _attachmentService.UploadAsync(stream, request).ConfigureAwait(false);
-                uploads++;
+                var result = await _attachmentWorkflow.UploadAsync(stream, request).ConfigureAwait(false);
+                processed++;
+                if (result.Deduplicated)
+                {
+                    deduplicated++;
+                }
             }
 
-            StatusMessage = uploads == 1
-                ? "Attachment uploaded successfully."
-                : $"Uploaded {uploads} attachments successfully.";
+            StatusMessage = AttachmentStatusFormatter.Format(processed, deduplicated);
         }
         catch (Exception ex)
         {

--- a/YasGMP.Wpf/ViewModels/Modules/ChangeControlModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/ChangeControlModuleViewModel.cs
@@ -22,7 +22,7 @@ public sealed partial class ChangeControlModuleViewModel : DataDrivenModuleDocum
     private readonly IChangeControlCrudService _changeControlService;
     private readonly IAuthContext _authContext;
     private readonly IFilePicker _filePicker;
-    private readonly IAttachmentService _attachmentService;
+    private readonly IAttachmentWorkflowService _attachmentWorkflow;
 
     private ChangeControl? _loadedEntity;
     private ChangeControlEditor? _snapshot;
@@ -33,7 +33,7 @@ public sealed partial class ChangeControlModuleViewModel : DataDrivenModuleDocum
         IChangeControlCrudService changeControlService,
         IAuthContext authContext,
         IFilePicker filePicker,
-        IAttachmentService attachmentService,
+        IAttachmentWorkflowService attachmentWorkflow,
         ICflDialogService cflDialogService,
         IShellInteractionService shellInteraction,
         IModuleNavigationService navigation)
@@ -42,7 +42,7 @@ public sealed partial class ChangeControlModuleViewModel : DataDrivenModuleDocum
         _changeControlService = changeControlService ?? throw new ArgumentNullException(nameof(changeControlService));
         _authContext = authContext ?? throw new ArgumentNullException(nameof(authContext));
         _filePicker = filePicker ?? throw new ArgumentNullException(nameof(filePicker));
-        _attachmentService = attachmentService ?? throw new ArgumentNullException(nameof(attachmentService));
+        _attachmentWorkflow = attachmentWorkflow ?? throw new ArgumentNullException(nameof(attachmentWorkflow));
 
         StatusOptions = Enum.GetNames(typeof(ChangeControlStatus));
         AttachDocumentCommand = new AsyncRelayCommand(AttachDocumentAsync, CanAttachDocument);
@@ -393,7 +393,8 @@ public sealed partial class ChangeControlModuleViewModel : DataDrivenModuleDocum
                 return;
             }
 
-            var uploads = 0;
+            var processed = 0;
+            var deduplicated = 0;
             foreach (var file in files)
             {
                 await using var stream = await file.OpenReadAsync().ConfigureAwait(false);
@@ -410,13 +411,15 @@ public sealed partial class ChangeControlModuleViewModel : DataDrivenModuleDocum
                     Notes = $"WPF:{ModuleKey}:{DateTime.UtcNow:O}"
                 };
 
-                await _attachmentService.UploadAsync(stream, request).ConfigureAwait(false);
-                uploads++;
+                var result = await _attachmentWorkflow.UploadAsync(stream, request).ConfigureAwait(false);
+                processed++;
+                if (result.Deduplicated)
+                {
+                    deduplicated++;
+                }
             }
 
-            StatusMessage = uploads == 1
-                ? "Attachment uploaded successfully."
-                : $"Uploaded {uploads} attachments.";
+            StatusMessage = AttachmentStatusFormatter.Format(processed, deduplicated);
         }
         catch (Exception ex)
         {

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -1,10 +1,10 @@
 # Codex Plan — WPF Shell & Full Integration
 
 ## Current Compile Status
-- [ ] Dotnet SDKs detected and recorded *(blocked: `dotnet` CLI not available in container PATH`; `dotnet --info` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-28, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, and 2025-10-24 → **command not found**)*
-- [ ] Solution restores *(pending SDK availability; `dotnet restore` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, and 2025-10-24 → **command not found**)*
-- [ ] MAUI builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, and 2025-10-24 → **command not found**)*
-- [ ] WPF builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, and 2025-10-24 → **command not found**)*
+- [ ] Dotnet SDKs detected and recorded *(blocked: `dotnet` CLI not available in container PATH`; `dotnet --info` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-28, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, and 2025-10-30 → **command not found**)*
+- [ ] Solution restores *(pending SDK availability; `dotnet restore` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, and 2025-10-30 → **command not found**)*
+- [ ] MAUI builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, and 2025-10-30 → **command not found**)*
+- [ ] WPF builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, and 2025-10-30 → **command not found**)*
 
 ## Decisions & Pins
 - Preferred WPF target: **net9.0-windows10.0.19041.0** (retain once .NET 9 SDK is installed).
@@ -46,6 +46,7 @@
 - `scripts/bootstrap-dotnet9.ps1` added to guide host setup *(installs/verifies .NET 9, Windows SDK, runs restore/build, seeds smoke test fixture).* 
 - `YasGMP.Wpf` already targets .NET 9 and references pinned packages; validate once builds are possible.
 - `tests/fixtures/hello.txt` seeded for upcoming smoke harness scenarios.
+- 2025-10-30: Introduced `AttachmentWorkflowService` in the WPF shell so module view-models share MAUI's dedup/encryption/retention workflow via `AttachmentService` + `DatabaseService.Attachments` helpers; registration and commands now rely on the adapter.
 - Assets module now exposes an attachment command that uploads via `IAttachmentService`; coverage added in unit tests.
 - Components module now completes the CRUD rollout with mode-aware editor, validation, and machine lookups; attachment/signature integration remains queued for Batch B2.
 - Parts and Warehouse modules now expose CRUD-capable editors with attachment upload support, stock-health warnings, and warehouse inventory previews; e-signatures and audit surfacing remain tied to Batch B2 once SDK access is restored.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -15,7 +15,8 @@
       "2025-10-14: dotnet --info/restore/build attempted again; CLI remains unavailable in container.",
       "2025-10-17: dotnet --info/restore/build retried; CLI still missing so commands exit with 'command not found'.",
       "2025-10-23: dotnet --info/restore/build attempted again; CLI remains unavailable in the container.",
-      "2025-10-27: dotnet --info/restore/build/test retried; CLI still missing so commands exit with 'command not found'."
+      "2025-10-27: dotnet --info/restore/build/test retried; CLI still missing so commands exit with 'command not found'.",
+      "2025-10-30: dotnet --info/restore/build retried; CLI still absent in container so commands fail with 'command not found'."
     ]
   },
   "batches": [
@@ -65,7 +66,7 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "fix: order audit query bounds while preserving filters",
+  "lastCommitSummary": "feat: add WPF attachment workflow adapter",
   "notes": [
     "Need to restore/install dotnet 9 SDK to proceed with Batch 0 validation steps.",
     "tests/fixtures/hello.txt seeded for smoke harness bootstrap",
@@ -109,6 +110,7 @@
     "2025-10-26: Audit filters now preserve a user-specified end date even when it predates the start picker by clamping the service query's start bound to that day and adding WPF regression coverage for the upper-bound behavior.",
     "2025-10-27: Audit filters now clamp the lower bound when the upper bound is moved earlier while keeping the selected end date intact; new WPF regression test ensures persisted filters and query arguments align.",
     "2025-10-28: Audit filters now retain the user's To picker while reordering the query bounds if the upper date precedes the lower; tests cover both existing From overrides and default-from scenarios.",
-    "2025-10-29: Audit module now orders inverted date ranges by min/max while preserving the user-selected To value; WPF tests assert the later bound reaches AuditService at end-of-day."
+    "2025-10-29: Audit module now orders inverted date ranges by min/max while preserving the user-selected To value; WPF tests assert the later bound reaches AuditService at end-of-day.",
+    "2025-10-30: WPF modules now route uploads through AttachmentWorkflowService so dedup, retention, and encryption follow the MAUI conventions; DI registration updated and commands now surface dedup status messaging."
   ]
 }


### PR DESCRIPTION
## Summary
- introduce an AttachmentWorkflowService for the WPF shell that layers deduplication, retention policy logging, and encryption metadata over AttachmentService/DatabaseService helpers
- switch module view-models to depend on the workflow adapter and share dedup-aware status messaging via a new formatter helper
- register the workflow adapter in App.xaml.cs and document the batch progress / SDK blocker updates in codex_plan.md and codex_progress.json

## Testing
- `dotnet restore` *(fails: command not found — container is missing the dotnet CLI)*
- `dotnet build yasgmp.sln` *(fails: command not found — container is missing the dotnet CLI)*

------
https://chatgpt.com/codex/tasks/task_e_68da250bbe148331a7a662c733b3a342