### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf.Tests/AssetsModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/AssetsModuleViewModelTests.cs
@@ -24,13 +24,14 @@ public class AssetsModuleViewModelTests
             CurrentDeviceInfo = "UnitTest",
             CurrentIpAddress = "10.0.0.25"
         };
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
         var filePicker = new TestFilePicker();
         var attachments = new TestAttachmentService();
 
-        var viewModel = new AssetsModuleViewModel(database, machineAdapter, auth, filePicker, attachments, dialog, shell, navigation);
+        var viewModel = new AssetsModuleViewModel(database, machineAdapter, auth, filePicker, attachments, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
 
         viewModel.Mode = FormMode.Add;
@@ -52,6 +53,12 @@ public class AssetsModuleViewModelTests
         Assert.Equal("Lyophilizer", persisted.Name);
         Assert.Equal("maintenance", persisted.Status);
         Assert.Equal("URS-LYO-01", persisted.UrsDoc);
+        Assert.Equal("test-signature", persisted.DigitalSignature);
+        Assert.Collection(signatureDialog.Requests, ctx =>
+        {
+            Assert.Equal("machines", ctx.TableName);
+            Assert.Equal(0, ctx.RecordId);
+        });
     }
 
     [Fact]
@@ -75,6 +82,7 @@ public class AssetsModuleViewModelTests
             CurrentDeviceInfo = "UnitTest",
             CurrentIpAddress = "127.0.0.42"
         };
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
@@ -87,7 +95,7 @@ public class AssetsModuleViewModelTests
             new PickedFile("hello.txt", "text/plain", () => Task.FromResult<Stream>(new MemoryStream(bytes, writable: false)), bytes.Length)
         };
 
-        var viewModel = new AssetsModuleViewModel(database, machineAdapter, auth, filePicker, attachments, dialog, shell, navigation);
+        var viewModel = new AssetsModuleViewModel(database, machineAdapter, auth, filePicker, attachments, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
 
         Assert.True(viewModel.AttachDocumentCommand.CanExecute(null));

--- a/YasGMP.Wpf.Tests/CalibrationModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/CalibrationModuleViewModelTests.cs
@@ -39,6 +39,7 @@ public class CalibrationModuleViewModelTests
             CurrentDeviceInfo = "UnitTest",
             CurrentIpAddress = "10.0.0.5"
         };
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
@@ -52,6 +53,7 @@ public class CalibrationModuleViewModelTests
             auth,
             filePicker,
             attachmentService,
+            signatureDialog,
             dialog,
             shell,
             navigation);
@@ -76,6 +78,12 @@ public class CalibrationModuleViewModelTests
         Assert.Equal(database.Suppliers[0].Id, persisted.SupplierId);
         Assert.Equal("PASS", persisted.Result);
         Assert.Equal("CERT-001.pdf", persisted.CertDoc);
+        Assert.Equal("test-signature", persisted.DigitalSignature);
+        Assert.Collection(signatureDialog.Requests, ctx =>
+        {
+            Assert.Equal("calibrations", ctx.TableName);
+            Assert.Equal(0, ctx.RecordId);
+        });
     }
 
     [Fact]
@@ -104,6 +112,7 @@ public class CalibrationModuleViewModelTests
             CurrentDeviceInfo = "UnitTest",
             CurrentIpAddress = "10.0.0.15"
         };
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
@@ -126,6 +135,7 @@ public class CalibrationModuleViewModelTests
             auth,
             filePicker,
             attachmentService,
+            signatureDialog,
             dialog,
             shell,
             navigation);

--- a/YasGMP.Wpf.Tests/ModuleCflTests.cs
+++ b/YasGMP.Wpf.Tests/ModuleCflTests.cs
@@ -29,6 +29,7 @@ public class ModuleCflTests
             InstallDate = DateTime.UtcNow
         });
 
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
@@ -48,7 +49,7 @@ public class ModuleCflTests
         var filePicker = new TestFilePicker();
         var attachments = new TestAttachmentService();
 
