### PR TITLE
Add WPF electronic signature dialog

### DIFF
--- a/YasGMP.Wpf/App.xaml.cs
+++ b/YasGMP.Wpf/App.xaml.cs
@@ -7,8 +7,10 @@ using YasGMP.AppCore.DependencyInjection;
 using YasGMP.Common;
 using YasGMP.Services;
 using YasGMP.Services.Interfaces;
+using YasGMP.ViewModels;
 using YasGMP.Wpf.Services;
 using YasGMP.Wpf.ViewModels;
+using YasGMP.Wpf.ViewModels.Dialogs;
 using YasGMP.Wpf.ViewModels.Modules;
 
 namespace YasGMP.Wpf
@@ -46,7 +48,11 @@ namespace YasGMP.Wpf
                         svc.AddSingleton<AuditService>();
                         svc.AddSingleton<IUserSession, UserSession>();
                         svc.AddSingleton<IPlatformService, WpfPlatformService>();
-                        svc.AddSingleton<IAuthContext, WpfAuthContext>();
+                        svc.AddSingleton<WpfAuthContext>();
+                        svc.AddSingleton<IAuthContext>(sp => sp.GetRequiredService<WpfAuthContext>());
+                        svc.AddSingleton<UserService>();
+                        svc.AddSingleton<IUserService>(sp => sp.GetRequiredService<UserService>());
+                        svc.AddSingleton<AuthService>();
                         svc.AddSingleton<IUiDispatcher, WpfUiDispatcher>();
                         svc.AddSingleton<IDialogService, WpfDialogService>();
                         svc.AddSingleton<IFilePicker, WpfFilePicker>();
@@ -82,7 +88,6 @@ namespace YasGMP.Wpf
                         svc.AddTransient<ISupplierAuditService, SupplierAuditService>();
                         svc.AddTransient<ISupplierCrudService, SupplierCrudServiceAdapter>();
                         svc.AddTransient<IExternalServicerCrudService, ExternalServicerCrudServiceAdapter>();
-                        svc.AddTransient<IUserService, UserService>();
                         svc.AddTransient<IUserCrudService, UserCrudServiceAdapter>();
                         svc.AddTransient<IScheduledJobCrudService, ScheduledJobCrudServiceAdapter>();
                         svc.AddSingleton<ShellInteractionService>();
@@ -92,6 +97,8 @@ namespace YasGMP.Wpf
                         svc.AddSingleton<InspectorPaneViewModel>();
                         svc.AddSingleton<ShellStatusBarViewModel>();
                         svc.AddSingleton<DebugSmokeTestService>();
+                        svc.AddTransient<DigitalSignatureViewModel>();
+                        svc.AddTransient<ElectronicSignatureDialogViewModel>();
                         svc.AddTransient<DashboardModuleViewModel>();
                         svc.AddTransient<AssetsModuleViewModel>();
                         svc.AddTransient<ComponentsModuleViewModel>();

