### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf.Tests/ChangeControlModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/ChangeControlModuleViewModelTests.cs
@@ -73,11 +73,12 @@ public class ChangeControlModuleViewModelTests
         var auth = new TestAuthContext { CurrentUser = new User { Id = 3 } };
         var filePicker = new TestFilePicker();
         var attachments = new TestAttachmentService();
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
 
-        var viewModel = new ChangeControlModuleViewModel(database, crud, auth, filePicker, attachments, dialog, shell, navigation);
+        var viewModel = new ChangeControlModuleViewModel(database, crud, auth, filePicker, attachments, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
 
         viewModel.SelectedRecord = viewModel.Records.First();

--- a/YasGMP.Wpf.Tests/ExternalServicersModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/ExternalServicersModuleViewModelTests.cs
@@ -95,11 +95,12 @@ public class ExternalServicersModuleViewModelTests
     {
         var service = new FakeExternalServicerCrudService();
         var auth = new TestAuthContext();
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
 
-        var viewModel = new ExternalServicersModuleViewModel(service, auth, dialog, shell, navigation);
+        var viewModel = new ExternalServicersModuleViewModel(service, auth, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
 
         Assert.False(viewModel.IsEditorEnabled);

--- a/YasGMP.Wpf.Tests/IncidentsModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/IncidentsModuleViewModelTests.cs
@@ -92,6 +92,7 @@ public class IncidentsModuleViewModelTests
             CurrentDeviceInfo = "UnitTest",
             CurrentIpAddress = "10.0.0.5"
         };
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
@@ -104,7 +105,7 @@ public class IncidentsModuleViewModelTests
             new PickedFile("evidence.txt", "text/plain", () => Task.FromResult<Stream>(new MemoryStream(bytes, writable: false)), bytes.Length)
         };
 
-        var viewModel = new IncidentsModuleViewModel(database, incidents, auth, filePicker, attachments, dialog, shell, navigation);
+        var viewModel = new IncidentsModuleViewModel(database, incidents, auth, filePicker, attachments, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
 
         Assert.True(viewModel.AttachEvidenceCommand.CanExecute(null));
@@ -141,11 +142,12 @@ public class IncidentsModuleViewModelTests
         var auth = new TestAuthContext();
         var filePicker = new TestFilePicker();
         var attachments = new TestAttachmentService();
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
 
-        var viewModel = new IncidentsModuleViewModel(database, incidents, auth, filePicker, attachments, dialog, shell, navigation);
+        var viewModel = new IncidentsModuleViewModel(database, incidents, auth, filePicker, attachments, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
         viewModel.Mode = FormMode.Add;
 
@@ -167,11 +169,12 @@ public class IncidentsModuleViewModelTests
         var auth = new TestAuthContext();
         var filePicker = new TestFilePicker();
         var attachments = new TestAttachmentService();
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
 
-        var viewModel = new IncidentsModuleViewModel(database, incidents, auth, filePicker, attachments, dialog, shell, navigation);
+        var viewModel = new IncidentsModuleViewModel(database, incidents, auth, filePicker, attachments, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
         viewModel.Mode = FormMode.Add;
 

--- a/YasGMP.Wpf.Tests/SchedulingModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/SchedulingModuleViewModelTests.cs
@@ -113,11 +113,12 @@ public class SchedulingModuleViewModelTests
         var auth = new TestAuthContext { CurrentUser = new User { Id = 9 } };
         var filePicker = new TestFilePicker();
         var attachments = new TestAttachmentService();
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
 
-        var viewModel = new SchedulingModuleViewModel(database, crud, auth, filePicker, attachments, dialog, shell, navigation);
+        var viewModel = new SchedulingModuleViewModel(database, crud, auth, filePicker, attachments, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
 
         viewModel.SelectedRecord = viewModel.Records.First();

--- a/YasGMP.Wpf.Tests/WarehouseModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/WarehouseModuleViewModelTests.cs
@@ -82,6 +82,7 @@ public class WarehouseModuleViewModelTests
             CurrentDeviceInfo = "UnitTest",
             CurrentIpAddress = "10.10.0.10"
         };
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
@@ -94,7 +95,7 @@ public class WarehouseModuleViewModelTests
             new PickedFile("warehouse.txt", "text/plain", () => Task.FromResult<Stream>(new MemoryStream(bytes, writable: false)), bytes.Length)
         };
 
-        var viewModel = new WarehouseModuleViewModel(database, warehouseAdapter, attachments, filePicker, auth, dialog, shell, navigation);
+        var viewModel = new WarehouseModuleViewModel(database, warehouseAdapter, attachments, filePicker, auth, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
         viewModel.SelectedRecord = viewModel.Records.First();
 
@@ -142,13 +143,14 @@ public class WarehouseModuleViewModelTests
             PerformedById: 4));
 
         var auth = new TestAuthContext { CurrentUser = new User { Id = 9, FullName = "QA" } };
+        var signatureDialog = new TestElectronicSignatureDialogService();
         var dialog = new TestCflDialogService();
         var shell = new TestShellInteractionService();
         var navigation = new TestModuleNavigationService();
         var filePicker = new TestFilePicker();
         var attachments = new TestAttachmentService();
 
-        var viewModel = new WarehouseModuleViewModel(database, warehouseAdapter, attachments, filePicker, auth, dialog, shell, navigation);
+        var viewModel = new WarehouseModuleViewModel(database, warehouseAdapter, attachments, filePicker, auth, signatureDialog, dialog, shell, navigation);
         await viewModel.InitializeAsync(null);
 
         viewModel.SelectedRecord = viewModel.Records.First();

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -1,10 +1,10 @@
 # Codex Plan — WPF Shell & Full Integration
 
 ## Current Compile Status
-- [ ] Dotnet SDKs detected and recorded *(blocked: `dotnet` CLI not available in container PATH`; `dotnet --info` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-28, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-04, and 2025-11-07 → **command not found**)*
-- [ ] Solution restores *(pending SDK availability; `dotnet restore` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, and 2025-11-07 → **command not found**)*
-- [ ] MAUI builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, and 2025-11-07 → **command not found**)*
-- [ ] WPF builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, and 2025-11-07 → **command not found**)*
+- [ ] Dotnet SDKs detected and recorded *(blocked: `dotnet` CLI not available in container PATH`; `dotnet --info` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-28, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-04, 2025-11-07, and 2025-11-09 → **command not found**)*
+- [ ] Solution restores *(pending SDK availability; `dotnet restore` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, 2025-11-07, and 2025-11-09 → **command not found**)*
+- [ ] MAUI builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, 2025-11-07, and 2025-11-09 → **command not found**)*
+- [ ] WPF builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, 2025-11-07, and 2025-11-09 → **command not found**)*
 
 ## Decisions & Pins
 - Preferred WPF target: **net9.0-windows10.0.19041.0** (retain once .NET 9 SDK is installed).
