### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf.Tests/AssetsModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/AssetsModuleViewModelTests.cs
@@ -63,6 +63,9 @@ public class AssetsModuleViewModelTests
             Assert.Equal("machines", ctx.TableName);
             Assert.Equal(0, ctx.RecordId);
         });
+        Assert.Single(signatureDialog.PersistedResults);
+        var persistedSignature = signatureDialog.PersistedResults[0];
+        Assert.Equal(machineAdapter.Saved[0].Id, persistedSignature.Signature.RecordId);
     }
 
     [Fact]

--- a/YasGMP.Wpf.Tests/CalibrationModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/CalibrationModuleViewModelTests.cs
@@ -85,6 +85,9 @@ public class CalibrationModuleViewModelTests
             Assert.Equal("calibrations", ctx.TableName);
             Assert.Equal(0, ctx.RecordId);
         });
+        Assert.Single(signatureDialog.PersistedResults);
+        var persistedSignature = signatureDialog.PersistedResults[0];
+        Assert.Equal(calibrationAdapter.Saved[0].Id, persistedSignature.Signature.RecordId);
     }
 
     [Fact]

--- a/YasGMP.Wpf.Tests/CapaModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/CapaModuleViewModelTests.cs
@@ -61,6 +61,9 @@ public class CapaModuleViewModelTests
             Assert.Equal("capa_cases", ctx.TableName);
             Assert.Equal(0, ctx.RecordId);
         });
+        Assert.Single(signatureDialog.PersistedResults);
+        var persistedSignature = signatureDialog.PersistedResults[0];
+        Assert.Equal(capaCrud.Saved[0].Id, persistedSignature.Signature.RecordId);
         Assert.False(viewModel.IsDirty);
     }
 

--- a/YasGMP.Wpf.Tests/ChangeControlModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/ChangeControlModuleViewModelTests.cs
@@ -50,6 +50,9 @@ public class ChangeControlModuleViewModelTests
             Assert.Equal("change_controls", ctx.TableName);
             Assert.Equal(0, ctx.RecordId);
         });
+        Assert.Single(signatureDialog.PersistedResults);
+        var persistedSignature = signatureDialog.PersistedResults[0];
+        Assert.Equal(crud.Saved[0].Id, persistedSignature.Signature.RecordId);
         Assert.False(viewModel.IsDirty);
     }
 

--- a/YasGMP.Wpf.Tests/ComponentsModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/ComponentsModuleViewModelTests.cs
@@ -69,6 +69,9 @@ public class ComponentsModuleViewModelTests
             Assert.Equal("components", ctx.TableName);
             Assert.Equal(0, ctx.RecordId);
         });
+        Assert.Single(signatureDialog.PersistedResults);
+        var persistedSignature = signatureDialog.PersistedResults[0];
+        Assert.Equal(componentAdapter.Saved[0].Id, persistedSignature.Signature.RecordId);
     }
 
     private static Task<bool> InvokeSaveAsync(ComponentsModuleViewModel viewModel)

--- a/YasGMP.Wpf.Tests/ExternalServicersModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/ExternalServicersModuleViewModelTests.cs
@@ -53,6 +53,9 @@ public class ExternalServicersModuleViewModelTests
             Assert.Equal("external_contractors", ctx.TableName);
             Assert.Equal(0, ctx.RecordId);
         });
+        Assert.Single(signatureDialog.PersistedResults);
+        var persistedSignature = signatureDialog.PersistedResults[0];
+        Assert.Equal(service.Saved[0].Id, persistedSignature.Signature.RecordId);
     }
 
     [Fact]

--- a/YasGMP.Wpf.Tests/IncidentsModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/IncidentsModuleViewModelTests.cs
@@ -53,6 +53,9 @@ public class IncidentsModuleViewModelTests
             Assert.Equal("incidents", ctx.TableName);
             Assert.Equal(0, ctx.RecordId);
         });
+        Assert.Single(signatureDialog.PersistedResults);
+        var persistedSignature = signatureDialog.PersistedResults[0];
+        Assert.Equal(incidents.Saved[0].Id, persistedSignature.Signature.RecordId);
         Assert.False(viewModel.IsDirty);
     }
 

--- a/YasGMP.Wpf.Tests/PartsModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/PartsModuleViewModelTests.cs
@@ -62,6 +62,9 @@ public class PartsModuleViewModelTests
             Assert.Equal("parts", ctx.TableName);
             Assert.Equal(0, ctx.RecordId);
         });
+        Assert.Single(signatureDialog.PersistedResults);
+        var persistedSignature = signatureDialog.PersistedResults[0];
+        Assert.Equal(partAdapter.Saved[0].Id, persistedSignature.Signature.RecordId);
     }
 
     [Fact]

--- a/YasGMP.Wpf.Tests/SchedulingModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/SchedulingModuleViewModelTests.cs
@@ -43,6 +43,14 @@ public class SchedulingModuleViewModelTests
         var created = Assert.Single(crud.Saved);
         Assert.Equal("weekly digest", created.JobType);
         Assert.False(viewModel.IsDirty);