-        var viewModel = new AssetsModuleViewModel(db, machineCrud, auth, filePicker, attachments, dialog, shell, navigation);
+        var viewModel = new AssetsModuleViewModel(db, machineCrud, auth, filePicker, attachments, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
         Assert.NotEmpty(viewModel.Records);
 
@@ -94,6 +95,7 @@ public class ModuleCflTests
             AssignedTo = new User { FullName = "Technician" }
         });
 
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
@@ -103,7 +105,7 @@ public class ModuleCflTests
         var workOrderCrud = new FakeWorkOrderCrudService();
         workOrderCrud.Saved.AddRange(db.WorkOrders);
 
-        var viewModel = new WorkOrdersModuleViewModel(db, workOrderCrud, auth, filePicker, attachments, dialog, shell, navigation);
+        var viewModel = new WorkOrdersModuleViewModel(db, workOrderCrud, auth, filePicker, attachments, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
         Assert.NotEmpty(viewModel.Records);
 
@@ -138,11 +140,28 @@ public class ModuleCflTests
             Comment = "All good"
         });
 
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
+        var calibrationService = new FakeCalibrationCrudService();
+        calibrationService.Saved.AddRange(db.Calibrations);
+        var componentService = new FakeComponentCrudService();
+        var auth = new TestAuthContext();
+        var filePicker = new TestFilePicker();
+        var attachmentService = new TestAttachmentService();
 
-        var viewModel = new CalibrationModuleViewModel(db, dialog, shell, navigation);
+        var viewModel = new CalibrationModuleViewModel(
+            db,
+            calibrationService,
+            componentService,
+            auth,
+            filePicker,
+            attachmentService,
+            signatureDialog,
+            dialog,
+            shell,
+            navigation);
         await viewModel.InitializeAsync(null);
         Assert.NotEmpty(viewModel.Records);
 

--- a/YasGMP.Wpf.Tests/PartsModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/PartsModuleViewModelTests.cs
@@ -26,13 +26,14 @@ public class PartsModuleViewModelTests
             CurrentDeviceInfo = "UnitTest",
             CurrentIpAddress = "127.0.0.50"
         };
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
         var filePicker = new TestFilePicker();
         var attachments = new TestAttachmentService();
 
-        var viewModel = new PartsModuleViewModel(database, partAdapter, attachments, filePicker, auth, dialog, shell, navigation);
+        var viewModel = new PartsModuleViewModel(database, partAdapter, attachments, filePicker, auth, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
 
         viewModel.Mode = FormMode.Add;
@@ -54,6 +55,12 @@ public class PartsModuleViewModelTests
         Assert.Equal("Pressure Gauge", persisted.Name);
         Assert.Equal(3, persisted.DefaultSupplierId);
         Assert.Equal("contoso", persisted.DefaultSupplierName.ToLowerInvariant());
+        Assert.Equal("test-signature", persisted.DigitalSignature);
+        Assert.Collection(signatureDialog.Requests, ctx =>
+        {
+            Assert.Equal("parts", ctx.TableName);
+            Assert.Equal(0, ctx.RecordId);
+        });
     }
 
     [Fact]
@@ -77,6 +84,7 @@ public class PartsModuleViewModelTests
             CurrentDeviceInfo = "UnitTest",
             CurrentIpAddress = "10.0.0.42"
         };
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
@@ -89,7 +97,7 @@ public class PartsModuleViewModelTests
             new PickedFile("part.txt", "text/plain", () => Task.FromResult<Stream>(new MemoryStream(bytes, writable: false)), bytes.Length)
         };
 
-        var viewModel = new PartsModuleViewModel(database, partAdapter, attachments, filePicker, auth, dialog, shell, navigation);
+        var viewModel = new PartsModuleViewModel(database, partAdapter, attachments, filePicker, auth, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
         viewModel.SelectedRecord = viewModel.Records.First();
 
@@ -122,13 +130,14 @@ public class PartsModuleViewModelTests
         });
 
         var auth = new TestAuthContext { CurrentUser = new User { Id = 5, FullName = "QA" } };
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
         var filePicker = new TestFilePicker();
         var attachments = new TestAttachmentService();
 