--- a/YasGMP.Wpf/ViewModels/Dialogs/ElectronicSignatureDialogViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Dialogs/ElectronicSignatureDialogViewModel.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using YasGMP.Common;
+using YasGMP.Helpers;
+using YasGMP.Models;
+using YasGMP.Services.Interfaces;
+using YasGMP.ViewModels;
+
+namespace YasGMP.Wpf.ViewModels.Dialogs;
+
+/// <summary>
+/// View-model backing the WPF electronic signature dialog. Collects the operator credential
+/// and GMP reason metadata, forwards persistence through the shared DigitalSignatureViewModel,
+/// and exposes a result describing the captured signature.
+/// </summary>
+public sealed partial class ElectronicSignatureDialogViewModel : ObservableObject
+{
+    private readonly DigitalSignatureViewModel _digitalSignatureViewModel;
+    private readonly IAuthContext _authContext;
+
+    public ElectronicSignatureDialogViewModel(
+        DigitalSignatureViewModel digitalSignatureViewModel,
+        IAuthContext authContext,
+        ElectronicSignatureContext context)
+    {
+        _digitalSignatureViewModel = digitalSignatureViewModel ?? throw new ArgumentNullException(nameof(digitalSignatureViewModel));
+        _authContext = authContext ?? throw new ArgumentNullException(nameof(authContext));
+        Context = context ?? throw new ArgumentNullException(nameof(context));
+
+        Reasons = new ObservableCollection<WorkOrderSignatureReasonCodes.Reason>(WorkOrderSignatureReasonCodes.All);
+        SelectedReason = Reasons.Count > 0 ? Reasons[0] : null;
+
+        ConfirmCommand = new AsyncRelayCommand(ConfirmAsync, CanConfirm);
+        CancelCommand = new RelayCommand(Cancel);
+
+        CurrentUserDisplay = BuildCurrentUserDisplay();
+    }
+
+    /// <summary>Context describing the target record and default signature attributes.</summary>
+    public ElectronicSignatureContext Context { get; }
+
+    /// <summary>Available GMP reason codes for signature justification.</summary>
+    public ObservableCollection<WorkOrderSignatureReasonCodes.Reason> Reasons { get; }
+
+    /// <summary>Display text that surfaces the active session user.</summary>
+    public string CurrentUserDisplay { get; }
+
+    /// <summary>Captured result populated once confirmation succeeds.</summary>
+    public ElectronicSignatureDialogResult? Result { get; private set; }
+
+    /// <summary>Command executed when the operator confirms the signature.</summary>
+    public IAsyncRelayCommand ConfirmCommand { get; }
+
+    /// <summary>Command executed when the operator cancels the dialog.</summary>
+    public IRelayCommand CancelCommand { get; }
+
+    [ObservableProperty]
+    private WorkOrderSignatureReasonCodes.Reason? _selectedReason;
+
+    [ObservableProperty]
+    private string? _customReasonCode;
+
+    [ObservableProperty]
+    private string? _reasonDetail;
+
+    [ObservableProperty]
+    private string _password = string.Empty;
+
+    [ObservableProperty]
+    private bool _isBusy;
+
+    [ObservableProperty]
+    private bool _isCustomReasonVisible;
+
+    [ObservableProperty]
+    private string? _statusMessage;
+
+    /// <summary>Raised when the dialog should close. Payload indicates success (<c>true</c>) or cancel (<c>false</c>).</summary>
+    public event EventHandler<bool>? RequestClose;
+
+    partial void OnSelectedReasonChanged(WorkOrderSignatureReasonCodes.Reason? value)
+    {
+        IsCustomReasonVisible = value is not null &&
+            string.Equals(value.Code, WorkOrderSignatureReasonCodes.Custom, StringComparison.OrdinalIgnoreCase);
+        ConfirmCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnPasswordChanged(string value) => ConfirmCommand.NotifyCanExecuteChanged();
+
+    partial void OnIsBusyChanged(bool value) => ConfirmCommand.NotifyCanExecuteChanged();
+
+    private bool CanConfirm()
+        => !IsBusy && !string.IsNullOrWhiteSpace(Password) && SelectedReason is not null;
+
+    private async Task ConfirmAsync()
+    {
+        if (SelectedReason is null)
+        {
+            StatusMessage = "Select a signature reason.";
+            return;
+        }
+
+        string reasonCode = SelectedReason.Code;
+        if (IsCustomReasonVisible)
+        {
+            reasonCode = CustomReasonCode?.Trim() ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(reasonCode))
+            {
+                StatusMessage = "Custom reason code is required.";
+                return;
+            }
+        }
+
+        string? reasonDetail = string.IsNullOrWhiteSpace(ReasonDetail) ? null : ReasonDetail!.Trim();
+        var user = _authContext.CurrentUser;
+        if (user is null || user.Id == 0)
+        {
+            StatusMessage = "Active user session is required.";
+            return;
+        }
+
+        IsBusy = true;
+        StatusMessage = null;
+
+        try
+        {
+            var timestampUtc = DateTime.UtcNow;
+            var signatureContext = DigitalSignatureHelper.ComputeUserContextSignature(
+                user.Id,
+                _authContext.CurrentSessionId,
+                _authContext.CurrentDeviceInfo,
+                timestampUtc);
+
+            var signature = new DigitalSignature
+            {
+                TableName = Context.TableName,
+                RecordId = Context.RecordId,
+                UserId = user.Id,
+                SignatureHash = signatureContext.Hash,
+                Method = Context.Method,
+                Status = Context.Status,
+                SignedAt = timestampUtc,
+                DeviceInfo = _authContext.CurrentDeviceInfo,
+                IpAddress = _authContext.CurrentIpAddress,
+                SessionId = _authContext.CurrentSessionId,
+                Note = ComposeNote(reasonCode, reasonDetail)
+            };
+
+            await _digitalSignatureViewModel.InsertSignatureAsync(signature, CancellationToken.None).ConfigureAwait(false);
+
+            Result = new ElectronicSignatureDialogResult(
+                Password,
+                reasonCode,
+                reasonDetail,
+                SelectedReason.DisplayLabel,
+                signature);
+
+            RequestClose?.Invoke(this, true);
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Failed to capture signature: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private static string ComposeNote(string reasonCode, string? reasonDetail)
+        => string.IsNullOrWhiteSpace(reasonDetail)
+            ? reasonCode
+            : $"{reasonCode}: {reasonDetail}";
+
+    private void Cancel()
+    {
+        Result = null;
+        RequestClose?.Invoke(this, false);
+    }
+
+    private string BuildCurrentUserDisplay()
+    {
+        var user = _authContext.CurrentUser;
+        if (user is null)
+        {
+            return "User: (not authenticated)";
+        }
+
+        string display = string.IsNullOrWhiteSpace(user.FullName) ? user.Username ?? "unknown" : user.FullName;
+        return $"User: {display}";
+    }
+}
+
+/// <summary>Describes the record and metadata that should be associated with the captured signature.</summary>
+/// <param name="TableName">Target table name persisted with the signature.</param>
+/// <param name="RecordId">Record identifier associated with the signature.</param>
+/// <param name="Method">Signature method (defaults to "password").</param>
+/// <param name="Status">Signature status (defaults to "valid").</param>
+public sealed record ElectronicSignatureContext(string TableName, int RecordId, string Method = "password", string Status = "valid");
+
+/// <summary>Result returned from the dialog once the signature capture succeeds.</summary>
+/// <param name="Password">Credential supplied by the operator.</param>
+/// <param name="ReasonCode">Normalized reason code (or custom input).</param>
+/// <param name="ReasonDetail">Free-form justification text.</param>
+/// <param name="ReasonDisplay">Human readable label of the selected reason.</param>
+/// <param name="Signature">Inserted digital signature row.</param>
+public sealed record ElectronicSignatureDialogResult(
+    string Password,
+    string ReasonCode,
+    string? ReasonDetail,
+    string ReasonDisplay,
+    DigitalSignature Signature);

--- a/YasGMP.Wpf/Views/Dialogs/ElectronicSignatureDialog.xaml
+++ b/YasGMP.Wpf/Views/Dialogs/ElectronicSignatureDialog.xaml
@@ -1,0 +1,97 @@
+<Window x:Class="YasGMP.Wpf.Views.Dialogs.ElectronicSignatureDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Electronic Signature"
+        SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterOwner"
+        MinWidth="460"
+        MinHeight="320"
+        ResizeMode="CanResizeWithGrip">
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+    </Window.Resources>
+    <Border Padding="16" Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Grid.Row="0" Grid.ColumnSpan="2"
+                       Text="Re-enter your credential and capture a GMP-compliant reason before applying the signature."
+                       TextWrapping="Wrap"
+                       Margin="0,0,0,12"
+                       FontWeight="SemiBold" />
+
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="User:" VerticalAlignment="Center" Margin="0,0,8,0" />
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding CurrentUserDisplay}" FontWeight="SemiBold" />
+
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Password/PIN:" VerticalAlignment="Center" Margin="0,12,8,0" />
+            <PasswordBox x:Name="PasswordBox"
+                         Grid.Row="2"
+                         Grid.Column="1"
+                         Margin="0,12,0,0"
+                         PasswordChanged="OnPasswordChanged"
+                         MinWidth="220"
+                         ToolTip="Enter your YasGMP password or PIN." />
+
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Reason code:" VerticalAlignment="Center" Margin="0,12,8,0" />
+            <ComboBox Grid.Row="3"
+                      Grid.Column="1"
+                      Margin="0,12,0,0"
+                      ItemsSource="{Binding Reasons}"
+                      SelectedItem="{Binding SelectedReason, Mode=TwoWay}"
+                      DisplayMemberPath="DisplayLabel"
+                      MinWidth="280" />
+
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Custom code:" VerticalAlignment="Center" Margin="0,12,8,0"
+                       Visibility="{Binding IsCustomReasonVisible, Converter={StaticResource BoolToVisibility}}" />
+            <TextBox Grid.Row="4"
+                     Grid.Column="1"
+                     Margin="0,12,0,0"
+                     Text="{Binding CustomReasonCode, UpdateSourceTrigger=PropertyChanged}"
+                     Visibility="{Binding IsCustomReasonVisible, Converter={StaticResource BoolToVisibility}}"
+                     MinWidth="200" />
+
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Reason note:" VerticalAlignment="Top" Margin="0,12,8,0" />
+            <TextBox Grid.Row="5"
+                     Grid.Column="1"
+                     Margin="0,12,0,0"
+                     Text="{Binding ReasonDetail, UpdateSourceTrigger=PropertyChanged}"
+                     AcceptsReturn="True"
+                     MinHeight="80"
+                     TextWrapping="Wrap"
+                     VerticalScrollBarVisibility="Auto" />
+
+            <TextBlock Grid.Row="6" Grid.ColumnSpan="2"
+                       Margin="0,12,0,0"
+                       Foreground="DarkRed"
+                       Text="{Binding StatusMessage}" />
+
+            <StackPanel Grid.Row="7" Grid.ColumnSpan="2"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        Margin="0,20,0,0">
+                <Button Content="Confirm"
+                        Width="100"
+                        Margin="0,0,12,0"
+                        IsDefault="True"
+                        Command="{Binding ConfirmCommand}" />
+                <Button Content="Cancel"
+                        Width="100"
+                        IsCancel="True"
+                        Command="{Binding CancelCommand}" />
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/YasGMP.Wpf/Views/Dialogs/ElectronicSignatureDialog.xaml.cs
+++ b/YasGMP.Wpf/Views/Dialogs/ElectronicSignatureDialog.xaml.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using YasGMP.Wpf.ViewModels.Dialogs;
+
+namespace YasGMP.Wpf.Views.Dialogs;
+
+public partial class ElectronicSignatureDialog : Window
+{
+    public ElectronicSignatureDialog()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+        Closed += OnClosed;
+    }
+
+    public ElectronicSignatureDialog(ElectronicSignatureDialogViewModel viewModel) : this()
+    {
+        DataContext = viewModel;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is ElectronicSignatureDialogViewModel vm)
+        {
+            vm.RequestClose += OnRequestClose;
+        }
+    }
+
+    private void OnClosed(object? sender, EventArgs e)
+    {
+        if (DataContext is ElectronicSignatureDialogViewModel vm)
+        {
+            vm.RequestClose -= OnRequestClose;
+        }
+    }
+
+    private void OnRequestClose(object? sender, bool confirmed)
+    {
+        Dispatcher.Invoke(() =>
+        {
+            DialogResult = confirmed;
+            Close();
+        });
+    }
+
+    private void OnPasswordChanged(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is ElectronicSignatureDialogViewModel vm && sender is PasswordBox passwordBox)
+        {
+            vm.Password = passwordBox.Password;
+        }
+    }
+}

