### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -52,6 +52,7 @@
 - 2025-11-04: Assets (machines) save flow now enriches the persisted machine with last-modified metadata after signature capture to keep downstream persistence aligned with Issue 3 requirements.
 - 2025-11-05: Electronic signature dialog service now separates capture from persistence, allowing modules to update generated record ids, persist the business entity first, and retry signature storage with clear status messaging when failures occur.
 - 2025-11-06: Assets editor now surfaces full e-sign metadata (hash, signer, reason, session/IP) via the new SignatureAwareEditor base and SignatureMetadataView control; save flow stamps the metadata before persistence while SDK access remains blocked.
+- 2025-11-07: B1 form base now tracks a status message version counter so save flows can distinguish module-supplied messaging from default fallbacks even when the text remains unchanged.
 - 2025-10-31: WPF shell now exposes an `IElectronicSignatureDialogService` that drives the signature dialog, captures password/PIN plus GMP reason text, and persists the note via the shared DatabaseService extensions before closing.
 - Assets module now exposes an attachment command that uploads via `IAttachmentService`; coverage added in unit tests.
 - Components module now completes the CRUD rollout with mode-aware editor, validation, machine lookups, and electronic signature capture ahead of persistence.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -18,7 +18,8 @@
       "2025-10-27: dotnet --info/restore/build/test retried; CLI still missing so commands exit with 'command not found'.",
       "2025-10-30: dotnet --info/restore/build retried; CLI still absent in container so commands fail with 'command not found'.",
       "2025-11-01: dotnet --info/restore/build retried; CLI remains unavailable in the container so commands fail with 'command not found'.",
-      "2025-11-02: dotnet restore/build retried; CLI remains unavailable so commands exit with 'command not found'."
+      "2025-11-02: dotnet restore/build retried; CLI remains unavailable so commands exit with 'command not found'.",
+      "2025-11-07: dotnet restore retried for yasgmp.sln; CLI still missing so command exits with 'command not found'."
     ]
   },
   "batches": [
@@ -123,6 +124,7 @@
     "2025-11-03: Extended electronic signature gating and metadata propagation to Components, Warehouses, Incidents, Validations, CAPA, Change Control, External Servicers, Scheduled Jobs, and Security modules with refreshed unit coverage (audit surfacing still pending SDK access).",
     "2025-11-04: Machines save workflow now stamps last-modified metadata post signature capture so downstream persistence receives the enriched payload while SDK blockers remain.",
     "2025-11-05: Electronic signature capture now decouples persistence via PersistSignatureAsync so modules can persist business entities first, update signature record ids, and surface clear retry messaging when digital signature storage fails.",
-    "2025-11-06: Assets module now derives from SignatureAwareEditor, capturing signer/session/IP metadata and exposing it via the shared SignatureMetadataView control after each save while SDK tooling remains unavailable."
+    "2025-11-06: Assets module now derives from SignatureAwareEditor, capturing signer/session/IP metadata and exposing it via the shared SignatureMetadataView control after each save while SDK tooling remains unavailable.",
+    "2025-11-07: B1 form base now increments a status message version counter so save flows can detect module-supplied messaging even when the text remains unchanged."
   ]
 }


### PR DESCRIPTION
## Summary
- replace the source-generated StatusMessage with a manual implementation that increments a version counter on every assignment and always pushes updates through the shell service
- capture the status message version during saves so default success/failure fallbacks only trigger when both the message and version remain unchanged
- document the counter work and repeated dotnet restore failure in codex_plan.md and codex_progress.json

## Testing
- ❌ `dotnet restore yasgmp.sln` *(fails: command not found: dotnet in container PATH)*
- ❌ `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj` *(fails: command not found: dotnet in container PATH)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence). *(blocked: dotnet CLI unavailable in container)*
- [ ] MAUI builds/runs unaffected. *(blocked: dotnet CLI unavailable in container)*
- [ ] Shared AppCore extraction complete where required; adapters compiled.
- [ ] ModulesPane lists every module and opens feature-parity editors.
- [ ] B1 FormModes & command enablement wired across editors.
- [ ] CFL pickers + Golden Arrow navigation working.
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end.
- [ ] Warehouse ledger with running balance and alerts.
- [ ] Audit surfacing + e-signature prompts on critical saves.
- [ ] Attachments DB-backed with upload/preview/download.
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented.
- [ ] Smoke tests succeed and log output.
- [ ] README_WPF_SHELL.md and /docs/WPF_MAPPING.md kept current.

------
https://chatgpt.com/codex/tasks/task_e_68da72f3f7d4833189eb2a38fddcb9e9