-        var viewModel = new PartsModuleViewModel(database, partAdapter, attachments, filePicker, auth, dialog, shell, navigation);
+        var viewModel = new PartsModuleViewModel(database, partAdapter, attachments, filePicker, auth, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
 
         viewModel.SelectedRecord = viewModel.Records.First();

--- a/YasGMP.Wpf.Tests/SuppliersModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/SuppliersModuleViewModelTests.cs
@@ -26,13 +26,14 @@ public class SuppliersModuleViewModelTests
             CurrentDeviceInfo = "UnitTest",
             CurrentIpAddress = "127.0.0.1"
         };
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
         var filePicker = new TestFilePicker();
         var attachments = new TestAttachmentService();
 
-        var viewModel = new SuppliersModuleViewModel(database, supplierAdapter, attachments, filePicker, auth, dialog, shell, navigation);
+        var viewModel = new SuppliersModuleViewModel(database, supplierAdapter, attachments, filePicker, auth, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
 
         viewModel.Mode = FormMode.Add;
@@ -52,6 +53,12 @@ public class SuppliersModuleViewModelTests
         Assert.Equal("contoso", supplier.Name.ToLowerInvariant());
         Assert.Equal("calibration", supplier.SupplierType.ToLowerInvariant());
         Assert.Equal("info@contoso.example", supplier.Email);
+        Assert.Equal("test-signature", supplier.DigitalSignature);
+        Assert.Collection(signatureDialog.Requests, ctx =>
+        {
+            Assert.Equal("suppliers", ctx.TableName);
+            Assert.Equal(0, ctx.RecordId);
+        });
     }
 
     [Fact]
@@ -75,6 +82,7 @@ public class SuppliersModuleViewModelTests
             CurrentDeviceInfo = "UnitTest",
             CurrentIpAddress = "10.10.10.10"
         };
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
@@ -87,7 +95,7 @@ public class SuppliersModuleViewModelTests
             new PickedFile("supplier.txt", "text/plain", () => Task.FromResult<Stream>(new MemoryStream(bytes, writable: false)), bytes.Length)
         };
 
-        var viewModel = new SuppliersModuleViewModel(database, supplierAdapter, attachments, filePicker, auth, dialog, shell, navigation);
+        var viewModel = new SuppliersModuleViewModel(database, supplierAdapter, attachments, filePicker, auth, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
 
         viewModel.SelectedRecord = viewModel.Records.First();
@@ -117,13 +125,14 @@ public class SuppliersModuleViewModelTests
         });
 
         var auth = new TestAuthContext();
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
         var filePicker = new TestFilePicker();
         var attachments = new TestAttachmentService();
 