--- a/YasGMP.Wpf/YasGMP.Wpf.csproj
+++ b/YasGMP.Wpf/YasGMP.Wpf.csproj
@@ -28,4 +28,13 @@
   <ItemGroup>
     <ProjectReference Include="..\YasGMP.AppCore\YasGMP.AppCore.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Helpers\DigitalSignatureHelper.cs">
+      <Link>Shared\Helpers\DigitalSignatureHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\ViewModels\DigitalSignatureViewModel.cs">
+      <Link>Shared\ViewModels\DigitalSignatureViewModel.cs</Link>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -47,6 +47,7 @@
 - `YasGMP.Wpf` already targets .NET 9 and references pinned packages; validate once builds are possible.
 - `tests/fixtures/hello.txt` seeded for upcoming smoke harness scenarios.
 - 2025-10-30: Introduced `AttachmentWorkflowService` in the WPF shell so module view-models share MAUI's dedup/encryption/retention workflow via `AttachmentService` + `DatabaseService.Attachments` helpers; registration and commands now rely on the adapter.
+- 2025-10-31: WPF shell now includes an electronic signature dialog that wraps the shared DigitalSignatureViewModel, captures password/PIN plus GMP reason text, and persists the note via the AppCore insert extension before closing.
 - Assets module now exposes an attachment command that uploads via `IAttachmentService`; coverage added in unit tests.
 - Components module now completes the CRUD rollout with mode-aware editor, validation, and machine lookups; attachment/signature integration remains queued for Batch B2.
 - Parts and Warehouse modules now expose CRUD-capable editors with attachment upload support, stock-health warnings, and warehouse inventory previews; e-signatures and audit surfacing remain tied to Batch B2 once SDK access is restored.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -111,6 +111,7 @@
     "2025-10-27: Audit filters now clamp the lower bound when the upper bound is moved earlier while keeping the selected end date intact; new WPF regression test ensures persisted filters and query arguments align.",
     "2025-10-28: Audit filters now retain the user's To picker while reordering the query bounds if the upper date precedes the lower; tests cover both existing From overrides and default-from scenarios.",
     "2025-10-29: Audit module now orders inverted date ranges by min/max while preserving the user-selected To value; WPF tests assert the later bound reaches AuditService at end-of-day.",
-    "2025-10-30: WPF modules now route uploads through AttachmentWorkflowService so dedup, retention, and encryption follow the MAUI conventions; DI registration updated and commands now surface dedup status messaging."
+    "2025-10-30: WPF modules now route uploads through AttachmentWorkflowService so dedup, retention, and encryption follow the MAUI conventions; DI registration updated and commands now surface dedup status messaging.",
+    "2025-10-31: WPF shell adds an electronic signature dialog that wraps DigitalSignatureViewModel, captures the operator password/PIN with GMP reason text, and persists the note via DatabaseService.DigitalSignatures.Insert before dismissing."
   ]
 }


### PR DESCRIPTION
## Summary
- add a WPF electronic signature dialog and backing view-model that reuse the shared DigitalSignatureViewModel to capture password/PIN and GMP reason data
- expose the DatabaseService.InsertDigitalSignatureAsync path through DigitalSignatureViewModel so dialog inserts signatures with the captured note
- register the shared and wrapper view-models with the WPF host, link the shared helper/view-model source, and document the new dialog in codex_plan/progress

## Testing
- not run (dotnet CLI unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68da2f83f4c4833180bb9338587aae82