### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf.Tests/B1FormDocumentViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/B1FormDocumentViewModelTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using YasGMP.Wpf.Services;
+using YasGMP.Wpf.ViewModels.Modules;
+
+namespace YasGMP.Wpf.Tests;
+
+public class B1FormDocumentViewModelTests
+{
+    [Fact]
+    public async Task SaveAsync_PreservesCancellationMessage()
+    {
+        const string cancellationMessage = "Save cancelled by integration";
+        var viewModel = new TestDocumentViewModel(
+            new NullCflDialogService(),
+            new PassiveShellInteractionService(),
+            new PassiveModuleNavigationService(),
+            cancellationMessage);
+
+        viewModel.Mode = FormMode.Add;
+        viewModel.IsDirty = true;
+        viewModel.StatusMessage = "Pending save";
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        Assert.Equal(cancellationMessage, viewModel.StatusMessage);
+        Assert.True(viewModel.IsDirty);
+        Assert.Equal(FormMode.Add, viewModel.Mode);
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        Assert.Equal(cancellationMessage, viewModel.StatusMessage);
+        Assert.True(viewModel.IsDirty);
+        Assert.Equal(FormMode.Add, viewModel.Mode);
+    }
+
+    private sealed class TestDocumentViewModel : B1FormDocumentViewModel
+    {
+        private readonly string _cancellationMessage;
+
+        public TestDocumentViewModel(
+            ICflDialogService cflDialogService,
+            IShellInteractionService shellInteraction,
+            IModuleNavigationService moduleNavigation,
+            string cancellationMessage)
+            : base("Test", "Test", cflDialogService, shellInteraction, moduleNavigation)
+        {
+            _cancellationMessage = cancellationMessage;
+        }
+
+        protected override Task<IReadOnlyList<ModuleRecord>> LoadAsync(object? parameter)
+            => Task.FromResult<IReadOnlyList<ModuleRecord>>(Array.Empty<ModuleRecord>());
+
+        protected override IReadOnlyList<ModuleRecord> CreateDesignTimeRecords()
+            => Array.Empty<ModuleRecord>();
+
+        protected override Task<bool> OnSaveAsync()
+        {
+            StatusMessage = _cancellationMessage;
+            return Task.FromResult(false);
+        }
+    }
+
+    private sealed class NullCflDialogService : ICflDialogService
+    {
+        public Task<CflResult?> ShowAsync(CflRequest request)
+            => Task.FromResult<CflResult?>(null);
+    }
+
+    private sealed class PassiveShellInteractionService : IShellInteractionService
+    {
+        public void UpdateInspector(InspectorContext context)
+        {
+        }
+
+        public void UpdateStatus(string message)
+        {
+        }
+    }
+
+    private sealed class PassiveModuleNavigationService : IModuleNavigationService
+    {
+        public void Activate(ModuleDocumentViewModel document)
+        {
+        }
+
+        public ModuleDocumentViewModel OpenModule(string moduleKey, object? parameter = null)
+            => throw new NotSupportedException();
+    }
+}

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -1,10 +1,10 @@
 # Codex Plan — WPF Shell & Full Integration
 
 ## Current Compile Status
-- [ ] Dotnet SDKs detected and recorded *(blocked: `dotnet` CLI not available in container PATH`; `dotnet --info` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-28, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, and 2025-11-04 → **command not found**)*
-- [ ] Solution restores *(pending SDK availability; `dotnet restore` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, and 2025-11-04 → **command not found**)*
-- [ ] MAUI builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, and 2025-11-04 → **command not found**)*
-- [ ] WPF builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, and 2025-11-04 → **command not found**)*
+- [ ] Dotnet SDKs detected and recorded *(blocked: `dotnet` CLI not available in container PATH`; `dotnet --info` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-28, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-04, and 2025-11-07 → **command not found**)*
+- [ ] Solution restores *(pending SDK availability; `dotnet restore` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, and 2025-11-07 → **command not found**)*
+- [ ] MAUI builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, and 2025-11-07 → **command not found**)*
+- [ ] WPF builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, and 2025-11-07 → **command not found**)*
 
 ## Decisions & Pins
 - Preferred WPF target: **net9.0-windows10.0.19041.0** (retain once .NET 9 SDK is installed).