-        var viewModel = new SuppliersModuleViewModel(database, supplierAdapter, attachments, filePicker, auth, dialog, shell, navigation);
+        var viewModel = new SuppliersModuleViewModel(database, supplierAdapter, attachments, filePicker, auth, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
 
         viewModel.SelectedRecord = viewModel.Records.First();

--- a/YasGMP.Wpf.Tests/TestElectronicSignatureDialogService.cs
+++ b/YasGMP.Wpf.Tests/TestElectronicSignatureDialogService.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using YasGMP.Models;
+using YasGMP.Wpf.Services;
+using YasGMP.Wpf.ViewModels.Dialogs;
+
+namespace YasGMP.Wpf.Tests;
+
+public sealed class TestElectronicSignatureDialogService : IElectronicSignatureDialogService
+{
+    public List<ElectronicSignatureContext> Requests { get; } = new();
+
+    public ElectronicSignatureDialogResult? Result { get; set; } = new ElectronicSignatureDialogResult(
+        "password",
+        "QA",
+        "Automated test",
+        "QA Reason",
+        new DigitalSignature
+        {
+            SignatureHash = "test-signature",
+            Method = "password",
+            Status = "valid"
+        });
+
+    public Exception? ExceptionToThrow { get; set; }
+
+    public Task<ElectronicSignatureDialogResult?> CaptureSignatureAsync(
+        ElectronicSignatureContext context,
+        CancellationToken cancellationToken = default)
+    {
+        Requests.Add(context);
+
+        if (ExceptionToThrow is not null)
+        {
+            throw ExceptionToThrow;
+        }
+
+        return Task.FromResult(Result);
+    }
+}

--- a/YasGMP.Wpf.Tests/WorkOrdersModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/WorkOrdersModuleViewModelTests.cs
@@ -21,11 +21,12 @@ public class WorkOrdersModuleViewModelTests
         var auth = new TestAuthContext { CurrentUser = new User { Id = 9, FullName = "QA" } };
         var filePicker = new TestFilePicker();
         var attachments = new TestAttachmentService();
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
 
-        var viewModel = new WorkOrdersModuleViewModel(database, workOrders, auth, filePicker, attachments, dialog, shell, navigation);
+        var viewModel = new WorkOrdersModuleViewModel(database, workOrders, auth, filePicker, attachments, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
 
         viewModel.Mode = FormMode.Add;
@@ -49,6 +50,12 @@ public class WorkOrdersModuleViewModelTests
         Assert.Equal("Replace gaskets", persisted.Title);
         Assert.Equal(12, persisted.MachineId);
         Assert.Equal(9, persisted.CreatedById);
+        Assert.Equal("test-signature", persisted.DigitalSignature);
+        Assert.Collection(signatureDialog.Requests, ctx =>
+        {
+            Assert.Equal("work_orders", ctx.TableName);
+            Assert.Equal(0, ctx.RecordId);
+        });
         Assert.False(viewModel.IsDirty);
     }
 
@@ -83,6 +90,7 @@ public class WorkOrdersModuleViewModelTests
             CurrentDeviceInfo = "UnitTest",
             CurrentIpAddress = "10.0.0.25"
         };
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
@@ -95,7 +103,7 @@ public class WorkOrdersModuleViewModelTests
             new PickedFile("evidence.txt", "text/plain", () => Task.FromResult<Stream>(new MemoryStream(bytes, writable: false)), bytes.Length)
         };
 
