### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf.Tests/AssetsModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/AssetsModuleViewModelTests.cs
@@ -58,6 +58,11 @@ public class AssetsModuleViewModelTests
         Assert.Equal("test-signature", persisted.DigitalSignature);
         Assert.Equal(7, persisted.LastModifiedById);
         Assert.NotEqual(default, persisted.LastModified);
+        var context = Assert.Single(machineAdapter.SavedContexts);
+        Assert.Equal("test-signature", context.SignatureHash);
+        Assert.Equal("password", context.SignatureMethod);
+        Assert.Equal("valid", context.SignatureStatus);
+        Assert.Equal("Automated test", context.SignatureNote);
         Assert.Collection(signatureDialog.Requests, ctx =>
         {
             Assert.Equal("machines", ctx.TableName);
@@ -66,6 +71,15 @@ public class AssetsModuleViewModelTests
         Assert.Single(signatureDialog.PersistedResults);
         var persistedSignature = signatureDialog.PersistedResults[0];
         Assert.Equal(machineAdapter.Saved[0].Id, persistedSignature.Signature.RecordId);
+        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
+        Assert.True(persistedSignature.Signature.Id > 0);
+        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
+        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
+        Assert.Equal(machineAdapter.Saved[0].Id, persistedMetadata.RecordId);
+        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
+        Assert.Equal("password", persistedMetadata.Method);
+        Assert.Equal("valid", persistedMetadata.Status);
+        Assert.Equal("Automated test", persistedMetadata.Note);
     }
 
     [Fact]

--- a/YasGMP.Wpf.Tests/CalibrationModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/CalibrationModuleViewModelTests.cs
@@ -80,6 +80,11 @@ public class CalibrationModuleViewModelTests
         Assert.Equal("PASS", persisted.Result);
         Assert.Equal("CERT-001.pdf", persisted.CertDoc);
         Assert.Equal("test-signature", persisted.DigitalSignature);
+        var context = Assert.Single(calibrationAdapter.SavedContexts);
+        Assert.Equal("test-signature", context.SignatureHash);
+        Assert.Equal("password", context.SignatureMethod);
+        Assert.Equal("valid", context.SignatureStatus);
+        Assert.Equal("Automated test", context.SignatureNote);
         Assert.Collection(signatureDialog.Requests, ctx =>
         {
             Assert.Equal("calibrations", ctx.TableName);
@@ -88,6 +93,15 @@ public class CalibrationModuleViewModelTests
         Assert.Single(signatureDialog.PersistedResults);
         var persistedSignature = signatureDialog.PersistedResults[0];
         Assert.Equal(calibrationAdapter.Saved[0].Id, persistedSignature.Signature.RecordId);
+        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
+        Assert.True(persistedSignature.Signature.Id > 0);
+        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
+        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
+        Assert.Equal(calibrationAdapter.Saved[0].Id, persistedMetadata.RecordId);
+        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
+        Assert.Equal("password", persistedMetadata.Method);
+        Assert.Equal("valid", persistedMetadata.Status);
+        Assert.Equal("Automated test", persistedMetadata.Note);
     }
 
     [Fact]

--- a/YasGMP.Wpf.Tests/CapaModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/CapaModuleViewModelTests.cs
@@ -56,6 +56,11 @@ public class CapaModuleViewModelTests
         Assert.Equal("Supplier qualification", persisted.Title);
         Assert.Equal("High", persisted.Priority);
         Assert.Equal("test-signature", persisted.DigitalSignature);
+        var context = Assert.Single(capaCrud.SavedContexts);
+        Assert.Equal("test-signature", context.SignatureHash);
+        Assert.Equal("password", context.SignatureMethod);
+        Assert.Equal("valid", context.SignatureStatus);
+        Assert.Equal("Automated test", context.SignatureNote);
         Assert.Collection(signatureDialog.Requests, ctx =>
         {
             Assert.Equal("capa_cases", ctx.TableName);
@@ -64,6 +69,15 @@ public class CapaModuleViewModelTests
         Assert.Single(signatureDialog.PersistedResults);
         var persistedSignature = signatureDialog.PersistedResults[0];
         Assert.Equal(capaCrud.Saved[0].Id, persistedSignature.Signature.RecordId);
+        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
+        Assert.True(persistedSignature.Signature.Id > 0);
+        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
+        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
+        Assert.Equal(capaCrud.Saved[0].Id, persistedMetadata.RecordId);
+        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
+        Assert.Equal("password", persistedMetadata.Method);
+        Assert.Equal("valid", persistedMetadata.Status);
+        Assert.Equal("Automated test", persistedMetadata.Note);
         Assert.False(viewModel.IsDirty);
     }
 

--- a/YasGMP.Wpf.Tests/ChangeControlModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/ChangeControlModuleViewModelTests.cs
@@ -45,6 +45,11 @@ public class ChangeControlModuleViewModelTests
         Assert.Equal("Validate HVAC filters", created.Title);
         Assert.Equal("CC-UNIT-100", created.Code);
         Assert.True(created.LastModified.HasValue);
+        var context = Assert.Single(crud.SavedContexts);
+        Assert.Equal("test-signature", context.SignatureHash);
+        Assert.Equal("password", context.SignatureMethod);
+        Assert.Equal("valid", context.SignatureStatus);
+        Assert.Equal("Automated test", context.SignatureNote);
         Assert.Collection(signatureDialog.Requests, ctx =>
         {
             Assert.Equal("change_controls", ctx.TableName);
@@ -53,6 +58,15 @@ public class ChangeControlModuleViewModelTests
         Assert.Single(signatureDialog.PersistedResults);
         var persistedSignature = signatureDialog.PersistedResults[0];
         Assert.Equal(crud.Saved[0].Id, persistedSignature.Signature.RecordId);
+        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
+        Assert.True(persistedSignature.Signature.Id > 0);
+        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
+        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
+        Assert.Equal(crud.Saved[0].Id, persistedMetadata.RecordId);
+        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
+        Assert.Equal("password", persistedMetadata.Method);
+        Assert.Equal("valid", persistedMetadata.Status);
+        Assert.Equal("Automated test", persistedMetadata.Note);
         Assert.False(viewModel.IsDirty);
     }
 

--- a/YasGMP.Wpf.Tests/ComponentsModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/ComponentsModuleViewModelTests.cs
@@ -65,6 +65,11 @@ public class ComponentsModuleViewModelTests
         Assert.Equal(machineAdapter.Saved[0].Id, persisted.MachineId);
         Assert.Equal("SOP-CMP-100", persisted.SopDoc);
         Assert.Equal("test-signature", persisted.DigitalSignature);
+        var context = Assert.Single(componentAdapter.SavedContexts);
+        Assert.Equal("test-signature", context.SignatureHash);
+        Assert.Equal("password", context.SignatureMethod);
+        Assert.Equal("valid", context.SignatureStatus);
+        Assert.Equal("Automated test", context.SignatureNote);
         Assert.Collection(signatureDialog.Requests, ctx =>
         {
             Assert.Equal("components", ctx.TableName);
@@ -73,6 +78,15 @@ public class ComponentsModuleViewModelTests
         Assert.Single(signatureDialog.PersistedResults);
         var persistedSignature = signatureDialog.PersistedResults[0];
         Assert.Equal(componentAdapter.Saved[0].Id, persistedSignature.Signature.RecordId);
+        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
+        Assert.True(persistedSignature.Signature.Id > 0);
+        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
+        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
+        Assert.Equal(componentAdapter.Saved[0].Id, persistedMetadata.RecordId);
+        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
+        Assert.Equal("password", persistedMetadata.Method);
+        Assert.Equal("valid", persistedMetadata.Status);
+        Assert.Equal("Automated test", persistedMetadata.Note);
     }
 
     [Fact]

--- a/YasGMP.Wpf.Tests/ExternalServicersModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/ExternalServicersModuleViewModelTests.cs
@@ -48,6 +48,11 @@ public class ExternalServicersModuleViewModelTests
         Assert.Equal("calibration", servicer.Type?.ToLowerInvariant());
         Assert.Equal("labs@contoso.example", servicer.Email);
         Assert.Equal("test-signature", servicer.DigitalSignature);
+        var context = Assert.Single(service.SavedContexts);
+        Assert.Equal("test-signature", context.SignatureHash);
+        Assert.Equal("password", context.SignatureMethod);
+        Assert.Equal("valid", context.SignatureStatus);
+        Assert.Equal("Automated test", context.SignatureNote);
         Assert.Collection(signatureDialog.Requests, ctx =>
         {
             Assert.Equal("external_contractors", ctx.TableName);
@@ -56,6 +61,15 @@ public class ExternalServicersModuleViewModelTests
         Assert.Single(signatureDialog.PersistedResults);
         var persistedSignature = signatureDialog.PersistedResults[0];
         Assert.Equal(service.Saved[0].Id, persistedSignature.Signature.RecordId);
+        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
+        Assert.True(persistedSignature.Signature.Id > 0);
+        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
+        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
+        Assert.Equal(service.Saved[0].Id, persistedMetadata.RecordId);
+        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
+        Assert.Equal("password", persistedMetadata.Method);
+        Assert.Equal("valid", persistedMetadata.Status);
+        Assert.Equal("Automated test", persistedMetadata.Note);
     }
 
     [Fact]

--- a/YasGMP.Wpf.Tests/IncidentsModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/IncidentsModuleViewModelTests.cs
@@ -48,6 +48,11 @@ public class IncidentsModuleViewModelTests
         Assert.Equal("Temperature deviation", persisted.Title);
         Assert.Equal("Deviation", persisted.Type);
         Assert.Equal("test-signature", persisted.DigitalSignature);
+        var context = Assert.Single(incidents.SavedContexts);
+        Assert.Equal("test-signature", context.SignatureHash);
+        Assert.Equal("password", context.SignatureMethod);
+        Assert.Equal("valid", context.SignatureStatus);
+        Assert.Equal("Automated test", context.SignatureNote);
         Assert.Collection(signatureDialog.Requests, ctx =>
         {
             Assert.Equal("incidents", ctx.TableName);
@@ -56,6 +61,15 @@ public class IncidentsModuleViewModelTests
         Assert.Single(signatureDialog.PersistedResults);
         var persistedSignature = signatureDialog.PersistedResults[0];
         Assert.Equal(incidents.Saved[0].Id, persistedSignature.Signature.RecordId);
+        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
+        Assert.True(persistedSignature.Signature.Id > 0);
+        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
+        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
+        Assert.Equal(incidents.Saved[0].Id, persistedMetadata.RecordId);
+        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
+        Assert.Equal("password", persistedMetadata.Method);
+        Assert.Equal("valid", persistedMetadata.Status);
+        Assert.Equal("Automated test", persistedMetadata.Note);
         Assert.False(viewModel.IsDirty);
     }
 

--- a/YasGMP.Wpf.Tests/PartsModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/PartsModuleViewModelTests.cs
@@ -57,6 +57,11 @@ public class PartsModuleViewModelTests
         Assert.Equal(3, persisted.DefaultSupplierId);
         Assert.Equal("contoso", persisted.DefaultSupplierName.ToLowerInvariant());
         Assert.Equal("test-signature", persisted.DigitalSignature);
+        var context = Assert.Single(partAdapter.SavedContexts);
+        Assert.Equal("test-signature", context.SignatureHash);
+        Assert.Equal("password", context.SignatureMethod);
+        Assert.Equal("valid", context.SignatureStatus);
+        Assert.Equal("Automated test", context.SignatureNote);
         Assert.Collection(signatureDialog.Requests, ctx =>
         {
             Assert.Equal("parts", ctx.TableName);
@@ -65,6 +70,15 @@ public class PartsModuleViewModelTests
         Assert.Single(signatureDialog.PersistedResults);
         var persistedSignature = signatureDialog.PersistedResults[0];
         Assert.Equal(partAdapter.Saved[0].Id, persistedSignature.Signature.RecordId);
+        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
+        Assert.True(persistedSignature.Signature.Id > 0);
+        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
+        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
+        Assert.Equal(partAdapter.Saved[0].Id, persistedMetadata.RecordId);
+        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
+        Assert.Equal("password", persistedMetadata.Method);
+        Assert.Equal("valid", persistedMetadata.Status);
+        Assert.Equal("Automated test", persistedMetadata.Note);
     }
 
     [Fact]

--- a/YasGMP.Wpf.Tests/SchedulingModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/SchedulingModuleViewModelTests.cs
@@ -43,6 +43,11 @@ public class SchedulingModuleViewModelTests
         var created = Assert.Single(crud.Saved);
         Assert.Equal("weekly digest", created.JobType);
         Assert.False(viewModel.IsDirty);
+        var context = Assert.Single(crud.SavedContexts);
+        Assert.Equal("test-signature", context.SignatureHash);
+        Assert.Equal("password", context.SignatureMethod);
+        Assert.Equal("valid", context.SignatureStatus);
+        Assert.Equal("Automated test", context.SignatureNote);
         Assert.Collection(signatureDialog.Requests, ctx =>
         {
             Assert.Equal("scheduled_jobs", ctx.TableName);
@@ -51,6 +56,15 @@ public class SchedulingModuleViewModelTests
         Assert.Single(signatureDialog.PersistedResults);
         var persistedSignature = signatureDialog.PersistedResults[0];
         Assert.Equal(created.Id, persistedSignature.Signature.RecordId);
+        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
+        Assert.True(persistedSignature.Signature.Id > 0);
+        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
+        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
+        Assert.Equal(created.Id, persistedMetadata.RecordId);
+        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
+        Assert.Equal("password", persistedMetadata.Method);
+        Assert.Equal("valid", persistedMetadata.Status);
+        Assert.Equal("Automated test", persistedMetadata.Note);
     }
 
     [Fact]

--- a/YasGMP.Wpf.Tests/SecurityModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/SecurityModuleViewModelTests.cs
@@ -53,6 +53,11 @@ public class SecurityModuleViewModelTests
         Assert.Equal("new.user", created.Username);
         Assert.Equal("New User", created.FullName);
         Assert.Equal("test-signature", created.DigitalSignature);
+        var context = Assert.Single(userService.SavedContexts);
+        Assert.Equal("test-signature", context.SignatureHash);
+        Assert.Equal("password", context.SignatureMethod);
+        Assert.Equal("valid", context.SignatureStatus);
+        Assert.Equal("Automated test", context.SignatureNote);
         Assert.Collection(signatureDialog.Requests, ctx =>
         {
             Assert.Equal("users", ctx.TableName);
@@ -61,6 +66,15 @@ public class SecurityModuleViewModelTests
         Assert.Single(signatureDialog.PersistedResults);
         var persistedSignature = signatureDialog.PersistedResults[0];
         Assert.Equal(created.Id, persistedSignature.Signature.RecordId);
+        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
+        Assert.True(persistedSignature.Signature.Id > 0);
+        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
+        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
+        Assert.Equal(created.Id, persistedMetadata.RecordId);
+        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
+        Assert.Equal("password", persistedMetadata.Method);
+        Assert.Equal("valid", persistedMetadata.Status);
+        Assert.Equal("Automated test", persistedMetadata.Note);
         var assignment = Assert.Single(userService.RoleAssignments);
         Assert.Equal(created.Id, assignment.UserId);
         Assert.Contains(adminRole.RoleId, assignment.Roles);
@@ -116,6 +130,13 @@ public class SecurityModuleViewModelTests
         Assert.Equal(7, updated.Id);
         Assert.Equal(string.Empty, viewModel.Editor.NewPassword);
         Assert.Equal(string.Empty, viewModel.Editor.ConfirmPassword);
+        var contexts = userService.SavedContexts.ToList();
+        Assert.NotEmpty(contexts);
+        var context = contexts[^1];
+        Assert.Equal("test-signature", context.SignatureHash);
+        Assert.Equal("password", context.SignatureMethod);
+        Assert.Equal("valid", context.SignatureStatus);
+        Assert.Equal("Automated test", context.SignatureNote);
         Assert.Collection(signatureDialog.Requests, ctx =>
         {
             Assert.Equal("users", ctx.TableName);
@@ -124,6 +145,15 @@ public class SecurityModuleViewModelTests
         Assert.Single(signatureDialog.PersistedResults);
         var persistedSignature = signatureDialog.PersistedResults[0];
         Assert.Equal(7, persistedSignature.Signature.RecordId);
+        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
+        Assert.True(persistedSignature.Signature.Id > 0);
+        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
+        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
+        Assert.Equal(7, persistedMetadata.RecordId);
+        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
+        Assert.Equal("password", persistedMetadata.Method);
+        Assert.Equal("valid", persistedMetadata.Status);
+        Assert.Equal("Automated test", persistedMetadata.Note);
         var assignment = userService.RoleAssignments.Last();
         Assert.Contains(2, assignment.Roles);
     }

--- a/YasGMP.Wpf.Tests/SuppliersModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/SuppliersModuleViewModelTests.cs
@@ -55,6 +55,11 @@ public class SuppliersModuleViewModelTests
         Assert.Equal("calibration", supplier.SupplierType.ToLowerInvariant());
         Assert.Equal("info@contoso.example", supplier.Email);
         Assert.Equal("test-signature", supplier.DigitalSignature);
+        var context = Assert.Single(supplierAdapter.SavedContexts);
+        Assert.Equal("test-signature", context.SignatureHash);
+        Assert.Equal("password", context.SignatureMethod);
+        Assert.Equal("valid", context.SignatureStatus);
+        Assert.Equal("Automated test", context.SignatureNote);
         Assert.Collection(signatureDialog.Requests, ctx =>
         {
             Assert.Equal("suppliers", ctx.TableName);
@@ -63,6 +68,15 @@ public class SuppliersModuleViewModelTests
         Assert.Single(signatureDialog.PersistedResults);
         var persistedSignature = signatureDialog.PersistedResults[0];
         Assert.Equal(supplierAdapter.Saved[0].Id, persistedSignature.Signature.RecordId);
+        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
+        Assert.True(persistedSignature.Signature.Id > 0);
+        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
+        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
+        Assert.Equal(supplierAdapter.Saved[0].Id, persistedMetadata.RecordId);
+        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
+        Assert.Equal("password", persistedMetadata.Method);
+        Assert.Equal("valid", persistedMetadata.Status);
+        Assert.Equal("Automated test", persistedMetadata.Note);
     }
 
     [Fact]

--- a/YasGMP.Wpf.Tests/ValidationsModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/ValidationsModuleViewModelTests.cs
@@ -45,6 +45,11 @@ public class ValidationsModuleViewModelTests
         Assert.Equal("VAL-100", created.Code);
         Assert.Equal("IQ", created.Type);
         Assert.Equal("test-signature", created.DigitalSignature);
+        var context = Assert.Single(crud.SavedContexts);
+        Assert.Equal("test-signature", context.SignatureHash);
+        Assert.Equal("password", context.SignatureMethod);
+        Assert.Equal("valid", context.SignatureStatus);
+        Assert.Equal("Automated test", context.SignatureNote);
         Assert.Collection(signatureDialog.Requests, ctx =>
         {
             Assert.Equal("validations", ctx.TableName);
@@ -53,6 +58,15 @@ public class ValidationsModuleViewModelTests
         Assert.Single(signatureDialog.PersistedResults);
         var persistedSignature = signatureDialog.PersistedResults[0];
         Assert.Equal(crud.Saved[0].Id, persistedSignature.Signature.RecordId);
+        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
+        Assert.True(persistedSignature.Signature.Id > 0);
+        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
+        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
+        Assert.Equal(crud.Saved[0].Id, persistedMetadata.RecordId);
+        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
+        Assert.Equal("password", persistedMetadata.Method);
+        Assert.Equal("valid", persistedMetadata.Status);
+        Assert.Equal("Automated test", persistedMetadata.Note);
         Assert.False(viewModel.IsDirty);
     }
 

--- a/YasGMP.Wpf.Tests/WarehouseModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/WarehouseModuleViewModelTests.cs
@@ -53,6 +53,11 @@ public class WarehouseModuleViewModelTests
         Assert.Equal("building c", persisted.Location.ToLowerInvariant());
         Assert.Equal("qualified", persisted.Status);
         Assert.Equal("test-signature", persisted.DigitalSignature);
+        var context = Assert.Single(warehouseAdapter.SavedContexts);
+        Assert.Equal("test-signature", context.SignatureHash);
+        Assert.Equal("password", context.SignatureMethod);
+        Assert.Equal("valid", context.SignatureStatus);
+        Assert.Equal("Automated test", context.SignatureNote);
         Assert.Collection(signatureDialog.Requests, ctx =>
         {
             Assert.Equal("warehouses", ctx.TableName);
@@ -61,6 +66,15 @@ public class WarehouseModuleViewModelTests
         Assert.Single(signatureDialog.PersistedResults);
         var persistedSignature = signatureDialog.PersistedResults[0];
         Assert.Equal(warehouseAdapter.Saved[0].Id, persistedSignature.Signature.RecordId);
+        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
+        Assert.True(persistedSignature.Signature.Id > 0);
+        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
+        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
+        Assert.Equal(warehouseAdapter.Saved[0].Id, persistedMetadata.RecordId);
+        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
+        Assert.Equal("password", persistedMetadata.Method);
+        Assert.Equal("valid", persistedMetadata.Status);
+        Assert.Equal("Automated test", persistedMetadata.Note);
     }
 
     [Fact]

--- a/YasGMP.Wpf.Tests/WorkOrdersModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/WorkOrdersModuleViewModelTests.cs
@@ -53,6 +53,11 @@ public class WorkOrdersModuleViewModelTests
         Assert.Equal(12, persisted.MachineId);
         Assert.Equal(9, persisted.CreatedById);
         Assert.Equal("test-signature", persisted.DigitalSignature);
+        var context = Assert.Single(workOrders.SavedContexts);
+        Assert.Equal("test-signature", context.SignatureHash);
+        Assert.Equal("password", context.SignatureMethod);
+        Assert.Equal("valid", context.SignatureStatus);
+        Assert.Equal("Automated test", context.SignatureNote);
         Assert.Collection(signatureDialog.Requests, ctx =>
         {
             Assert.Equal("work_orders", ctx.TableName);
@@ -61,6 +66,15 @@ public class WorkOrdersModuleViewModelTests
         Assert.Single(signatureDialog.PersistedResults);
         var persistedSignature = signatureDialog.PersistedResults[0];
         Assert.Equal(workOrders.Saved[0].Id, persistedSignature.Signature.RecordId);
+        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
+        Assert.True(persistedSignature.Signature.Id > 0);
+        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
+        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
+        Assert.Equal(workOrders.Saved[0].Id, persistedMetadata.RecordId);
+        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
+        Assert.Equal("password", persistedMetadata.Method);
+        Assert.Equal("valid", persistedMetadata.Status);
+        Assert.Equal("Automated test", persistedMetadata.Note);
         Assert.False(viewModel.IsDirty);
     }
 

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -49,6 +49,7 @@
 - 2025-11-17: System event logging now records digital signature ids/hashes alongside audit payloads with automatic fallbacks for legacy schemas; unit coverage verifies both the enriched insert and the legacy downgrade path.
 - 2025-11-18: Test electronic signature dialog service now assigns incremental signature ids, clones persisted results, and records hash/method/status/note metadata for assertions while dotnet CLI access remains blocked.
 - 2025-11-19: WPF test CRUD fakes now capture create/update snapshots with contexts to simplify module assertions; dotnet restore/build retries still fail because the CLI is absent in the container.
+- 2025-11-20: WPF module regression tests now pin signature dialog ids, assert CRUD contexts surface signature hash/method/status/note metadata, and confirm persisted signature ids are returned from the enhanced dialog service while dotnet CLI access remains unavailable.
 - `scripts/bootstrap-dotnet9.ps1` added to guide host setup *(installs/verifies .NET 9, Windows SDK, runs restore/build, seeds smoke test fixture).* 
 - `YasGMP.Wpf` already targets .NET 9 and references pinned packages; validate once builds are possible.
 - `tests/fixtures/hello.txt` seeded for upcoming smoke harness scenarios.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -78,7 +78,7 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "test: track WPF CRUD contexts in fakes",
+  "lastCommitSummary": "test: assert WPF signature metadata propagation",
   "notes": [
     "Need to restore/install dotnet 9 SDK to proceed with Batch 0 validation steps.",
     "tests/fixtures/hello.txt seeded for smoke harness bootstrap",
@@ -142,6 +142,7 @@
     "2025-11-15: Read paths for work orders, calibrations, and parts now include digital_signature_id with safe fallbacks so UI/audit layers can rely on persisted signature references even on legacy schemas.",
     "2025-11-16: CAPA service/interface now forward optional SignatureMetadataDto payloads through DatabaseService.Capa helpers so signatures persist with IP/device/session context while dotnet restore/build remain blocked by the missing CLI.",
     "2025-11-17: System event logging now records digital signature ids/hashes with legacy fallbacks verified by new unit tests.",
-    "2025-11-18: TestElectronicSignatureDialogService now auto-increments signature ids, clones persisted results, and stores hash/method/status/note metadata for downstream assertions; dotnet CLI remains unavailable so restore/build stay blocked."
+    "2025-11-18: TestElectronicSignatureDialogService now auto-increments signature ids, clones persisted results, and stores hash/method/status/note metadata for downstream assertions; dotnet CLI remains unavailable so restore/build stay blocked.",
+    "2025-11-20: WPF module tests now assert CRUD contexts expose signature hash/method/status/note metadata and verify persisted signature ids returned from the enhanced dialog service while dotnet CLI access is still blocked."
   ]
 }


### PR DESCRIPTION
## Summary
- extend every WPF module save-path test to assert signature contexts expose hash/method/status/note metadata and confirm dialog persistence returns generated signature ids
- document the expanded signature metadata coverage in codex_plan and codex_progress tracking notes

## Testing
- dotnet restore yasgmp.sln *(fails: command not found)*
- dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj *(fails: command not found)*
- dotnet build yasgmp.csproj *(fails: command not found)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence)
- [ ] MAUI builds/runs unaffected
- [ ] Shared AppCore extraction complete where required; adapters compiled
- [ ] ModulesPane lists every module and opens feature-parity editors
- [ ] B1 FormModes & command enablement wired across editors
- [ ] CFL pickers + Golden Arrow navigation working
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end
- [ ] Warehouse ledger with running balance and alerts
- [ ] Audit surfacing + e-signature prompts on critical saves
- [ ] Attachments DB-backed with upload/preview/download
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented
- [ ] Smoke tests succeed and log output
- [ ] README_WPF_SHELL.md and /docs/WPF_MAPPING.md kept current

------
https://chatgpt.com/codex/tasks/task_e_68db9c4c83348331bc12601865dde15e