+        Assert.Collection(signatureDialog.Requests, ctx =>
+        {
+            Assert.Equal("scheduled_jobs", ctx.TableName);
+            Assert.Equal(0, ctx.RecordId);
+        });
+        Assert.Single(signatureDialog.PersistedResults);
+        var persistedSignature = signatureDialog.PersistedResults[0];
+        Assert.Equal(created.Id, persistedSignature.Signature.RecordId);
     }
 
     [Fact]

--- a/YasGMP.Wpf.Tests/SecurityModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/SecurityModuleViewModelTests.cs
@@ -58,6 +58,9 @@ public class SecurityModuleViewModelTests
             Assert.Equal("users", ctx.TableName);
             Assert.Equal(0, ctx.RecordId);
         });
+        Assert.Single(signatureDialog.PersistedResults);
+        var persistedSignature = signatureDialog.PersistedResults[0];
+        Assert.Equal(created.Id, persistedSignature.Signature.RecordId);
         var assignment = Assert.Single(userService.RoleAssignments);
         Assert.Equal(created.Id, assignment.UserId);
         Assert.Contains(adminRole.RoleId, assignment.Roles);
@@ -113,6 +116,14 @@ public class SecurityModuleViewModelTests
         Assert.Equal(7, updated.Id);
         Assert.Equal(string.Empty, viewModel.Editor.NewPassword);
         Assert.Equal(string.Empty, viewModel.Editor.ConfirmPassword);
+        Assert.Collection(signatureDialog.Requests, ctx =>
+        {
+            Assert.Equal("users", ctx.TableName);
+            Assert.Equal(7, ctx.RecordId);
+        });
+        Assert.Single(signatureDialog.PersistedResults);
+        var persistedSignature = signatureDialog.PersistedResults[0];
+        Assert.Equal(7, persistedSignature.Signature.RecordId);
         var assignment = userService.RoleAssignments.Last();
         Assert.Contains(2, assignment.Roles);
     }

--- a/YasGMP.Wpf.Tests/SuppliersModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/SuppliersModuleViewModelTests.cs
@@ -60,6 +60,9 @@ public class SuppliersModuleViewModelTests
             Assert.Equal("suppliers", ctx.TableName);
             Assert.Equal(0, ctx.RecordId);
         });
+        Assert.Single(signatureDialog.PersistedResults);
+        var persistedSignature = signatureDialog.PersistedResults[0];
+        Assert.Equal(supplierAdapter.Saved[0].Id, persistedSignature.Signature.RecordId);
     }
 
     [Fact]

--- a/YasGMP.Wpf.Tests/ValidationsModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/ValidationsModuleViewModelTests.cs
@@ -50,6 +50,9 @@ public class ValidationsModuleViewModelTests
             Assert.Equal("validations", ctx.TableName);
             Assert.Equal(0, ctx.RecordId);
         });
+        Assert.Single(signatureDialog.PersistedResults);
+        var persistedSignature = signatureDialog.PersistedResults[0];
+        Assert.Equal(crud.Saved[0].Id, persistedSignature.Signature.RecordId);
         Assert.False(viewModel.IsDirty);
     }
 

--- a/YasGMP.Wpf.Tests/WarehouseModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/WarehouseModuleViewModelTests.cs
@@ -58,6 +58,9 @@ public class WarehouseModuleViewModelTests
             Assert.Equal("warehouses", ctx.TableName);
             Assert.Equal(0, ctx.RecordId);
         });
+        Assert.Single(signatureDialog.PersistedResults);
+        var persistedSignature = signatureDialog.PersistedResults[0];
+        Assert.Equal(warehouseAdapter.Saved[0].Id, persistedSignature.Signature.RecordId);
     }
 
     [Fact]

--- a/YasGMP.Wpf.Tests/WorkOrdersModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/WorkOrdersModuleViewModelTests.cs
@@ -57,6 +57,9 @@ public class WorkOrdersModuleViewModelTests
             Assert.Equal("work_orders", ctx.TableName);
             Assert.Equal(0, ctx.RecordId);
         });
+        Assert.Single(signatureDialog.PersistedResults);
+        var persistedSignature = signatureDialog.PersistedResults[0];
+        Assert.Equal(workOrders.Saved[0].Id, persistedSignature.Signature.RecordId);
         Assert.False(viewModel.IsDirty);
     }
 

--- a/YasGMP.Wpf/Services/IElectronicSignatureDialogService.cs
+++ b/YasGMP.Wpf/Services/IElectronicSignatureDialogService.cs
@@ -13,9 +13,20 @@ public interface IElectronicSignatureDialogService
     /// Presents the electronic signature dialog and returns the captured metadata when confirmed.
     /// </summary>
     /// <param name="context">Target record context for the signature.</param>