-        var viewModel = new WorkOrdersModuleViewModel(database, workOrders, auth, filePicker, attachments, dialog, shell, navigation);
+        var viewModel = new WorkOrdersModuleViewModel(database, workOrders, auth, filePicker, attachments, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
 
         Assert.True(viewModel.AttachDocumentCommand.CanExecute(null));

--- a/YasGMP.Wpf.Tests/YasGMP.Wpf.Tests.csproj
+++ b/YasGMP.Wpf.Tests/YasGMP.Wpf.Tests.csproj
@@ -24,6 +24,7 @@
     <Compile Include="..\YasGMP.Wpf\Services\IMachineCrudService.cs" Link="Wpf\Services\IMachineCrudService.cs" />
     <Compile Include="..\YasGMP.Wpf\Services\IComponentCrudService.cs" Link="Wpf\Services\IComponentCrudService.cs" />
     <Compile Include="..\YasGMP.Wpf\Services\ICalibrationCrudService.cs" Link="Wpf\Services\ICalibrationCrudService.cs" />
+    <Compile Include="..\YasGMP.Wpf\Services\IElectronicSignatureDialogService.cs" Link="Wpf\Services\IElectronicSignatureDialogService.cs" />
     <Compile Include="..\YasGMP.Wpf\ViewModels\Modules\IncidentsModuleViewModel.cs" Link="Wpf\Modules\IncidentsModuleViewModel.cs" />
     <Compile Include="..\YasGMP.Wpf\ViewModels\Modules\PartsModuleViewModel.cs" Link="Wpf\Modules\PartsModuleViewModel.cs" />
     <Compile Include="..\YasGMP.Wpf\ViewModels\Modules\WarehouseModuleViewModel.cs" Link="Wpf\Modules\WarehouseModuleViewModel.cs" />
@@ -37,5 +38,6 @@
     <Compile Include="..\YasGMP.Wpf\Services\IExternalServicerCrudService.cs" Link="Wpf\Services\IExternalServicerCrudService.cs" />
     <Compile Include="..\YasGMP.Wpf\ViewModels\Modules\SuppliersModuleViewModel.cs" Link="Wpf\Modules\SuppliersModuleViewModel.cs" />
     <Compile Include="..\YasGMP.Wpf\ViewModels\Modules\ExternalServicersModuleViewModel.cs" Link="Wpf\Modules\ExternalServicersModuleViewModel.cs" />
+    <Compile Include="..\YasGMP.Wpf\ViewModels\Dialogs\ElectronicSignatureDialogViewModel.cs" Link="Wpf\Dialogs\ElectronicSignatureDialogViewModel.cs" />
   </ItemGroup>
 </Project>

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -1,10 +1,10 @@
 # Codex Plan — WPF Shell & Full Integration
 
 ## Current Compile Status
-- [ ] Dotnet SDKs detected and recorded *(blocked: `dotnet` CLI not available in container PATH`; `dotnet --info` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-28, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, and 2025-10-30 → **command not found**)*
-- [ ] Solution restores *(pending SDK availability; `dotnet restore` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, and 2025-10-30 → **command not found**)*
-- [ ] MAUI builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, and 2025-10-30 → **command not found**)*
-- [ ] WPF builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, and 2025-10-30 → **command not found**)*
+- [ ] Dotnet SDKs detected and recorded *(blocked: `dotnet` CLI not available in container PATH`; `dotnet --info` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-28, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, and 2025-11-01 → **command not found**)*
+- [ ] Solution restores *(pending SDK availability; `dotnet restore` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, and 2025-11-01 → **command not found**)*
+- [ ] MAUI builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, and 2025-11-01 → **command not found**)*
+- [ ] WPF builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, and 2025-11-01 → **command not found**)*
 
 ## Decisions & Pins
 - Preferred WPF target: **net9.0-windows10.0.19041.0** (retain once .NET 9 SDK is installed).
@@ -16,19 +16,19 @@
 ## Batches
 - **B0 — Environment stabilization** (SDKs, NuGets, XAML namespaces) — **blocked** *(no `dotnet` CLI)*
 - **B1 — Shell foundation** (Ribbon, Docking, StatusBar, FormMode state machine) — [ ] todo
-- **B2 — Cross-cutting** (Attachments DB, E-Signature, Audit) — [ ] todo
+- **B2 — Cross-cutting** (Attachments DB, E-Signature, Audit) — [~] in-progress *(e-sign capture integrated across Assets, Work Orders, Calibration, Suppliers, and Parts; audit surfacing still pending until SDK access returns)*
 - **B3 — Editor framework** (templates, host, unsaved-guard) — [ ] todo
 - **B4+ — Module rollout:**
-  - Assets/Machines — [x] done *(mode-aware CRUD plus attachment upload wired through AttachmentService; e-sign prompt scheduled under Batch B2)*
+  - Assets/Machines — [x] done *(mode-aware CRUD with attachment uploads and e-signature capture via IElectronicSignatureDialogService; audit surfacing still pending)*
   - Components — [x] done *(mode-aware editor wired to ComponentService; attachments/signature work tracked under Batch B2)*
