### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf.Tests/AttachmentWorkflowServiceTests.cs
+++ b/YasGMP.Wpf.Tests/AttachmentWorkflowServiceTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Services.Interfaces;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.Tests;
+
+public class AttachmentWorkflowServiceTests
+{
+    [Fact]
+    public async Task UploadAsync_LogsAuditEntry_ForNewUpload()
+    {
+        var databaseService = new DatabaseService("Server=localhost;Database=unit_test;Uid=test;Pwd=test;");
+        var attachmentService = new FakeAttachmentService
+        {
+            UploadResult = FakeAttachmentService.CreateUploadResult(11, "machines", 5)
+        };
+        var auditService = new RecordingAuditService(databaseService);
+        var workflow = new AttachmentWorkflowService(
+            attachmentService,
+            databaseService,
+            new AttachmentEncryptionOptions(),
+            auditService);
+
+        await using var stream = new MemoryStream(new byte[] { 1, 2, 3, 4 });
+        var request = new AttachmentUploadRequest
+        {
+            FileName = "spec.pdf",
+            EntityType = "machines",
+            EntityId = 5,
+            UploadedById = 42,
+            Reason = "unit-test"
+        };
+
+        var result = await workflow.UploadAsync(stream, request, CancellationToken.None).ConfigureAwait(false);
+
+        Assert.False(result.Deduplicated);
+        var record = Assert.Single(auditService.Records);
+        Assert.Equal(request.UploadedById, record.ActorUserId);
+        Assert.Equal(request.EntityType, record.EntityType);
+        Assert.Equal(request.EntityId, record.EntityId);
+        Assert.Equal(result.Attachment.Id, record.AttachmentId);
+        Assert.Contains("dedup=new", record.Description);
+        Assert.Contains($"reason={request.Reason}", record.Description);
+        Assert.Contains("ts=", record.Description);
+    }
+
+    [Fact]
+    public async Task UploadAsync_LogsAuditEntry_ForDeduplicatedUpload()
+    {
+        var databaseService = new DatabaseService("Server=localhost;Database=unit_test;Uid=test;Pwd=test;");
+        var uploadResult = FakeAttachmentService.CreateUploadResult(21, "incidents", 8);
+        var attachmentService = new FakeAttachmentService
+        {
+            UploadResult = uploadResult,
+            ExistingAttachment = uploadResult.Attachment
+        };
+        var auditService = new RecordingAuditService(databaseService);
+        var workflow = new AttachmentWorkflowService(
+            attachmentService,
+            databaseService,
+            new AttachmentEncryptionOptions(),
+            auditService);
+
+        await using var stream = new MemoryStream(new byte[] { 9, 8, 7, 6 });
+        var request = new AttachmentUploadRequest
+        {
+            FileName = "dedup.txt",
+            EntityType = "incidents",
+            EntityId = 8,
+            UploadedById = 7,
+            Reason = "dedup-check"
+        };
+
+        var result = await workflow.UploadAsync(stream, request, CancellationToken.None).ConfigureAwait(false);
+
+        Assert.True(result.Deduplicated);
+        var record = Assert.Single(auditService.Records);
+        Assert.Equal(request.UploadedById, record.ActorUserId);
+        Assert.Equal(result.Attachment.Id, record.AttachmentId);
+        Assert.Contains("dedup=deduplicated", record.Description);
+        Assert.Contains("existing=21", record.Description);
+    }
+
+    private sealed class FakeAttachmentService : IAttachmentService
+    {
+        public AttachmentUploadResult UploadResult { get; set; } = CreateUploadResult(1, "", 0);
+
+        public Attachment? ExistingAttachment { get; set; }
+
+        public List<AttachmentUploadRequest> Requests { get; } = new();
+
+        public Task<AttachmentUploadResult> UploadAsync(Stream content, AttachmentUploadRequest request, CancellationToken token = default)
+        {
+            Requests.Add(request);
+            return Task.FromResult(UploadResult);
+        }
+
+        public Task<Attachment?> FindByHashAsync(string sha256, CancellationToken token = default)
+            => Task.FromResult<Attachment?>(ExistingAttachment);
+
+        public Task<Attachment?> FindByHashAndSizeAsync(string sha256, long fileSize, CancellationToken token = default)
+            => Task.FromResult<Attachment?>(ExistingAttachment);
+
+        public Task<AttachmentStreamResult> StreamContentAsync(int attachmentId, Stream destination, AttachmentReadRequest? request = null, CancellationToken token = default)
+            => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<AttachmentLinkWithAttachment>> GetLinksForEntityAsync(string entityType, int entityId, CancellationToken token = default)
+            => throw new NotSupportedException();
+
+        public Task RemoveLinkAsync(int linkId, CancellationToken token = default)
+            => throw new NotSupportedException();
+
+        public Task RemoveLinkAsync(string entityType, int entityId, int attachmentId, CancellationToken token = default)
+            => throw new NotSupportedException();
+
+        public static AttachmentUploadResult CreateUploadResult(int attachmentId, string entityType, int entityId)
+        {
+            var attachment = new Attachment
+            {
+                Id = attachmentId,
+                EntityTable = entityType,
+                EntityId = entityId,
+                FileName = $"{attachmentId}.bin"
+            };
+            var link = new AttachmentLink
+            {
+                Id = attachmentId,
+                AttachmentId = attachmentId,
+                EntityType = entityType,
+                EntityId = entityId
+            };
+            var retention = new RetentionPolicy
+            {
+                PolicyName = "default",
+                RetainUntil = DateTime.UtcNow.AddDays(30)
+            };
+            return new AttachmentUploadResult(attachment, link, retention);
+        }
+    }
+
+    private sealed record AuditRecord(int? ActorUserId, string EntityType, int EntityId, string Description, int AttachmentId);
+
+    private sealed class RecordingAuditService : AuditService, IAttachmentWorkflowAudit
+    {
+        public RecordingAuditService(DatabaseService db)
+            : base(db)
+        {
+        }
+
+        public List<AuditRecord> Records { get; } = new();
+
+        public Task LogAttachmentUploadAsync(int? actorUserId, string entityType, int entityId, string description, int attachmentId, CancellationToken token)
+        {
+            Records.Add(new AuditRecord(actorUserId, entityType, entityId, description, attachmentId));
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -66,6 +66,7 @@
 - 2025-11-10: Added WPF module regression tests covering electronic signature cancellation/exception flows to ensure edit mode persists and adapters are not invoked when capture fails; dotnet CLI remains unavailable so restore/build/test steps are still blocked.
 - 2025-11-21: Calibration module unit tests now queue cancellation/exception paths on the signature dialog to assert saves abort before persistence and no signature metadata is stored when capture fails.
 - 2025-11-22: Suppliers module unit tests now cover electronic signature cancellation and capture exception flows to ensure form mode/status remain stable and no supplier/signature data persists when capture fails; dotnet CLI access is still pending for restore/build validation.
+- 2025-11-23: Attachment workflow now injects AuditService to stamp upload metadata (actor/entity/dedup/reason/timestamp) and unit coverage verifies the audit hook fires for both new and deduplicated uploads; dotnet CLI remains unavailable so restore/build/test attempts still fail with `command not found`.
 - 2025-10-31: WPF shell now exposes an `IElectronicSignatureDialogService` that drives the signature dialog, captures password/PIN plus GMP reason text, and persists the note via the shared DatabaseService extensions before closing.
 - Assets module now exposes an attachment command that uploads via `IAttachmentService`; coverage added in unit tests.
 - Components module now completes the CRUD rollout with mode-aware editor, validation, machine lookups, and electronic signature capture ahead of persistence.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -145,6 +145,7 @@
     "2025-11-18: TestElectronicSignatureDialogService now auto-increments signature ids, clones persisted results, and stores hash/method/status/note metadata for downstream assertions; dotnet CLI remains unavailable so restore/build stay blocked.",
     "2025-11-20: WPF module tests now assert CRUD contexts expose signature hash/method/status/note metadata and verify persisted signature ids returned from the enhanced dialog service while dotnet CLI access is still blocked.",
     "2025-11-21: Calibration module tests cover signature cancellation and capture exceptions to ensure persistence is skipped and no metadata is stored when the dialog fails.",
-    "2025-11-22: Suppliers module tests now assert cancellation and capture exception flows so persistence is skipped, mode/status remain stable, and digital signature storage stays empty when the dialog fails; dotnet CLI remains unavailable for restore/build/test runs."
+    "2025-11-22: Suppliers module tests now assert cancellation and capture exception flows so persistence is skipped, mode/status remain stable, and digital signature storage stays empty when the dialog fails; dotnet CLI remains unavailable for restore/build/test runs.",
+    "2025-11-23: AttachmentWorkflowService now routes uploads through AuditService for audit logging with actor/entity/dedup/reason/timestamp metadata and WPF unit coverage verifies both new and deduplicated uploads; dotnet CLI remains unavailable so restore/build/test attempts still fail with 'command not found'."
   ]
 }


### PR DESCRIPTION
## Summary
- inject `AuditService` into the WPF attachment workflow so uploads emit actor/entity/dedup/reason/timestamp metadata and reuseable audit hooks
- add an attachment workflow audit adapter plus WPF unit coverage that verifies audit logging for both fresh and deduplicated uploads
- document the new audit trail behaviour in `codex_plan.md` / `codex_progress.json`

## Testing
- `dotnet restore yasgmp.sln` *(fails: command not found — dotnet CLI unavailable in container)*
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj -c Debug` *(fails: command not found — dotnet CLI unavailable in container)*
- `dotnet build yasgmp.csproj -f net8.0-windows10.0.19041.0` *(fails: command not found — dotnet CLI unavailable in container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence).
- [ ] MAUI builds/runs unaffected.
- [ ] Shared AppCore extraction complete where required; adapters compiled.
- [ ] ModulesPane lists every module and opens feature-parity editors.
- [ ] B1 FormModes & command enablement wired across editors.
- [ ] CFL pickers + Golden Arrow navigation working.
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end.
- [ ] Warehouse ledger with running balance and alerts.
- [ ] Audit surfacing + e-signature prompts on critical saves. *(Attachment uploads now audit actor/entity/dedup/reason/timestamp.)*
- [ ] Attachments DB-backed with upload/preview/download.
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented.
- [ ] Smoke tests succeed and log output.
- [ ] `README_WPF_SHELL.md` and `/docs/WPF_MAPPING.md` kept current.

------
https://chatgpt.com/codex/tasks/task_e_68dbb1857f2c8331a6a1b51af34aa92d