-    /// <param name="cancellationToken">Token used to observe cancellation while persisting.</param>
+    /// <param name="cancellationToken">Token used to observe cancellation while the dialog is shown.</param>
     /// <returns>The captured signature metadata when confirmed; otherwise <c>null</c>.</returns>
     Task<ElectronicSignatureDialogResult?> CaptureSignatureAsync(
         ElectronicSignatureContext context,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Persists the supplied signature payload without re-opening the dialog.
+    /// Callers may update <see cref="ElectronicSignatureDialogResult.Signature"/> (e.g. record id)
+    /// before invoking this method.
+    /// </summary>
+    /// <param name="result">The capture result that should be persisted.</param>
+    /// <param name="cancellationToken">Token used to observe cancellation while persisting.</param>
+    Task PersistSignatureAsync(
+        ElectronicSignatureDialogResult result,
         CancellationToken cancellationToken = default);
 }

--- a/YasGMP.Wpf/ViewModels/Modules/B1FormDocumentViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/B1FormDocumentViewModel.cs
@@ -344,17 +344,25 @@ public abstract partial class B1FormDocumentViewModel : DocumentViewModel
                 return false;
             }
 
+            var previousMessage = StatusMessage;
             var saved = await OnSaveAsync().ConfigureAwait(false);
             if (saved)
             {
-                StatusMessage = $"{Title} saved successfully.";
+                if (string.IsNullOrWhiteSpace(StatusMessage) || StatusMessage == previousMessage)
+                {
+                    StatusMessage = $"{Title} saved successfully.";
+                }
+
                 ResetDirty();
                 Mode = FormMode.View;
                 await RefreshAsync().ConfigureAwait(false);
             }
             else
             {
-                StatusMessage = $"No changes to save for {Title}.";
+                if (string.IsNullOrWhiteSpace(StatusMessage) || StatusMessage == previousMessage)
+                {
+                    StatusMessage = $"No changes to save for {Title}.";
+                }
             }
 
             return saved;

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -50,6 +50,7 @@
 - 2025-11-02: Test project relocated the electronic signature dialog fake into `TestDoubles`, added queueable results/exception hooks, and updated module/unit factories to inject the dependency explicitly.
 - 2025-11-03: Extended IElectronicSignatureDialogService integration across Components, Warehouses, Incidents, Validations, CAPA, Change Control, External Servicers, Scheduling, and Security modules with metadata propagation and refreshed unit coverage.
 - 2025-11-04: Assets (machines) save flow now enriches the persisted machine with last-modified metadata after signature capture to keep downstream persistence aligned with Issue 3 requirements.
+- 2025-11-05: Electronic signature dialog service now separates capture from persistence, allowing modules to update generated record ids, persist the business entity first, and retry signature storage with clear status messaging when failures occur.
 - 2025-10-31: WPF shell now exposes an `IElectronicSignatureDialogService` that drives the signature dialog, captures password/PIN plus GMP reason text, and persists the note via the shared DatabaseService extensions before closing.
 - Assets module now exposes an attachment command that uploads via `IAttachmentService`; coverage added in unit tests.
 - Components module now completes the CRUD rollout with mode-aware editor, validation, machine lookups, and electronic signature capture ahead of persistence.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -121,6 +121,7 @@
     "2025-11-01: Assets, Work Orders, Calibration, Suppliers, and Parts now require electronic signature capture before CRUD calls, propagate the resulting digital signature hash, and surface cancellation/failure states through StatusMessage.",
     "2025-11-02: Test suite moved the electronic signature dialog fake under TestDoubles, added queueable results/exception hooks, and updated module tests to inject the dependency explicitly.",
     "2025-11-03: Extended electronic signature gating and metadata propagation to Components, Warehouses, Incidents, Validations, CAPA, Change Control, External Servicers, Scheduled Jobs, and Security modules with refreshed unit coverage (audit surfacing still pending SDK access).",
-    "2025-11-04: Machines save workflow now stamps last-modified metadata post signature capture so downstream persistence receives the enriched payload while SDK blockers remain."
+    "2025-11-04: Machines save workflow now stamps last-modified metadata post signature capture so downstream persistence receives the enriched payload while SDK blockers remain.",
+    "2025-11-05: Electronic signature capture now decouples persistence via PersistSignatureAsync so modules can persist business entities first, update signature record ids, and surface clear retry messaging when digital signature storage fails."
   ]
 }


### PR DESCRIPTION
## Summary
- extend IElectronicSignatureDialogService with a PersistSignatureAsync method and update the WPF implementation to separate capture from storage so callers can adjust record ids before writing to the database
- rework every module save path to capture signatures, persist the business entity, update signature metadata, and invoke the new persistence API while leaving forms in edit mode with clear status messaging on failure
- align B1FormDocumentViewModel status handling and refresh WPF unit tests/test doubles plus codex documentation to reflect the new capture/persist workflow

## Testing
- `dotnet restore yasgmp.sln` *(fails: dotnet CLI unavailable in container)*
- `dotnet build yasgmp.sln -c Release` *(fails: dotnet CLI unavailable in container)*
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj -c Release` *(fails: dotnet CLI unavailable in container)*
- `dotnet build yasgmp.csproj -c Release` *(fails: dotnet CLI unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da625b608c8331891f5d1009b33606