### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -16,7 +16,7 @@
 ## Batches
 - **B0 — Environment stabilization** (SDKs, NuGets, XAML namespaces) — **blocked** *(no `dotnet` CLI)*
 - **B1 — Shell foundation** (Ribbon, Docking, StatusBar, FormMode state machine) — [ ] todo
-- **B2 — Cross-cutting** (Attachments DB, E-Signature, Audit) — [~] in-progress *(e-sign capture now spans Assets, Components, Warehouses, Incidents, CAPA, Change Control, Validations, Scheduled Jobs, Suppliers, External Servicers, Users, and Work Orders; audit surfacing still pending until SDK access returns)*
+- **B2 — Cross-cutting** (Attachments DB, E-Signature, Audit) — [~] in-progress *(e-sign capture now spans Assets, Components, Warehouses, Incidents, CAPA, Change Control, Validations, Scheduled Jobs, Suppliers, External Servicers, Users, and Work Orders; WPF adapters now push captured signature metadata into entities/audit stamps while core APIs await expansion; audit surfacing still pending until SDK access returns)*
 - **B3 — Editor framework** (templates, host, unsaved-guard) — [ ] todo
 - **B4+ — Module rollout:**
   - Assets/Machines — [x] done *(mode-aware CRUD with attachment uploads and e-signature capture via IElectronicSignatureDialogService; audit surfacing still pending)*
@@ -89,6 +89,7 @@
 - 2025-10-28: Audit filters now keep the user's "To" picker intact while ordering the query bounds when the upper date precedes the lower; WPF coverage adds a default-from regression asserting the service respects the earlier upper bound.
 - 2025-10-29: Audit filters now order query bounds by min/max so inverted ranges still span the full window while preserving the user's "To" picker; WPF regression coverage asserts the service receives the later bound's end-of-day timestamp.
 - 2025-11-11: CRUD context factories now expose signature id/hash/method/status/note members with an overload that accepts `ElectronicSignatureDialogResult`, letting module save flows hydrate audit metadata alongside user/IP/session defaults.
+- 2025-11-12: Machine, Work Order, Calibration, Supplier, and Part adapters now hydrate captured signature hash/method/status/note onto their entities before persistence and include the metadata in supplier/part audit stamps while core services await extended signatures support.
 - Next actionable slice once SDK access is restored: wire Assets attachments + signatures, then replicate CRUD pattern for Components.
 - 2025-09-26: Assets editor now drives MachineService CRUD + validation with mode-aware UI; run smoke harness once SDK restored.
 - 2025-09-27: Components module now surfaces a CRUD-capable editor using ComponentService with machine lookups; attachments/e-signature integration tracked under Batch B2.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -43,7 +43,7 @@
       "name": "Cross-cutting services",
       "status": "in-progress",
       "notes": [
-        "Electronic signature capture now enforced across Assets, Work Orders, Calibration, Suppliers, and Parts; audit surfacing still pending"
+        "Electronic signature capture now enforced across Assets, Work Orders, Calibration, Suppliers, and Parts; WPF adapters now hydrate captured signature metadata onto entities/audit stamps while core APIs await expansion; audit surfacing still pending"
       ]
     },
     {
@@ -119,6 +119,7 @@
     "2025-10-27: Audit filters now clamp the lower bound when the upper bound is moved earlier while keeping the selected end date intact; new WPF regression test ensures persisted filters and query arguments align.",
     "2025-10-28: Audit filters now retain the user's To picker while reordering the query bounds if the upper date precedes the lower; tests cover both existing From overrides and default-from scenarios.",
     "2025-11-11: CRUD context factories in the WPF services now capture signature id/hash/method/status/note and surface an overload that accepts `ElectronicSignatureDialogResult`, enabling modules to forward dialog metadata alongside user/IP/session defaults before hitting adapters.",
+    "2025-11-12: Machine, Work Order, Calibration, Supplier, and Part WPF adapters now apply captured signature hash/method/status/note to entities before persistence and include the metadata in supplier/part audit logging while awaiting core signature API expansion.",
     "2025-10-29: Audit module now orders inverted date ranges by min/max while preserving the user-selected To value; WPF tests assert the later bound reaches AuditService at end-of-day.",
     "2025-10-30: WPF modules now route uploads through AttachmentWorkflowService so dedup, retention, and encryption follow the MAUI conventions; DI registration updated and commands now surface dedup status messaging.",
     "2025-10-31: WPF shell adds an IElectronicSignatureDialogService that drives the signature dialog, captures the operator password/PIN with GMP reason text, and persists through DatabaseServiceDigitalSignaturesExtensions before dismissing.",


### PR DESCRIPTION
## Summary
- propagate captured signature hash/method/status/note through the Machine, Work Order, Calibration, Supplier, and Part adapters before delegating to the shared services
- enrich Supplier/Part stamping to persist the supplied signature hash and include signature metadata in audit entries with legacy fallbacks for older schemas
- refresh codex planning/progress notes to reflect the adapter metadata work and ongoing SDK blocking status

## Testing
- ❌ `dotnet restore yasgmp.sln` *(blocked: `dotnet` CLI not installed in container)*
- ❌ `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj -c Release` *(blocked: `dotnet` CLI not installed in container)*
- ❌ `dotnet build YasGMP.Maui/YasGMP.Maui.csproj -c Release` *(blocked: `dotnet` CLI not installed in container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence) *(blocked until .NET SDK available)*
- [ ] MAUI builds/runs unaffected *(blocked until .NET SDK available)*
- [ ] Shared AppCore extraction complete where required; adapters compiled *(continuing incrementally alongside SDK availability)*
- [ ] ModulesPane lists every module and opens feature-parity editors *(tracked across ongoing module rollout)*
- [ ] B1 FormModes & command enablement wired across editors *(tracked via module-level tasks)*
- [ ] CFL pickers + Golden Arrow navigation working *(tracked; no change in this batch)*
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end *(tracked; adapters updated here while full verification awaits builds)*
- [ ] Warehouse ledger with running balance and alerts *(tracked; no change in this batch)*
- [ ] Audit surfacing + e-signature prompts on critical saves *(partially implemented; signature metadata forwarding updated in this batch)*
- [ ] Attachments DB-backed with upload/preview/download *(tracked; no change in this batch)*
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented *(documentation in progress; no change in this batch)*
- [ ] Smoke tests succeed and log output *(blocked until .NET SDK + Windows automation stack available)*
- [ ] README_WPF_SHELL.md and /docs/WPF_MAPPING.md kept current *(pending broader documentation sweep once SDK access restored)*

------
https://chatgpt.com/codex/tasks/task_e_68db670868288331ba38b5f139b11c6f