-  - Parts & Warehouses — [x] done *(inventory snapshots, warehouse ledger preview, and stock health warnings surfaced; signature prompts queued for Batch B2)*
-  - Work Orders — [x] done *(CRUD adapter wired with attachments; e-signature/audit surfacing slated for Batch B2)*
-  - Calibration — [x] done *(CRUD editor now supports attachment uploads via AttachmentService; e-signature/audit surfacing remains queued for Batch B2)*
+  - Parts & Warehouses — [x] done *(inventory snapshots, warehouse ledger preview, stock health warnings, and e-signature capture baked into save flows; audit surfacing remains blocked on SDK access)*
+  - Work Orders — [x] done *(CRUD adapter wired with attachments and e-signature capture ahead of adapter calls; audit surfacing queued once SDK access returns)*
+  - Calibration — [x] done *(CRUD editor with attachment uploads and e-signature capture; audit surfacing remains queued for Batch B2)*
   - Incident → CAPA → Change Control — [x] done *(Incidents, CAPA, and Change Control editors now CRUD-capable with attachments; signature/audit prompts queued for Batch B2)*
   - Validations (IQ/OQ/PQ) — [x] done *(mode-aware validation editor with CRUD adapter, CFL, and attachment workflow; signature/audit prompts queued for Batch B2)*
   - Scheduled Jobs — [x] done *(mode-aware editor with execute/acknowledge tooling and attachment workflow; signature/audit surfacing tracked under Batch B2)*
   - Users/Roles — [x] done *(Security module now exposes a CRUD-capable user/role editor with CFL, toolbar modes, and role assignment management; signature prompts queued for Batch B2)*
-  - Suppliers/External Servicers — [x] done *(Suppliers module ships with attachments + CFL; External Servicers cockpit now live with mode-aware CRUD and navigation)*
+  - Suppliers/External Servicers — [x] done *(Suppliers module now enforces electronic signatures on save alongside attachments + CFL; External Servicers cockpit remains mode-aware with CRUD and navigation)*
   - Audit/API Audit — [~] in-progress *(WPF audit trail now pulls filtered entries via AuditService with expanded inspector grid, filters, and explicit empty/error status flags.)*
   - Documents/Attachments — [ ] todo
   - Dashboard/Reports — [ ] todo
@@ -38,8 +38,7 @@
 - `dotnet` executable not found. Install/expose **.NET 9 SDK** and **Windows 10 SDK (19041+)** on the host; if building inside a container, expose host `dotnet` or install within the container. Run `scripts/bootstrap-dotnet9.ps1` to verify and pin via `global.json`. *(2025-09-25 & 2025-09-27 retries confirmed `dotnet --info` continues to fail with **command not found**; 2025-10-09 recheck still reports the command missing.)*
   - Pending inventory of MAUI assets/services/modules; schedule once SDK issue is resolved.
   - Smoke automation is blocked until SDK + Windows tooling are installed.
-  - Work Orders editor still requires e-signature prompt + inspector audit surfacing once Batch B2 unblocks the shared services.
-  - Asset signature prompt and inspector audit surfacing will ride the Batch B2 cross-cutting work once the SDK blocker is cleared.
+- Audit inspector surfacing and smoke automation remain blocked until the SDK gap is resolved.
   - 2025-09-24: Batch 0 rerun inside container confirmed `.NET 9` CLI is still missing; all `dotnet` commands fail immediately. Remains a prerequisite before module CRUD refactors can progress.
 
 ## Notes
@@ -47,6 +46,7 @@
 - `YasGMP.Wpf` already targets .NET 9 and references pinned packages; validate once builds are possible.
 - `tests/fixtures/hello.txt` seeded for upcoming smoke harness scenarios.
 - 2025-10-30: Introduced `AttachmentWorkflowService` in the WPF shell so module view-models share MAUI's dedup/encryption/retention workflow via `AttachmentService` + `DatabaseService.Attachments` helpers; registration and commands now rely on the adapter.