@@ -52,6 +52,7 @@
 - 2025-11-04: Assets (machines) save flow now enriches the persisted machine with last-modified metadata after signature capture to keep downstream persistence aligned with Issue 3 requirements.
 - 2025-11-05: Electronic signature dialog service now separates capture from persistence, allowing modules to update generated record ids, persist the business entity first, and retry signature storage with clear status messaging when failures occur.
 - 2025-11-06: Assets editor now surfaces full e-sign metadata (hash, signer, reason, session/IP) via the new SignatureAwareEditor base and SignatureMetadataView control; save flow stamps the metadata before persistence while SDK access remains blocked.
+- 2025-11-07: Added `B1FormDocumentViewModel` regression coverage to ensure cancellation status text, dirty tracking, and form mode remain intact when `OnSaveAsync` returns false; SDK/tooling still blocked by missing `dotnet` CLI.
 - 2025-10-31: WPF shell now exposes an `IElectronicSignatureDialogService` that drives the signature dialog, captures password/PIN plus GMP reason text, and persists the note via the shared DatabaseService extensions before closing.
 - Assets module now exposes an attachment command that uploads via `IAttachmentService`; coverage added in unit tests.
 - Components module now completes the CRUD rollout with mode-aware editor, validation, machine lookups, and electronic signature capture ahead of persistence.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -18,7 +18,8 @@
       "2025-10-27: dotnet --info/restore/build/test retried; CLI still missing so commands exit with 'command not found'.",
       "2025-10-30: dotnet --info/restore/build retried; CLI still absent in container so commands fail with 'command not found'.",
       "2025-11-01: dotnet --info/restore/build retried; CLI remains unavailable in the container so commands fail with 'command not found'.",
-      "2025-11-02: dotnet restore/build retried; CLI remains unavailable so commands exit with 'command not found'."
+      "2025-11-02: dotnet restore/build retried; CLI remains unavailable so commands exit with 'command not found'.",
+      "2025-11-07: dotnet restore retried; CLI still missing in container so all dotnet commands fail with 'command not found'."
     ]
   },
   "batches": [
@@ -123,6 +124,7 @@
     "2025-11-03: Extended electronic signature gating and metadata propagation to Components, Warehouses, Incidents, Validations, CAPA, Change Control, External Servicers, Scheduled Jobs, and Security modules with refreshed unit coverage (audit surfacing still pending SDK access).",
     "2025-11-04: Machines save workflow now stamps last-modified metadata post signature capture so downstream persistence receives the enriched payload while SDK blockers remain.",
     "2025-11-05: Electronic signature capture now decouples persistence via PersistSignatureAsync so modules can persist business entities first, update signature record ids, and surface clear retry messaging when digital signature storage fails.",
-    "2025-11-06: Assets module now derives from SignatureAwareEditor, capturing signer/session/IP metadata and exposing it via the shared SignatureMetadataView control after each save while SDK tooling remains unavailable."
+    "2025-11-06: Assets module now derives from SignatureAwareEditor, capturing signer/session/IP metadata and exposing it via the shared SignatureMetadataView control after each save while SDK tooling remains unavailable.",
+    "2025-11-07: Added B1FormDocumentViewModel cancellation regression test ensuring status text, dirty flag, and form mode remain intact when OnSaveAsync returns false; restore/build remain blocked pending dotnet CLI access."
   ]
 }


### PR DESCRIPTION
## Summary
- add a focused B1FormDocumentViewModel regression test to verify cancellation messaging, dirty tracking, and mode state remain intact when OnSaveAsync returns false
- record the new coverage and the latest dotnet CLI blocker retry in codex_plan.md and codex_progress.json

## Testing
- ❌ `dotnet restore` (missing dotnet CLI inside container)
- ❌ `dotnet build yasgmp.sln` (missing dotnet CLI inside container)

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence).
- [ ] MAUI builds/runs unaffected.
- [ ] Shared AppCore extraction complete where required; adapters compiled.
- [ ] ModulesPane lists every module and opens feature-parity editors.
- [ ] B1 FormModes & command enablement wired across editors.
- [ ] CFL pickers + Golden Arrow navigation working.
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end.
- [ ] Warehouse ledger with running balance and alerts.
- [ ] Audit surfacing + e-signature prompts on critical saves.
- [ ] Attachments DB-backed with upload/preview/download.
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented.
- [ ] Smoke tests succeed and log output.
- [ ] README_WPF_SHELL.md and /docs/WPF_MAPPING.md kept current.

------
https://chatgpt.com/codex/tasks/task_e_68da75526fb48331ab274a4de9d8ea60