### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf/App.xaml.cs
+++ b/YasGMP.Wpf/App.xaml.cs
@@ -58,6 +58,7 @@ namespace YasGMP.Wpf
                         svc.AddSingleton<IFilePicker, WpfFilePicker>();
                         svc.AddSingleton<IAttachmentService, AttachmentService>();
                         svc.AddSingleton<IAttachmentWorkflowService, AttachmentWorkflowService>();
+                        svc.AddSingleton<IElectronicSignatureDialogService, ElectronicSignatureDialogService>();
                         svc.AddSingleton<ICflDialogService, CflDialogService>();
                         svc.AddSingleton<IRBACService, RBACService>();
                         svc.AddSingleton<WorkOrderAuditService>();

--- a/YasGMP.Wpf/Services/ElectronicSignatureDialogService.cs
+++ b/YasGMP.Wpf/Services/ElectronicSignatureDialogService.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using YasGMP.Services;
+using YasGMP.Services.Interfaces;
+using YasGMP.Wpf.ViewModels.Dialogs;
+using YasGMP.Wpf.Views.Dialogs;
+
+namespace YasGMP.Wpf.Services;
+
+/// <summary>
+/// Concrete implementation that displays the WPF electronic signature dialog and persists
+/// the captured signature through the shared database extensions.
+/// </summary>
+public sealed class ElectronicSignatureDialogService : IElectronicSignatureDialogService
+{
+    private readonly IUiDispatcher _uiDispatcher;
+    private readonly DatabaseService _databaseService;
+    private readonly IAuthContext _authContext;
+
+    public ElectronicSignatureDialogService(
+        IUiDispatcher uiDispatcher,
+        DatabaseService databaseService,
+        IAuthContext authContext)
+    {
+        _uiDispatcher = uiDispatcher ?? throw new ArgumentNullException(nameof(uiDispatcher));
+        _databaseService = databaseService ?? throw new ArgumentNullException(nameof(databaseService));
+        _authContext = authContext ?? throw new ArgumentNullException(nameof(authContext));
+    }
+
+    public async Task<ElectronicSignatureDialogResult?> CaptureSignatureAsync(
+        ElectronicSignatureContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (context is null) throw new ArgumentNullException(nameof(context));
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var viewModel = new ElectronicSignatureDialogViewModel(_authContext, context);
+        ElectronicSignatureDialogResult? result = null;
+
+        await _uiDispatcher.InvokeAsync(() =>
+        {
+            var dialog = new ElectronicSignatureDialog(viewModel);
+            var owner = Application.Current?.Windows
+                .OfType<Window>()
+                .FirstOrDefault(w => w.IsActive) ?? Application.Current?.MainWindow;
+            if (owner is not null)
+            {
+                dialog.Owner = owner;
+            }
+
+            bool? confirmed = dialog.ShowDialog();
+            if (confirmed == true)
+            {
+                result = viewModel.Result;
+            }
+        }).ConfigureAwait(false);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (result?.Signature is null)
+        {
+            return result;
+        }
+
+        await _databaseService.InsertDigitalSignatureAsync(result.Signature, cancellationToken).ConfigureAwait(false);
+        return result;
+    }
+}

--- a/YasGMP.Wpf/Services/IElectronicSignatureDialogService.cs
+++ b/YasGMP.Wpf/Services/IElectronicSignatureDialogService.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+using YasGMP.Wpf.ViewModels.Dialogs;
+
+namespace YasGMP.Wpf.Services;
+
+/// <summary>
+/// Abstraction used by save workflows to capture an electronic signature via the WPF dialog.
+/// </summary>
+public interface IElectronicSignatureDialogService
+{
+    /// <summary>
+    /// Presents the electronic signature dialog and returns the captured metadata when confirmed.
+    /// </summary>
+    /// <param name="context">Target record context for the signature.</param>
+    /// <param name="cancellationToken">Token used to observe cancellation while persisting.</param>
+    /// <returns>The captured signature metadata when confirmed; otherwise <c>null</c>.</returns>
+    Task<ElectronicSignatureDialogResult?> CaptureSignatureAsync(
+        ElectronicSignatureContext context,
+        CancellationToken cancellationToken = default);
+}

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -47,7 +47,7 @@
 - `YasGMP.Wpf` already targets .NET 9 and references pinned packages; validate once builds are possible.
 - `tests/fixtures/hello.txt` seeded for upcoming smoke harness scenarios.
 - 2025-10-30: Introduced `AttachmentWorkflowService` in the WPF shell so module view-models share MAUI's dedup/encryption/retention workflow via `AttachmentService` + `DatabaseService.Attachments` helpers; registration and commands now rely on the adapter.
-- 2025-10-31: WPF shell now includes an electronic signature dialog that wraps the shared DigitalSignatureViewModel, captures password/PIN plus GMP reason text, and persists the note via the AppCore insert extension before closing.
+- 2025-10-31: WPF shell now exposes an `IElectronicSignatureDialogService` that drives the signature dialog, captures password/PIN plus GMP reason text, and persists the note via the shared DatabaseService extensions before closing.
 - Assets module now exposes an attachment command that uploads via `IAttachmentService`; coverage added in unit tests.
 - Components module now completes the CRUD rollout with mode-aware editor, validation, and machine lookups; attachment/signature integration remains queued for Batch B2.
 - Parts and Warehouse modules now expose CRUD-capable editors with attachment upload support, stock-health warnings, and warehouse inventory previews; e-signatures and audit surfacing remain tied to Batch B2 once SDK access is restored.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -112,6 +112,6 @@
     "2025-10-28: Audit filters now retain the user's To picker while reordering the query bounds if the upper date precedes the lower; tests cover both existing From overrides and default-from scenarios.",
     "2025-10-29: Audit module now orders inverted date ranges by min/max while preserving the user-selected To value; WPF tests assert the later bound reaches AuditService at end-of-day.",
     "2025-10-30: WPF modules now route uploads through AttachmentWorkflowService so dedup, retention, and encryption follow the MAUI conventions; DI registration updated and commands now surface dedup status messaging.",
-    "2025-10-31: WPF shell adds an electronic signature dialog that wraps DigitalSignatureViewModel, captures the operator password/PIN with GMP reason text, and persists the note via DatabaseService.DigitalSignatures.Insert before dismissing."
+    "2025-10-31: WPF shell adds an IElectronicSignatureDialogService that drives the signature dialog, captures the operator password/PIN with GMP reason text, and persists through DatabaseServiceDigitalSignaturesExtensions before dismissing."
   ]
 }


### PR DESCRIPTION
## Summary
- add an IElectronicSignatureDialogService abstraction so save workflows can request WPF signature capture asynchronously
- implement ElectronicSignatureDialogService to show the dialog on the UI dispatcher and persist confirmations through the DatabaseService digital signature extensions
- adjust the electronic signature dialog view-model to hand back composed metadata for persistence and register the new service in the WPF host

## Testing
- dotnet restore *(fails: command not found)*
- dotnet build yasgmp.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68da39926d108331b5aad7957e87eb6c