+- 2025-11-01: Assets, Work Orders, Calibration, Suppliers, and Parts now block saves on successful electronic signature capture, persist the resulting digital signature hash, and surface cancellation/failure states through StatusMessage; unit tests gained a reusable signature dialog stub.
 - 2025-10-31: WPF shell now exposes an `IElectronicSignatureDialogService` that drives the signature dialog, captures password/PIN plus GMP reason text, and persists the note via the shared DatabaseService extensions before closing.
 - Assets module now exposes an attachment command that uploads via `IAttachmentService`; coverage added in unit tests.
 - Components module now completes the CRUD rollout with mode-aware editor, validation, and machine lookups; attachment/signature integration remains queued for Batch B2.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -16,7 +16,8 @@
       "2025-10-17: dotnet --info/restore/build retried; CLI still missing so commands exit with 'command not found'.",
       "2025-10-23: dotnet --info/restore/build attempted again; CLI remains unavailable in the container.",
       "2025-10-27: dotnet --info/restore/build/test retried; CLI still missing so commands exit with 'command not found'.",
-      "2025-10-30: dotnet --info/restore/build retried; CLI still absent in container so commands fail with 'command not found'."
+      "2025-10-30: dotnet --info/restore/build retried; CLI still absent in container so commands fail with 'command not found'.",
+      "2025-11-01: dotnet --info/restore/build retried; CLI remains unavailable in the container so commands fail with 'command not found'."
     ]
   },
   "batches": [
@@ -36,7 +37,10 @@
     {
       "id": "B2",
       "name": "Cross-cutting services",
-      "status": "pending"
+      "status": "in-progress",
+      "notes": [
+        "Electronic signature capture now enforced across Assets, Work Orders, Calibration, Suppliers, and Parts; audit surfacing still pending"
+      ]
     },
     {
       "id": "B3",
@@ -70,9 +74,9 @@
   "notes": [
     "Need to restore/install dotnet 9 SDK to proceed with Batch 0 validation steps.",
     "tests/fixtures/hello.txt seeded for smoke harness bootstrap",
-    "Work Orders editor now surfaces CRUD via adapter with attachments; e-signature/audit pending Batch B2",
-    "Calibration editor now exposes CRUD with supplier/component lookups and attachment uploads via IAttachmentService; signature + audit work remains queued for Batch B2",
-    "Assets module now uploads attachments via AttachmentService from the WPF shell; signature prompts tracked under Batch B2.",
+    "Work Orders editor now surfaces CRUD via adapter with attachments and mandatory e-signature capture; audit surfacing still pending Batch B2",
+    "Calibration editor now exposes CRUD with supplier/component lookups, attachment uploads, and mandatory e-signature capture; audit work remains queued for Batch B2",
+    "Assets module now uploads attachments via AttachmentService from the WPF shell and enforces electronic signatures before save; audit surfacing remains pending.",
     "2025-09-24 & 2025-09-26: Batch 0 retries confirmed dotnet CLI still unavailable (`dotnet --info/restore/build` all fail). Awaiting host SDK install before expanding CRUD refactors to Assets module.",
     "2025-09-25: Batch 0 retry again hit 'command not found' for dotnet --info/restore/build in container.",
     "2025-09-27: Batch 0 still blocked in container; dotnet CLI absent so restore/build/smoke cannot execute.",
@@ -80,7 +84,7 @@
     "2025-09-27: Components module reached CRUD parity through ComponentService with machine lookups; cross-cutting attachments/e-signature work scheduled under Batch B2.",
     "2025-09-27: Components module exposes B1-mode editor using ComponentService and machine lookups; attachments/e-signature follow-ups remain.",
     "2025-09-29: WPF mapping updated for Components; adapters documented while awaiting SDK to finish Batch B2 attachment/signature tasks.",
-    "2025-09-30: Parts & Warehouse editors now include stock health messaging, warehouse summaries, and inventory ledger previews while retaining attachment support; e-signature/audit surfacing will follow in Batch B2 once .NET 9 SDK is accessible.",
+    "2025-09-30: Parts & Warehouse editors now include stock health messaging, warehouse summaries, and inventory ledger previews while retaining attachment support; e-signature capture has been added while audit surfacing will follow once .NET 9 SDK is accessible.",
     "2025-09-30: Incidents module now runs through IIncidentCrudService with mode-aware editor and attachment uploads; CAPA/Change Control remain pending.",
     "2025-10-01: Incidents editor exposes CFL-driven linking to work orders and CAPA cases with unit coverage for the new mode transitions.",
     "2025-10-02: CAPA module now persists via ICapaCrudService with component lookups, attachments, and unit coverage for save/attachment flows; Change Control still pending.",
@@ -88,7 +92,7 @@
     "2025-10-04: Validations module now reuses ValidationService through a new adapter with machine/component lookups, CFL picker, and attachment uploads; signature/audit surfacing slated for Batch B2 once .NET 9 SDK is available.",
     "2025-10-05: Scheduled Jobs module now exposes a CRUD-capable editor with execute/acknowledge commands, CFL hooks, and attachment uploads via the new IScheduledJobCrudService adapter; signature/audit prompts remain queued for Batch B2.",
     "2025-10-06: Security (Users/Roles) module now leverages IUserCrudService with RBAC role assignment management, CFL, and unit coverage; signature/audit surfacing will follow under Batch B2.",
-    "2025-10-07: Suppliers module now uses ISupplierCrudService with attachments, CFL, and mode-aware editor coverage; External Servicers remain a follow-up task.",
+    "2025-10-07: Suppliers module now uses ISupplierCrudService with attachments, CFL, mode-aware editor coverage, and mandatory e-signature capture; External Servicers remain a follow-up task.",
     "2025-10-08: External Servicers module now has a dedicated adapter, WPF document, CFL picker, golden-arrow navigation, and unit/smoke harness coverage.",
     "2025-10-09: External Servicer database extensions now drive CRUD (list/load/save/delete) with unit tests asserting `external_contractors` access.",
     "2025-10-10: Audit module now surfaces AuditService-backed filtering with richer inspector columns and WPF coverage; dotnet --info still fails with 'command not found'.",
@@ -112,6 +116,7 @@
     "2025-10-28: Audit filters now retain the user's To picker while reordering the query bounds if the upper date precedes the lower; tests cover both existing From overrides and default-from scenarios.",
     "2025-10-29: Audit module now orders inverted date ranges by min/max while preserving the user-selected To value; WPF tests assert the later bound reaches AuditService at end-of-day.",
     "2025-10-30: WPF modules now route uploads through AttachmentWorkflowService so dedup, retention, and encryption follow the MAUI conventions; DI registration updated and commands now surface dedup status messaging.",
-    "2025-10-31: WPF shell adds an IElectronicSignatureDialogService that drives the signature dialog, captures the operator password/PIN with GMP reason text, and persists through DatabaseServiceDigitalSignaturesExtensions before dismissing."
+    "2025-10-31: WPF shell adds an IElectronicSignatureDialogService that drives the signature dialog, captures the operator password/PIN with GMP reason text, and persists through DatabaseServiceDigitalSignaturesExtensions before dismissing.",
+    "2025-11-01: Assets, Work Orders, Calibration, Suppliers, and Parts now require electronic signature capture before CRUD calls, propagate the resulting digital signature hash, and surface cancellation/failure states through StatusMessage."
   ]
 }


### PR DESCRIPTION
## Summary
- require the electronic signature dialog service when constructing the Assets, Work Orders, Calibration, Suppliers, and Parts module view-models
- capture signatures prior to CRUD calls, persist the returned hashes, and surface cancellation/failure status so operators can retry without leaving edit mode
- expand WPF unit tests with a reusable signature dialog stub and update planning docs to reflect the new cross-cutting progress

## Testing
- `dotnet restore yasgmp.sln` *(fails: `dotnet` command not found in container environment)*
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj` *(fails: `dotnet` command not found in container environment)*
- `dotnet build yasgmp.csproj -f net9.0-windows10.0.19041.0` *(fails: `dotnet` command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da4963cbf88331836e9e7f9886826c