@@ -54,6 +54,7 @@
 - 2025-11-06: Assets editor now surfaces full e-sign metadata (hash, signer, reason, session/IP) via the new SignatureAwareEditor base and SignatureMetadataView control; save flow stamps the metadata before persistence while SDK access remains blocked.
 - 2025-11-07: Added `B1FormDocumentViewModel` regression coverage to ensure cancellation status text, dirty tracking, and form mode remain intact when `OnSaveAsync` returns false; SDK/tooling still blocked by missing `dotnet` CLI.
 - 2025-11-08: Introduced `TestElectronicSignatureDialogService` with queueable confirmations/cancellations/exceptions and updated module/unit factories to consume the new helper while keeping the legacy fake as an alias.
+- 2025-11-09: Updated WPF module unit tests to inject `TestElectronicSignatureDialogService` in the new constructor slot after attachment workflow services; dotnet CLI still unavailable so test runs remain blocked.
 - 2025-10-31: WPF shell now exposes an `IElectronicSignatureDialogService` that drives the signature dialog, captures password/PIN plus GMP reason text, and persists the note via the shared DatabaseService extensions before closing.
 - Assets module now exposes an attachment command that uploads via `IAttachmentService`; coverage added in unit tests.
 - Components module now completes the CRUD rollout with mode-aware editor, validation, machine lookups, and electronic signature capture ahead of persistence.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -20,7 +20,8 @@
       "2025-11-01: dotnet --info/restore/build retried; CLI remains unavailable in the container so commands fail with 'command not found'.",
       "2025-11-02: dotnet restore/build retried; CLI remains unavailable so commands exit with 'command not found'.",
       "2025-11-07: dotnet restore retried; CLI still missing in container so all dotnet commands fail with 'command not found'.",
-      "2025-11-08: dotnet restore/build retried; CLI remains unavailable in the container so commands exit with 'command not found'."
+      "2025-11-08: dotnet restore/build retried; CLI remains unavailable in the container so commands exit with 'command not found'.",
+      "2025-11-09: dotnet restore/build/test retried; CLI still missing in the container so all dotnet commands fail with 'command not found'."
     ]
   },
   "batches": [
@@ -73,7 +74,7 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "test: introduce queueable electronic signature dialog service",
+  "lastCommitSummary": "fix: align WPF module tests with signature dialog injection",
   "notes": [
     "Need to restore/install dotnet 9 SDK to proceed with Batch 0 validation steps.",
     "tests/fixtures/hello.txt seeded for smoke harness bootstrap",
@@ -127,6 +128,7 @@
     "2025-11-05: Electronic signature capture now decouples persistence via PersistSignatureAsync so modules can persist business entities first, update signature record ids, and surface clear retry messaging when digital signature storage fails.",
     "2025-11-06: Assets module now derives from SignatureAwareEditor, capturing signer/session/IP metadata and exposing it via the shared SignatureMetadataView control after each save while SDK tooling remains unavailable.",
     "2025-11-07: Added B1FormDocumentViewModel cancellation regression test ensuring status text, dirty flag, and form mode remain intact when OnSaveAsync returns false; restore/build remain blocked pending dotnet CLI access.",
-    "2025-11-08: Replaced the legacy FakeElectronicSignatureDialogService with the queueable TestElectronicSignatureDialogService and updated module tests to consume the new helper while leaving an obsolete alias for backwards compatibility."
+    "2025-11-08: Replaced the legacy FakeElectronicSignatureDialogService with the queueable TestElectronicSignatureDialogService and updated module tests to consume the new helper while leaving an obsolete alias for backwards compatibility.",
+    "2025-11-09: Updated Change Control, External Servicers, Warehouse, Scheduling, and Incidents WPF tests to pass TestElectronicSignatureDialogService in the production constructor slot; test execution still blocked until dotnet CLI is available."
   ]
 }


### PR DESCRIPTION
## Summary
- inject the TestElectronicSignatureDialogService stub into change control, external servicers, warehouse, scheduling, and incidents module tests to match the production constructor signature
- update module test helpers to accommodate the additional signature dialog dependency
- refresh codex plan/progress logs to capture the new constructor ordering work and continued dotnet CLI outage

## Testing
- `dotnet restore yasgmp.sln` *(fails: `dotnet`: command not found in container)*
- `dotnet build yasgmp.sln` *(fails: `dotnet`: command not found in container)*
- `dotnet test YasGMP.Wpf.Tests/YasGMP.Wpf.Tests.csproj` *(fails: `dotnet`: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da7d42a28c83318570038b2887b2dd