### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.AppCore/Models/Calibration.cs
+++ b/YasGMP.AppCore/Models/Calibration.cs
@@ -68,6 +68,11 @@ namespace YasGMP.Models
         [Display(Name = "Napomena/uvjeti")]
         public string Comment { get; set; } = string.Empty;
 
+        /// <summary>Reference to persisted digital signature metadata.</summary>
+        [Column("digital_signature_id")]
+        [Display(Name = "ID digitalnog potpisa")]
+        public int? DigitalSignatureId { get; set; }
+
         /// <summary>Digital signature (name, hash, or e-signature of creator or approver).</summary>
         [MaxLength(128)]
         [Column("digital_signature")]

--- a/YasGMP.AppCore/Models/Machine.cs
+++ b/YasGMP.AppCore/Models/Machine.cs
@@ -168,6 +168,10 @@ namespace YasGMP.Models
         [ForeignKey(nameof(LastModifiedById))]
         public virtual User? LastModifiedBy { get; set; }
 
+        [Column("digital_signature_id")]
+        [Display(Name = "ID digitalnog potpisa")]
+        public int? DigitalSignatureId { get; set; }
+
         [StringLength(128)]
         [Column("digital_signature")]
         [Display(Name = "Digitalni potpis")]

--- a/YasGMP.AppCore/Models/Part.cs
+++ b/YasGMP.AppCore/Models/Part.cs
@@ -106,6 +106,9 @@ namespace YasGMP.Models
         [MaxLength(255)]
         public string? RegulatoryCertificates { get; set; }
 
+        [Column("digital_signature_id")]
+        public int? DigitalSignatureId { get; set; }
+
         [Column("digital_signature")]
         [MaxLength(255)]
         public string? DigitalSignature { get; set; }

--- a/YasGMP.AppCore/Models/Supplier.cs
+++ b/YasGMP.AppCore/Models/Supplier.cs
@@ -84,6 +84,9 @@ namespace YasGMP.Models
         [NotMapped]
         public string GmpComment { get; set; } = string.Empty;
 
+        [Column("digital_signature_id")]
+        public int? DigitalSignatureId { get; set; }
+
         [MaxLength(128)]
         [Column("digital_signature")]
         public string DigitalSignature { get; set; } = string.Empty;

--- a/YasGMP.AppCore/Models/WorkOrder.cs
+++ b/YasGMP.AppCore/Models/WorkOrder.cs
@@ -162,6 +162,10 @@ namespace YasGMP.Models
         public string Notes { get; set; } = string.Empty;
 
         // ========== ADVANCED / FORENSIC ==========
+        [Column("digital_signature_id")]
+        [Display(Name = "ID digitalnog potpisa")]
+        public int? DigitalSignatureId { get; set; }
+
         [StringLength(128)]
         [Column("digital_signature")]
         [Display(Name = "Digitalni potpis")]

--- a/YasGMP.AppCore/Services/CalibrationService.cs
+++ b/YasGMP.AppCore/Services/CalibrationService.cs
@@ -267,6 +267,11 @@ namespace YasGMP.Services
             string hash = metadata?.Hash ?? cal.DigitalSignature ?? legacyFactory();
             cal.DigitalSignature = hash;
 
