### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf.Tests/ElectronicSignatureDialogServiceTests.cs
+++ b/YasGMP.Wpf.Tests/ElectronicSignatureDialogServiceTests.cs
@@ -1,0 +1,260 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using MySqlConnector;
+using Xunit;
+using YasGMP.Common;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Services.Interfaces;
+using YasGMP.Wpf.Services;
+using YasGMP.Wpf.ViewModels.Dialogs;
+
+namespace YasGMP.Wpf.Tests;
+
+public sealed class ElectronicSignatureDialogServiceTests : IDisposable
+{
+    private readonly DatabaseService _databaseService;
+    private readonly AuditService _auditService;
+    private readonly StubAuthContext _authContext;
+    private readonly ImmediateUiDispatcher _dispatcher = new();
+    private readonly List<SystemEventLogEntry> _systemEvents = new();
+    private readonly List<Dictionary<string, object?>> _signatureCommands = new();
+    private readonly ServiceProvider _serviceProvider;
+
+    public ElectronicSignatureDialogServiceTests()
+    {
+        _databaseService = new DatabaseService("Server=localhost;Database=test;Uid=test;Pwd=test;");
+        _databaseService.ExecuteNonQueryOverride = CaptureNonQueryAsync;
+        _databaseService.ExecuteScalarOverride = (_, _, _) => Task.FromResult<object?>(101);
+
+        _authContext = new StubAuthContext
+        {
+            CurrentUser = new User
+            {
+                Id = 77,
+                Username = "tester",
+                FullName = "Test User"
+            },
+            CurrentDeviceInfo = "unit-test-device",
+            CurrentSessionId = "session-xyz",
+            CurrentIpAddress = "192.0.2.25"
+        };
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IAuthContext>(_authContext);
+        services.AddSingleton<IPlatformService, StubPlatformService>();
+        _serviceProvider = services.BuildServiceProvider();
+        ServiceLocator.RegisterFallback(() => _serviceProvider);
+
+        _auditService = new AuditService(_databaseService);
+    }
+
+    [Fact]
+    public async Task CaptureSignatureAsync_LogsAuditWhenConfirmed()
+    {
+        var context = new ElectronicSignatureContext("machines", 42, method: "password", status: "valid");
+        var signature = new DigitalSignature
+        {
+            TableName = context.TableName,
+            RecordId = context.RecordId,
+            UserId = _authContext.CurrentUser!.Id,
+            SignatureHash = "hash-123",
+            Method = context.Method,
+            Status = context.Status,
+            SessionId = _authContext.CurrentSessionId,
+            Note = "QA: detail"
+        };
+
+        var captureResult = new ElectronicSignatureDialogResult(
+            "password",
+            "QA",
+            "detail",
+            "QA Reason",
+            signature);
+
+        var service = new ElectronicSignatureDialogService(
+            _dispatcher,
+            _databaseService,
+            _authContext,
+            _auditService,
+            vm =>
+            {
+                SetViewModelResult(vm, captureResult);
+                return true;
+            });
+
+        ElectronicSignatureDialogResult? result = await service.CaptureSignatureAsync(context);
+
+        Assert.NotNull(result);
+        Assert.Equal(captureResult.ReasonCode, result!.ReasonCode);
+        Assert.Equal(captureResult.ReasonDetail, result.ReasonDetail);
+        Assert.Equal(captureResult.Signature.SignatureHash, result.Signature.SignatureHash);
+
+        var captureEvent = Assert.Single(_systemEvents.Where(e => e.EventType == "SIGNATURE_CAPTURE_CONFIRMED"));
+        Assert.Equal(context.TableName, captureEvent.TableName);
+        Assert.Equal(context.RecordId, captureEvent.RecordId);
+        Assert.Equal(_authContext.CurrentUser!.Id, captureEvent.UserId);
+        Assert.Equal(_authContext.CurrentSessionId, captureEvent.SessionId);
+        Assert.Contains("reason=QA", captureEvent.Description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("detail=detail", captureEvent.Description, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PersistSignatureAsync_PersistsAndAudits()
+    {
+        var signature = new DigitalSignature
+        {
+            TableName = "components",
+            RecordId = 321,
+            UserId = _authContext.CurrentUser!.Id,
+            SignatureHash = "hash-xyz",
+            Method = "password",
+            Status = "valid",
+            SessionId = _authContext.CurrentSessionId,
+            Note = "QA approval"
+        };
+
+        var result = new ElectronicSignatureDialogResult(
+            "password",
+            "QA",
+            "detail",
+            "QA Reason",
+            signature);
+
+        var service = new ElectronicSignatureDialogService(
+            _dispatcher,
+            _databaseService,
+            _authContext,
+            _auditService,
+            _ => true);
+
+        await service.PersistSignatureAsync(result);
+
+        Assert.Equal(101, result.Signature.Id);
+        Assert.Contains(_signatureCommands, cmd =>
+            string.Equals(GetString(cmd, "@table"), signature.TableName, StringComparison.OrdinalIgnoreCase)
+            && Convert.ToInt32(cmd["@rid"] ?? 0) == signature.RecordId);
+
+        var persistEvent = Assert.Single(_systemEvents.Where(e => e.EventType == "SIGNATURE_PERSISTED"));
+        Assert.Equal(signature.TableName, persistEvent.TableName);
+        Assert.Equal(signature.RecordId, persistEvent.RecordId);
+        Assert.Equal(_authContext.CurrentUser!.Id, persistEvent.UserId);
+        Assert.Contains("hash=hash-xyz", persistEvent.Description, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public void Dispose()
+    {
+        _databaseService.ResetTestOverrides();
+        _serviceProvider.Dispose();
+        _systemEvents.Clear();
+        _signatureCommands.Clear();
+        ServiceLocator.RegisterFallback(() => null);
+    }
+
+    private Task<int> CaptureNonQueryAsync(string sql, IEnumerable<MySqlParameter>? parameters, CancellationToken token)
+    {
+        var parameterMap = ToDictionary(parameters);
+        if (sql.Contains("system_event_log", StringComparison.OrdinalIgnoreCase))
+        {
+            _systemEvents.Add(new SystemEventLogEntry(
+                GetString(parameterMap, "@etype") ?? string.Empty,
+                GetString(parameterMap, "@table"),
+                GetNullableInt(parameterMap, "@rid"),
+                GetString(parameterMap, "@desc"),
+                GetNullableInt(parameterMap, "@uid"),
+                GetString(parameterMap, "@sid")));
+        }
+        else if (sql.Contains("digital_signatures", StringComparison.OrdinalIgnoreCase))
+        {
+            _signatureCommands.Add(parameterMap);
+        }
+
+        return Task.FromResult(1);
+    }
+
+    private static Dictionary<string, object?> ToDictionary(IEnumerable<MySqlParameter>? parameters)
+    {
+        var dict = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        if (parameters is null)
+        {
+            return dict;
+        }
+
+        foreach (var parameter in parameters)
+        {
+            dict[parameter.ParameterName] = parameter.Value == DBNull.Value ? null : parameter.Value;
+        }
+
+        return dict;
+    }
+
+    private static string? GetString(IDictionary<string, object?> dict, string key)
+    {
+        return dict.TryGetValue(key, out var value) ? value?.ToString() : null;
+    }
+
+    private static int? GetNullableInt(IDictionary<string, object?> dict, string key)
+    {
+        if (!dict.TryGetValue(key, out var value) || value is null)
+        {
+            return null;
+        }
+
+        return Convert.ToInt32(value);
+    }
+
+    private static void SetViewModelResult(ElectronicSignatureDialogViewModel viewModel, ElectronicSignatureDialogResult result)
+    {
+        var property = typeof(ElectronicSignatureDialogViewModel)
+            .GetProperty("Result", BindingFlags.Instance | BindingFlags.Public);
+        var setter = property?.GetSetMethod(nonPublic: true)
+            ?? throw new InvalidOperationException("Result setter is not accessible.");
+        setter.Invoke(viewModel, new object?[] { result });
+    }
+
+    private sealed record SystemEventLogEntry(
+        string EventType,
+        string? TableName,
+        int? RecordId,
+        string? Description,
+        int? UserId,
+        string? SessionId);
+
+    private sealed class ImmediateUiDispatcher : IUiDispatcher
+    {
+        public bool IsDispatchRequired => false;
+
+        public void BeginInvoke(Action action) => action();
+
+        public Task InvokeAsync(Action action)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task InvokeAsync(Func<Task> asyncAction) => asyncAction();
+
+        public Task<T> InvokeAsync<T>(Func<T> func) => Task.FromResult(func());
+    }
+
+    private sealed class StubAuthContext : IAuthContext
+    {
+        public User? CurrentUser { get; set; }
+        public string CurrentSessionId { get; set; } = string.Empty;
+        public string CurrentDeviceInfo { get; set; } = string.Empty;
+        public string CurrentIpAddress { get; set; } = string.Empty;
+    }
+
+    private sealed class StubPlatformService : IPlatformService
+    {
+        public string GetHostName() => "test-host";
+        public string GetLocalIpAddress() => "127.0.0.1";
+        public string GetOsVersion() => "Windows 11";
+        public string GetUserName() => "tester";
+    }
+}

--- a/YasGMP.Wpf.Tests/YasGMP.Wpf.Tests.csproj
+++ b/YasGMP.Wpf.Tests/YasGMP.Wpf.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -15,29 +16,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\YasGMP.AppCore\YasGMP.AppCore.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="..\YasGMP.Wpf\ViewModels\Modules\AssetsModuleViewModel.cs" Link="Wpf\Modules\AssetsModuleViewModel.cs" />
-    <Compile Include="..\YasGMP.Wpf\ViewModels\Modules\ComponentsModuleViewModel.cs" Link="Wpf\Modules\ComponentsModuleViewModel.cs" />
-    <Compile Include="..\YasGMP.Wpf\ViewModels\Modules\WorkOrdersModuleViewModel.cs" Link="Wpf\Modules\WorkOrdersModuleViewModel.cs" />
-    <Compile Include="..\YasGMP.Wpf\ViewModels\Modules\CalibrationModuleViewModel.cs" Link="Wpf\Modules\CalibrationModuleViewModel.cs" />
-    <Compile Include="..\YasGMP.Wpf\Services\IMachineCrudService.cs" Link="Wpf\Services\IMachineCrudService.cs" />
-    <Compile Include="..\YasGMP.Wpf\Services\IComponentCrudService.cs" Link="Wpf\Services\IComponentCrudService.cs" />
-    <Compile Include="..\YasGMP.Wpf\Services\ICalibrationCrudService.cs" Link="Wpf\Services\ICalibrationCrudService.cs" />
-    <Compile Include="..\YasGMP.Wpf\Services\IElectronicSignatureDialogService.cs" Link="Wpf\Services\IElectronicSignatureDialogService.cs" />
-    <Compile Include="..\YasGMP.Wpf\ViewModels\Modules\IncidentsModuleViewModel.cs" Link="Wpf\Modules\IncidentsModuleViewModel.cs" />
-    <Compile Include="..\YasGMP.Wpf\ViewModels\Modules\PartsModuleViewModel.cs" Link="Wpf\Modules\PartsModuleViewModel.cs" />
-    <Compile Include="..\YasGMP.Wpf\ViewModels\Modules\WarehouseModuleViewModel.cs" Link="Wpf\Modules\WarehouseModuleViewModel.cs" />
-    <Compile Include="..\YasGMP.Wpf\Services\IPartCrudService.cs" Link="Wpf\Services\IPartCrudService.cs" />
-    <Compile Include="..\YasGMP.Wpf\Services\IWarehouseCrudService.cs" Link="Wpf\Services\IWarehouseCrudService.cs" />
-    <Compile Include="..\YasGMP.Wpf\Services\IIncidentCrudService.cs" Link="Wpf\Services\IIncidentCrudService.cs" />
-    <Compile Include="..\YasGMP.Wpf\ViewModels\Modules\SchedulingModuleViewModel.cs" Link="Wpf\Modules\SchedulingModuleViewModel.cs" />
-    <Compile Include="..\YasGMP.Wpf\Services\IScheduledJobCrudService.cs" Link="Wpf\Services\IScheduledJobCrudService.cs" />
-    <Compile Include="..\YasGMP.Wpf\Services\IUserCrudService.cs" Link="Wpf\Services\IUserCrudService.cs" />
-    <Compile Include="..\YasGMP.Wpf\Services\ISupplierCrudService.cs" Link="Wpf\Services\ISupplierCrudService.cs" />
-    <Compile Include="..\YasGMP.Wpf\Services\IExternalServicerCrudService.cs" Link="Wpf\Services\IExternalServicerCrudService.cs" />
-    <Compile Include="..\YasGMP.Wpf\ViewModels\Modules\SuppliersModuleViewModel.cs" Link="Wpf\Modules\SuppliersModuleViewModel.cs" />
-    <Compile Include="..\YasGMP.Wpf\ViewModels\Modules\ExternalServicersModuleViewModel.cs" Link="Wpf\Modules\ExternalServicersModuleViewModel.cs" />
-    <Compile Include="..\YasGMP.Wpf\ViewModels\Dialogs\ElectronicSignatureDialogViewModel.cs" Link="Wpf\Dialogs\ElectronicSignatureDialogViewModel.cs" />
+    <ProjectReference Include="..\YasGMP.Wpf\YasGMP.Wpf.csproj" />
   </ItemGroup>
 </Project>

--- a/YasGMP.Wpf/Services/ElectronicSignatureDialogService.cs
+++ b/YasGMP.Wpf/Services/ElectronicSignatureDialogService.cs
@@ -19,15 +19,21 @@ public sealed class ElectronicSignatureDialogService : IElectronicSignatureDialo
     private readonly IUiDispatcher _uiDispatcher;
     private readonly DatabaseService _databaseService;
     private readonly IAuthContext _authContext;
+    private readonly AuditService _auditService;
+    private readonly Func<ElectronicSignatureDialogViewModel, bool?> _showDialog;
 
     public ElectronicSignatureDialogService(
         IUiDispatcher uiDispatcher,
         DatabaseService databaseService,
-        IAuthContext authContext)
+        IAuthContext authContext,
+        AuditService auditService,
+        Func<ElectronicSignatureDialogViewModel, bool?>? dialogInvoker = null)
     {
         _uiDispatcher = uiDispatcher ?? throw new ArgumentNullException(nameof(uiDispatcher));
         _databaseService = databaseService ?? throw new ArgumentNullException(nameof(databaseService));
         _authContext = authContext ?? throw new ArgumentNullException(nameof(authContext));
+        _auditService = auditService ?? throw new ArgumentNullException(nameof(auditService));
+        _showDialog = dialogInvoker ?? ShowDialog;
     }
 
     public async Task<ElectronicSignatureDialogResult?> CaptureSignatureAsync(
@@ -43,26 +49,26 @@ public sealed class ElectronicSignatureDialogService : IElectronicSignatureDialo
 
         await _uiDispatcher.InvokeAsync(() =>
         {
-            var dialog = new ElectronicSignatureDialog(viewModel);
-            var owner = Application.Current?.Windows
-                .OfType<Window>()
-                .FirstOrDefault(w => w.IsActive) ?? Application.Current?.MainWindow;
-            if (owner is not null)
-            {
-                dialog.Owner = owner;
-            }
-
-            bool? confirmed = dialog.ShowDialog();
+            bool? confirmed = _showDialog(viewModel);
             if (confirmed == true)
             {
                 result = viewModel.Result;
             }
         }).ConfigureAwait(false);
 
+        if (result is not null)
+        {
+            await _auditService.LogSystemEventAsync(
+                "SIGNATURE_CAPTURE_CONFIRMED",
+                BuildCaptureAuditDetails(context, result),
+                context.TableName,
+                context.RecordId).ConfigureAwait(false);
+        }
+
         return result;
     }
 
-    public Task PersistSignatureAsync(
+    public async Task PersistSignatureAsync(
         ElectronicSignatureDialogResult result,
         CancellationToken cancellationToken = default)
     {
@@ -77,6 +83,47 @@ public sealed class ElectronicSignatureDialogService : IElectronicSignatureDialo
         }
 
         cancellationToken.ThrowIfCancellationRequested();
-        return _databaseService.InsertDigitalSignatureAsync(result.Signature, cancellationToken);
+        await _databaseService.InsertDigitalSignatureAsync(result.Signature, cancellationToken).ConfigureAwait(false);
+
+        await _auditService.LogSystemEventAsync(
+            "SIGNATURE_PERSISTED",
+            BuildPersistAuditDetails(result),
+            result.Signature.TableName,
+            result.Signature.RecordId).ConfigureAwait(false);
+    }
+
+    private bool? ShowDialog(ElectronicSignatureDialogViewModel viewModel)
+    {
+        var dialog = new ElectronicSignatureDialog(viewModel);
+        var owner = Application.Current?.Windows
+            .OfType<Window>()
+            .FirstOrDefault(w => w.IsActive) ?? Application.Current?.MainWindow;
+        if (owner is not null)
+        {
+            dialog.Owner = owner;
+        }
+
+        return dialog.ShowDialog();
+    }
+
+    private string BuildCaptureAuditDetails(ElectronicSignatureContext context, ElectronicSignatureDialogResult result)
+    {
+        string reasonDetail = string.IsNullOrWhiteSpace(result.ReasonDetail) ? "-" : result.ReasonDetail;
+        string method = result.Signature?.Method ?? context.Method;
+        string status = result.Signature?.Status ?? context.Status;
+        string display = string.IsNullOrWhiteSpace(result.ReasonDisplay) ? result.ReasonCode : result.ReasonDisplay;
+
+        return $"reason={result.ReasonCode}; display={display}; detail={reasonDetail}; method={method}; status={status}; session={_authContext.CurrentSessionId}";
+    }
+
+    private string BuildPersistAuditDetails(ElectronicSignatureDialogResult result)
+    {
+        var signature = result.Signature;
+        string hash = string.IsNullOrWhiteSpace(signature.SignatureHash) ? "-" : signature.SignatureHash;
+        string note = string.IsNullOrWhiteSpace(signature.Note) ? "-" : signature.Note;
+        string method = string.IsNullOrWhiteSpace(signature.Method) ? "-" : signature.Method;
+        string status = string.IsNullOrWhiteSpace(signature.Status) ? "-" : signature.Status;
+
+        return $"reason={result.ReasonCode}; detail={result.ReasonDetail ?? "-"}; method={method}; status={status}; hash={hash}; note={note}; session={signature.SessionId ?? _authContext.CurrentSessionId}";
     }
 }

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -16,7 +16,7 @@
 ## Batches
 - **B0 — Environment stabilization** (SDKs, NuGets, XAML namespaces) — **blocked** *(no `dotnet` CLI)*
 - **B1 — Shell foundation** (Ribbon, Docking, StatusBar, FormMode state machine) — [ ] todo
-- **B2 — Cross-cutting** (Attachments DB, E-Signature, Audit) — [~] in-progress *(e-sign capture now spans Assets, Components, Warehouses, Incidents, CAPA, Change Control, Validations, Scheduled Jobs, Suppliers, External Servicers, Users, and Work Orders; WPF adapters and AppCore services now propagate optional signature metadata through to the database, falling back to the legacy hash generator only when metadata is missing; audit surfacing still pending until SDK access returns)*
+- **B2 — Cross-cutting** (Attachments DB, E-Signature, Audit) — [~] in-progress *(e-sign capture now spans Assets, Components, Warehouses, Incidents, CAPA, Change Control, Validations, Scheduled Jobs, Suppliers, External Servicers, Users, and Work Orders; WPF adapters and AppCore services propagate optional signature metadata through to the database, falling back to the legacy hash generator only when metadata is missing; the WPF dialog service now emits audit events on capture/persist while broader audit surfacing remains gated on SDK access)*
 - **B3 — Editor framework** (templates, host, unsaved-guard) — [ ] todo
 - **B4+ — Module rollout:**
   - Assets/Machines — [x] done *(mode-aware CRUD with attachment uploads and e-signature capture via IElectronicSignatureDialogService; audit surfacing still pending)*
@@ -67,6 +67,7 @@
 - 2025-11-21: Calibration module unit tests now queue cancellation/exception paths on the signature dialog to assert saves abort before persistence and no signature metadata is stored when capture fails.
 - 2025-11-22: Suppliers module unit tests now cover electronic signature cancellation and capture exception flows to ensure form mode/status remain stable and no supplier/signature data persists when capture fails; dotnet CLI access is still pending for restore/build validation.
 - 2025-11-23: Attachment workflow now injects AuditService to stamp upload metadata (actor/entity/dedup/reason/timestamp) and unit coverage verifies the audit hook fires for both new and deduplicated uploads; dotnet CLI remains unavailable so restore/build/test attempts still fail with `command not found`.
+- 2025-11-24: ElectronicSignatureDialogService now resolves AuditService, logging capture and persistence events with reason metadata; WPF dialog service tests assert both audit emissions alongside digital signature persistence while the dotnet CLI gap persists.
 - 2025-10-31: WPF shell now exposes an `IElectronicSignatureDialogService` that drives the signature dialog, captures password/PIN plus GMP reason text, and persists the note via the shared DatabaseService extensions before closing.
 - Assets module now exposes an attachment command that uploads via `IAttachmentService`; coverage added in unit tests.
 - Components module now completes the CRUD rollout with mode-aware editor, validation, machine lookups, and electronic signature capture ahead of persistence.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -147,5 +147,6 @@
     "2025-11-21: Calibration module tests cover signature cancellation and capture exceptions to ensure persistence is skipped and no metadata is stored when the dialog fails.",
     "2025-11-22: Suppliers module tests now assert cancellation and capture exception flows so persistence is skipped, mode/status remain stable, and digital signature storage stays empty when the dialog fails; dotnet CLI remains unavailable for restore/build/test runs.",
     "2025-11-23: AttachmentWorkflowService now routes uploads through AuditService for audit logging with actor/entity/dedup/reason/timestamp metadata and WPF unit coverage verifies both new and deduplicated uploads; dotnet CLI remains unavailable so restore/build/test attempts still fail with 'command not found'."
+    ,"2025-11-24: ElectronicSignatureDialogService now resolves AuditService, emitting capture and persistence audit events with reason metadata; new WPF dialog service tests assert both audit calls and signature persistence while dotnet CLI access remains blocked."
   ]
 }


### PR DESCRIPTION
## Summary
- inject AuditService into the WPF electronic signature dialog so capture and persistence paths emit rich audit events
- add net9.0-windows coverage for the dialog service with new unit tests that assert audit calls and signature persistence
- refresh codex planning/progress artifacts to record the expanded audit logging work

## Testing
- `dotnet restore yasgmp.sln` *(fails: command not found in container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence).
- [ ] MAUI builds/runs unaffected.
- [ ] Shared AppCore extraction complete where required; adapters compiled.
- [ ] ModulesPane lists every module and opens feature-parity editors.
- [ ] B1 FormModes & command enablement wired across editors.
- [ ] CFL pickers + Golden Arrow navigation working.
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end.
- [ ] Warehouse ledger with running balance and alerts.
- [ ] Audit surfacing + e-signature prompts on critical saves.
- [ ] Attachments DB-backed with upload/preview/download.
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented.
- [ ] Smoke tests succeed and log output.
- [ ] README_WPF_SHELL.md and /docs/WPF_MAPPING.md kept current.


------
https://chatgpt.com/codex/tasks/task_e_68dbb7dae2ac833198ef5531403907c1