### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -64,6 +64,7 @@
 - 2025-11-08: Introduced `TestElectronicSignatureDialogService` with queueable confirmations/cancellations/exceptions and updated module/unit factories to consume the new helper while keeping the legacy fake as an alias.
 - 2025-11-09: Updated WPF module unit tests to inject `TestElectronicSignatureDialogService` in the new constructor slot after attachment workflow services; dotnet CLI still unavailable so test runs remain blocked.
 - 2025-11-10: Added WPF module regression tests covering electronic signature cancellation/exception flows to ensure edit mode persists and adapters are not invoked when capture fails; dotnet CLI remains unavailable so restore/build/test steps are still blocked.
+- 2025-11-21: Calibration module unit tests now queue cancellation/exception paths on the signature dialog to assert saves abort before persistence and no signature metadata is stored when capture fails.
 - 2025-10-31: WPF shell now exposes an `IElectronicSignatureDialogService` that drives the signature dialog, captures password/PIN plus GMP reason text, and persists the note via the shared DatabaseService extensions before closing.
 - Assets module now exposes an attachment command that uploads via `IAttachmentService`; coverage added in unit tests.
 - Components module now completes the CRUD rollout with mode-aware editor, validation, machine lookups, and electronic signature capture ahead of persistence.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -78,7 +78,7 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "test: assert WPF signature metadata propagation",
+  "lastCommitSummary": "chore: add calibration signature failure coverage",
   "notes": [
     "Need to restore/install dotnet 9 SDK to proceed with Batch 0 validation steps.",
     "tests/fixtures/hello.txt seeded for smoke harness bootstrap",
@@ -143,6 +143,7 @@
     "2025-11-16: CAPA service/interface now forward optional SignatureMetadataDto payloads through DatabaseService.Capa helpers so signatures persist with IP/device/session context while dotnet restore/build remain blocked by the missing CLI.",
     "2025-11-17: System event logging now records digital signature ids/hashes with legacy fallbacks verified by new unit tests.",
     "2025-11-18: TestElectronicSignatureDialogService now auto-increments signature ids, clones persisted results, and stores hash/method/status/note metadata for downstream assertions; dotnet CLI remains unavailable so restore/build stay blocked.",
-    "2025-11-20: WPF module tests now assert CRUD contexts expose signature hash/method/status/note metadata and verify persisted signature ids returned from the enhanced dialog service while dotnet CLI access is still blocked."
+    "2025-11-20: WPF module tests now assert CRUD contexts expose signature hash/method/status/note metadata and verify persisted signature ids returned from the enhanced dialog service while dotnet CLI access is still blocked.",
+    "2025-11-21: Calibration module tests cover signature cancellation and capture exceptions to ensure persistence is skipped and no metadata is stored when the dialog fails."
   ]
 }


### PR DESCRIPTION
## Summary
- add calibration module regression tests for cancelled and exception signature captures to ensure persistence is skipped
- record the new coverage in codex plan and progress logs

## Testing
- dotnet restore yasgmp.sln *(fails: `dotnet` command not found in container)*
- dotnet build yasgmp.sln -c Debug -f net9.0-windows10.0.19041.0 *(fails: `dotnet` command not found in container)*
- dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj -c Debug *(fails: `dotnet` command not found in container)*
- dotnet build yasgmp.csproj -c Debug -f net9.0-windows10.0.19041.0 *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dba7319b8483319240430fb2019b47