+            if (metadata?.Id.HasValue == true)
+            {
+                cal.DigitalSignatureId = metadata.Id;
+            }
+
             if (!string.IsNullOrWhiteSpace(metadata?.IpAddress))
             {
                 cal.SourceIp = metadata.IpAddress!;

--- a/YasGMP.AppCore/Services/DatabaseService.Calibrations.Extensions.cs
+++ b/YasGMP.AppCore/Services/DatabaseService.Calibrations.Extensions.cs
@@ -20,14 +20,31 @@ namespace YasGMP.Services
     {
         public static async Task<List<Calibration>> GetAllCalibrationsAsync(this DatabaseService db, CancellationToken token = default)
         {
-            const string sql = @"SELECT 
+            const string sqlPreferred = @"SELECT
+    id, component_id, supplier_id, calibration_date, next_due, cert_doc, result, comment,
+    digital_signature, digital_signature_id, last_modified, last_modified_by_id, source_ip,
+    approved, approved_at, approved_by_id, previous_calibration_id, next_calibration_id,
+    change_version, is_deleted
+FROM calibrations
+ORDER BY calibration_date DESC, id DESC";
+
+            const string sqlLegacy = @"SELECT
     id, component_id, supplier_id, calibration_date, next_due, cert_doc, result, comment,
     digital_signature, last_modified, last_modified_by_id, source_ip,
     approved, approved_at, approved_by_id, previous_calibration_id, next_calibration_id,
     change_version, is_deleted
 FROM calibrations
 ORDER BY calibration_date DESC, id DESC";
-            var dt = await db.ExecuteSelectAsync(sql, null, token).ConfigureAwait(false);
+
+            System.Data.DataTable dt;
+            try
+            {
+                dt = await db.ExecuteSelectAsync(sqlPreferred, null, token).ConfigureAwait(false);
+            }
+            catch (MySqlException ex) when (ex.Number == 1054)
+            {
+                dt = await db.ExecuteSelectAsync(sqlLegacy, null, token).ConfigureAwait(false);
+            }
             var list = new List<Calibration>(dt.Rows.Count);
             foreach (DataRow r in dt.Rows) list.Add(Parse(r));
             return list;
@@ -35,25 +52,57 @@ ORDER BY calibration_date DESC, id DESC";
 
         public static async Task<Calibration?> GetCalibrationByIdAsync(this DatabaseService db, int id, CancellationToken token = default)
         {
-            const string sql = @"SELECT 
+            const string sqlPreferred = @"SELECT
+    id, component_id, supplier_id, calibration_date, next_due, cert_doc, result, comment,
+    digital_signature, digital_signature_id, last_modified, last_modified_by_id, source_ip,
+    approved, approved_at, approved_by_id, previous_calibration_id, next_calibration_id,
+    change_version, is_deleted
+FROM calibrations WHERE id=@id LIMIT 1";
+
+            const string sqlLegacy = @"SELECT
     id, component_id, supplier_id, calibration_date, next_due, cert_doc, result, comment,
     digital_signature, last_modified, last_modified_by_id, source_ip,
     approved, approved_at, approved_by_id, previous_calibration_id, next_calibration_id,
     change_version, is_deleted
 FROM calibrations WHERE id=@id LIMIT 1";
-            var dt = await db.ExecuteSelectAsync(sql, new[] { new MySqlParameter("@id", id) }, token).ConfigureAwait(false);
+
+            System.Data.DataTable dt;
+            try
+            {
+                dt = await db.ExecuteSelectAsync(sqlPreferred, new[] { new MySqlParameter("@id", id) }, token).ConfigureAwait(false);
+            }
+            catch (MySqlException ex) when (ex.Number == 1054)
+            {
+                dt = await db.ExecuteSelectAsync(sqlLegacy, new[] { new MySqlParameter("@id", id) }, token).ConfigureAwait(false);
+            }
             return dt.Rows.Count == 1 ? Parse(dt.Rows[0]) : null;
         }
 
         public static async Task<List<Calibration>> GetCalibrationsForComponentAsync(this DatabaseService db, int componentId, CancellationToken token = default)
         {
-            const string sql = @"SELECT 
+            const string sqlPreferred = @"SELECT
+    id, component_id, supplier_id, calibration_date, next_due, cert_doc, result, comment,
+    digital_signature, digital_signature_id, last_modified, last_modified_by_id, source_ip,
+    approved, approved_at, approved_by_id, previous_calibration_id, next_calibration_id,
+    change_version, is_deleted
+FROM calibrations WHERE component_id=@cid ORDER BY calibration_date DESC, id DESC";
+
+            const string sqlLegacy = @"SELECT
     id, component_id, supplier_id, calibration_date, next_due, cert_doc, result, comment,
     digital_signature, last_modified, last_modified_by_id, source_ip,
     approved, approved_at, approved_by_id, previous_calibration_id, next_calibration_id,
     change_version, is_deleted
 FROM calibrations WHERE component_id=@cid ORDER BY calibration_date DESC, id DESC";
-            var dt = await db.ExecuteSelectAsync(sql, new[] { new MySqlParameter("@cid", componentId) }, token).ConfigureAwait(false);
+
+            System.Data.DataTable dt;
+            try
+            {
+                dt = await db.ExecuteSelectAsync(sqlPreferred, new[] { new MySqlParameter("@cid", componentId) }, token).ConfigureAwait(false);
+            }
+            catch (MySqlException ex) when (ex.Number == 1054)
+            {
+                dt = await db.ExecuteSelectAsync(sqlLegacy, new[] { new MySqlParameter("@cid", componentId) }, token).ConfigureAwait(false);
+            }
             var list = new List<Calibration>(dt.Rows.Count);
             foreach (DataRow r in dt.Rows) list.Add(Parse(r));
             return list;
@@ -61,13 +110,29 @@ FROM calibrations WHERE component_id=@cid ORDER BY calibration_date DESC, id DES
 
         public static async Task<List<Calibration>> GetCalibrationsBySupplierAsync(this DatabaseService db, int supplierId, CancellationToken token = default)
         {
-            const string sql = @"SELECT 
+            const string sqlPreferred = @"SELECT
+    id, component_id, supplier_id, calibration_date, next_due, cert_doc, result, comment,
+    digital_signature, digital_signature_id, last_modified, last_modified_by_id, source_ip,
+    approved, approved_at, approved_by_id, previous_calibration_id, next_calibration_id,
+    change_version, is_deleted
+FROM calibrations WHERE supplier_id=@sid ORDER BY calibration_date DESC, id DESC";
+
+            const string sqlLegacy = @"SELECT
     id, component_id, supplier_id, calibration_date, next_due, cert_doc, result, comment,
     digital_signature, last_modified, last_modified_by_id, source_ip,
     approved, approved_at, approved_by_id, previous_calibration_id, next_calibration_id,
     change_version, is_deleted
 FROM calibrations WHERE supplier_id=@sid ORDER BY calibration_date DESC, id DESC";
-            var dt = await db.ExecuteSelectAsync(sql, new[] { new MySqlParameter("@sid", supplierId) }, token).ConfigureAwait(false);
+
+            System.Data.DataTable dt;
+            try
+            {
+                dt = await db.ExecuteSelectAsync(sqlPreferred, new[] { new MySqlParameter("@sid", supplierId) }, token).ConfigureAwait(false);
+            }
+            catch (MySqlException ex) when (ex.Number == 1054)
+            {
+                dt = await db.ExecuteSelectAsync(sqlLegacy, new[] { new MySqlParameter("@sid", supplierId) }, token).ConfigureAwait(false);
+            }
             var list = new List<Calibration>(dt.Rows.Count);
             foreach (DataRow r in dt.Rows) list.Add(Parse(r));
             return list;
@@ -75,14 +140,30 @@ FROM calibrations WHERE supplier_id=@sid ORDER BY calibration_date DESC, id DESC
 
         public static async Task<List<Calibration>> GetCalibrationsByDateRangeAsync(this DatabaseService db, DateTime from, DateTime to, CancellationToken token = default)
         {
-            const string sql = @"SELECT 
+            const string sqlPreferred = @"SELECT
+    id, component_id, supplier_id, calibration_date, next_due, cert_doc, result, comment,
+    digital_signature, digital_signature_id, last_modified, last_modified_by_id, source_ip,
+    approved, approved_at, approved_by_id, previous_calibration_id, next_calibration_id,
+    change_version, is_deleted
+FROM calibrations WHERE calibration_date BETWEEN @f AND @t ORDER BY calibration_date DESC, id DESC";
+
+            const string sqlLegacy = @"SELECT
     id, component_id, supplier_id, calibration_date, next_due, cert_doc, result, comment,
     digital_signature, last_modified, last_modified_by_id, source_ip,
     approved, approved_at, approved_by_id, previous_calibration_id, next_calibration_id,
     change_version, is_deleted
 FROM calibrations WHERE calibration_date BETWEEN @f AND @t ORDER BY calibration_date DESC, id DESC";
+
             var pars = new[] { new MySqlParameter("@f", from), new MySqlParameter("@t", to) };
-            var dt = await db.ExecuteSelectAsync(sql, pars, token).ConfigureAwait(false);
+            System.Data.DataTable dt;
+            try
+            {
+                dt = await db.ExecuteSelectAsync(sqlPreferred, pars, token).ConfigureAwait(false);
+            }
+            catch (MySqlException ex) when (ex.Number == 1054)
+            {
+                dt = await db.ExecuteSelectAsync(sqlLegacy, pars, token).ConfigureAwait(false);
+            }
             var list = new List<Calibration>(dt.Rows.Count);
             foreach (DataRow r in dt.Rows) list.Add(Parse(r));
             return list;
@@ -101,11 +182,21 @@ FROM calibrations WHERE calibration_date BETWEEN @f AND @t ORDER BY calibration_
                 c.DigitalSignature = signatureMetadata!.Hash!;
             }
 
+            if (signatureMetadata?.Id.HasValue == true)
+            {
+                c.DigitalSignatureId = signatureMetadata.Id;
+            }
+
             c.SourceIp = effectiveIp;
 
-            string insert = @"INSERT INTO calibrations (component_id, supplier_id, calibration_date, next_due, cert_doc, result, comment, digital_signature, source_ip)
+            int? initialSignatureId = c.DigitalSignatureId;
+
+            string insert = @"INSERT INTO calibrations (component_id, supplier_id, calibration_date, next_due, cert_doc, result, comment, digital_signature, source_ip, digital_signature_id)
+                              VALUES (@cid,@sid,@cd,@due,@doc,@res,@comm,@sig,@ip,@sig_id)";
+            string insertLegacy = @"INSERT INTO calibrations (component_id, supplier_id, calibration_date, next_due, cert_doc, result, comment, digital_signature, source_ip)
                               VALUES (@cid,@sid,@cd,@due,@doc,@res,@comm,@sig,@ip)";
-            string updateSql = @"UPDATE calibrations SET component_id=@cid, supplier_id=@sid, calibration_date=@cd, next_due=@due, cert_doc=@doc, result=@res, comment=@comm, digital_signature=@sig, source_ip=@ip WHERE id=@id";
+            string updateSql = @"UPDATE calibrations SET component_id=@cid, supplier_id=@sid, calibration_date=@cd, next_due=@due, cert_doc=@doc, result=@res, comment=@comm, digital_signature=@sig, source_ip=@ip, digital_signature_id=@sig_id WHERE id=@id";
+            string updateLegacy = @"UPDATE calibrations SET component_id=@cid, supplier_id=@sid, calibration_date=@cd, next_due=@due, cert_doc=@doc, result=@res, comment=@comm, digital_signature=@sig, source_ip=@ip WHERE id=@id";
 
             var pars = new List<MySqlParameter>
             {
@@ -117,22 +208,75 @@ FROM calibrations WHERE calibration_date BETWEEN @f AND @t ORDER BY calibration_
                 new("@res", c.Result ?? string.Empty),
                 new("@comm", c.Comment ?? string.Empty),
                 new("@sig", c.DigitalSignature ?? string.Empty),
-                new("@ip", effectiveIp)
+                new("@ip", effectiveIp),
+                new("@sig_id", (object?)c.DigitalSignatureId ?? DBNull.Value)
             };
             if (update) pars.Add(new MySqlParameter("@id", c.Id));
 
             if (!update)
             {
-                await db.ExecuteNonQueryAsync(insert, pars, token).ConfigureAwait(false);
+                try
+                {
+                    await db.ExecuteNonQueryAsync(insert, pars, token).ConfigureAwait(false);
+                }
+                catch (MySqlException ex) when (ex.Number == 1054)
+                {
+                    var legacyPars = new List<MySqlParameter>(pars);
+                    legacyPars.RemoveAll(p => p.ParameterName.Equals("@sig_id", StringComparison.OrdinalIgnoreCase));
+                    await db.ExecuteNonQueryAsync(insertLegacy, legacyPars, token).ConfigureAwait(false);
+                }
+
                 var idObj = await db.ExecuteScalarAsync("SELECT LAST_INSERT_ID()", null, token).ConfigureAwait(false);
                 c.Id = Convert.ToInt32(idObj);
             }
             else
             {
-                await db.ExecuteNonQueryAsync(updateSql, pars, token).ConfigureAwait(false);
+                try
+                {
+                    await db.ExecuteNonQueryAsync(updateSql, pars, token).ConfigureAwait(false);
+                }
+                catch (MySqlException ex) when (ex.Number == 1054)
+                {
+                    var legacyPars = new List<MySqlParameter>(pars);
+                    legacyPars.RemoveAll(p => p.ParameterName.Equals("@sig_id", StringComparison.OrdinalIgnoreCase));
+                    await db.ExecuteNonQueryAsync(updateLegacy, legacyPars, token).ConfigureAwait(false);
+                }
             }
 
             await db.LogSystemEventAsync(actorUserId, update ? "CAL_UPDATE" : "CAL_CREATE", "calibrations", "CalibrationModule", c.Id, null, effectiveIp, "audit", effectiveDevice, effectiveSession, token: token).ConfigureAwait(false);
+
+            if (signatureMetadata != null)
+            {
+                var signatureRecord = new DigitalSignature
+                {
+                    Id = signatureMetadata.Id ?? 0,
+                    TableName = "calibrations",
+                    RecordId = c.Id,
+                    UserId = actorUserId,
+                    SignatureHash = signatureMetadata.Hash ?? c.DigitalSignature,
+                    Method = signatureMetadata.Method,
+                    Status = signatureMetadata.Status,
+                    Note = signatureMetadata.Note,
+                    SignedAt = DateTime.UtcNow,
+                    DeviceInfo = signatureMetadata.Device ?? effectiveDevice,
+                    IpAddress = effectiveIp,
+                    SessionId = signatureMetadata.Session ?? effectiveSession
+                };
+
+                var persistedId = await db.InsertDigitalSignatureAsync(signatureRecord, token).ConfigureAwait(false);
+                if (persistedId > 0)
+                {
+                    signatureMetadata.Id = persistedId;
+                    if (c.DigitalSignatureId != persistedId)
+                    {
+                        c.DigitalSignatureId = persistedId;
+                        if (persistedId != initialSignatureId)
+                        {
+                            await db.TryUpdateEntitySignatureIdAsync("calibrations", "id", c.Id, "digital_signature_id", persistedId, token).ConfigureAwait(false);
+                        }
+                    }
+                }
+            }
             return c.Id;
         }
 
@@ -172,6 +316,7 @@ FROM calibrations WHERE calibration_date BETWEEN @f AND @t ORDER BY calibration_
                 Result = S("result"),
                 Comment = S("comment"),
                 DigitalSignature = S("digital_signature"),
+                DigitalSignatureId = GetIntN("digital_signature_id"),
                 LastModified = GetDate("last_modified"),
                 LastModifiedById = GetIntN("last_modified_by_id"),
                 SourceIp = S("source_ip"),

--- a/YasGMP.AppCore/Services/PartService.cs
+++ b/YasGMP.AppCore/Services/PartService.cs
@@ -134,6 +134,11 @@ namespace YasGMP.Services
             string hash = metadata?.Hash ?? part.DigitalSignature ?? legacyFactory();
             part.DigitalSignature = hash;
 
+            if (metadata?.Id.HasValue == true)
+            {
+                part.DigitalSignatureId = metadata.Id;
+            }
+
             if (!string.IsNullOrWhiteSpace(metadata?.IpAddress))
             {
                 part.SourceIp = metadata.IpAddress!;

--- a/YasGMP.AppCore/Services/SupplierService.cs
+++ b/YasGMP.AppCore/Services/SupplierService.cs
@@ -42,7 +42,14 @@ namespace YasGMP.Services
             ValidateSupplier(supplier);
 
             ApplySignatureMetadata(supplier, signatureMetadata, () => ComputeLegacyDigitalSignature(supplier));
-            await _db.InsertOrUpdateSupplierAsync(supplier, update: false, signatureMetadata: signatureMetadata);
+            await _db.InsertOrUpdateSupplierAsync(
+                supplier,
+                update: false,
+                signatureMetadata: signatureMetadata,
+                actorUserId: userId,
+                ip: signatureMetadata?.IpAddress ?? string.Empty,
+                device: signatureMetadata?.Device ?? string.Empty,
+                sessionId: signatureMetadata?.Session);
 
             await LogAudit(
                 supplier.Id,
@@ -56,7 +63,14 @@ namespace YasGMP.Services
             ValidateSupplier(supplier);
 
             ApplySignatureMetadata(supplier, signatureMetadata, () => ComputeLegacyDigitalSignature(supplier));
-            await _db.InsertOrUpdateSupplierAsync(supplier, update: true, signatureMetadata: signatureMetadata);
+            await _db.InsertOrUpdateSupplierAsync(
+                supplier,
+                update: true,
+                signatureMetadata: signatureMetadata,
+                actorUserId: userId,
+                ip: signatureMetadata?.IpAddress ?? string.Empty,
+                device: signatureMetadata?.Device ?? string.Empty,
+                sessionId: signatureMetadata?.Session);
 
             await LogAudit(
                 supplier.Id,
@@ -101,7 +115,14 @@ namespace YasGMP.Services
                 " | Suspended: ", reason, " (", DateTime.UtcNow.ToString("dd.MM.yyyy"), ")");
 
             ApplySignatureMetadata(supplier, signatureMetadata, () => ComputeLegacyDigitalSignature(supplier));
-            await _db.InsertOrUpdateSupplierAsync(supplier, update: true, signatureMetadata: signatureMetadata);
+            await _db.InsertOrUpdateSupplierAsync(
+                supplier,
+                update: true,
+                signatureMetadata: signatureMetadata,
+                actorUserId: userId,
+                ip: signatureMetadata?.IpAddress ?? string.Empty,
+                device: signatureMetadata?.Device ?? string.Empty,
+                sessionId: signatureMetadata?.Session);
 
             await LogAudit(
                 supplierId,
@@ -150,6 +171,11 @@ namespace YasGMP.Services
 
             string hash = metadata?.Hash ?? supplier.DigitalSignature ?? legacyFactory();
             supplier.DigitalSignature = hash;
+
+            if (metadata?.Id.HasValue == true)
+            {
+                supplier.DigitalSignatureId = metadata.Id;
+            }
 
             if (!string.IsNullOrWhiteSpace(metadata?.IpAddress))
             {

--- a/YasGMP.AppCore/Services/WorkOrderService.cs
+++ b/YasGMP.AppCore/Services/WorkOrderService.cs
@@ -217,6 +217,11 @@ namespace YasGMP.Services
             string hash = metadata?.Hash ?? order.DigitalSignature ?? legacyFactory();
             order.DigitalSignature = hash;
 
+            if (metadata?.Id.HasValue == true)
+            {
+                order.DigitalSignatureId = metadata.Id;
+            }
+
             if (!string.IsNullOrWhiteSpace(metadata?.Device))
             {
                 order.DeviceInfo = metadata.Device;

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -43,6 +43,8 @@
 
 ## Notes
 - 2025-11-13: Completed signature metadata DTO propagation through Machine, Work Order, Calibration, Supplier, and Part services plus DatabaseService helpers; persistence now accepts optional metadata and falls back to the legacy hash generator when absent, while WPF adapters feed DTOs downstream.
+- 2025-11-14: Database helpers for machines, work orders, calibrations, suppliers, and parts now persist digital_signature_id columns when present, tolerate legacy schemas, and upsert the digital_signatures table with hash/method/status/note metadata while propagating the resulting signature id back to DTOs and audit flows.
+- 2025-11-15: Read-side queries for calibrations, work orders, and parts now prefer the digital_signature_id column with legacy fallbacks so editors and audit trails can reuse persisted signature references regardless of schema vintage.
 - `scripts/bootstrap-dotnet9.ps1` added to guide host setup *(installs/verifies .NET 9, Windows SDK, runs restore/build, seeds smoke test fixture).* 
 - `YasGMP.Wpf` already targets .NET 9 and references pinned packages; validate once builds are possible.
 - `tests/fixtures/hello.txt` seeded for upcoming smoke harness scenarios.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -74,7 +74,7 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "test: cover signature cancellation flows",
+  "lastCommitSummary": "fix: hydrate signature ids on read queries",
   "notes": [
     "Need to restore/install dotnet 9 SDK to proceed with Batch 0 validation steps.",
     "tests/fixtures/hello.txt seeded for smoke harness bootstrap",
@@ -133,6 +133,8 @@
     "2025-11-08: Replaced the legacy FakeElectronicSignatureDialogService with the queueable TestElectronicSignatureDialogService and updated module tests to consume the new helper while leaving an obsolete alias for backwards compatibility.",
     "2025-11-09: Updated Change Control, External Servicers, Warehouse, Scheduling, and Incidents WPF tests to pass TestElectronicSignatureDialogService in the production constructor slot; test execution still blocked until dotnet CLI is available.",
     "2025-11-10: Added signature cancellation/exception coverage across Assets, Components, and Work Orders WPF tests to ensure edit mode persists and adapters are skipped when capture fails; dotnet CLI remains unavailable so restore/build/test commands continue to be blocked.",
-    "2025-11-13: AppCore services and database helpers now accept optional SignatureMetadataDto values, persisting supplied hashes/IP/session/device data while falling back to the legacy generator when metadata is absent; WPF adapters forward DTOs downstream."
+    "2025-11-13: AppCore services and database helpers now accept optional SignatureMetadataDto values, persisting supplied hashes/IP/session/device data while falling back to the legacy generator when metadata is absent; WPF adapters forward DTOs downstream.",
+    "2025-11-14: DatabaseService helpers now write digital_signature_id columns when present, fall back for legacy schemas, and upsert digital_signatures with method/status/note metadata while propagating the resulting id back to SignatureMetadataDto consumers.",
+    "2025-11-15: Read paths for work orders, calibrations, and parts now include digital_signature_id with safe fallbacks so UI/audit layers can rely on persisted signature references even on legacy schemas."
   ]
 }


### PR DESCRIPTION
## Summary
- persist digital_signature_id values across machines, work orders, calibrations, suppliers, and parts while tolerating legacy schemas
- upsert digital_signatures with supplied hash/method/status/note metadata and propagate generated ids back to DTOs and services
- refresh signature-aware services/models/docs so audit flows receive the new signature ids

## Testing
- dotnet restore *(fails: command not found in container)*
- dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db78c929308331b448a1db02e6f618