### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf/Services/CrudSaveResult.cs
+++ b/YasGMP.Wpf/Services/CrudSaveResult.cs
@@ -1,0 +1,36 @@
+using YasGMP.AppCore.Models.Signatures;
+
+namespace YasGMP.Wpf.Services;
+
+/// <summary>
+/// Represents the payload returned from a CRUD adapter after the entity has been persisted.
+/// </summary>
+/// <typeparam name="TIdentifier">Type used to uniquely identify the saved entity.</typeparam>
+public sealed record CrudSaveResult<TIdentifier>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CrudSaveResult{TIdentifier}"/> record.
+    /// </summary>
+    /// <param name="identifier">Unique identifier generated for the persisted entity.</param>
+    /// <param name="signatureMetadata">Electronic signature metadata captured alongside the save.</param>
+    public CrudSaveResult(TIdentifier identifier, SignatureMetadataDto? signatureMetadata)
+    {
+        Identifier = identifier;
+        SignatureMetadata = signatureMetadata;
+    }
+
+    /// <summary>
+    /// Gets the unique identifier for the entity that was saved. Callers should apply this value to
+    /// refresh editor state, update navigation contexts, or trigger follow-up lookups that require the
+    /// persisted entity's key.
+    /// </summary>
+    public TIdentifier Identifier { get; }
+
+    /// <summary>
+    /// Gets the electronic signature metadata captured during the save operation. Callers should
+    /// persist or surface this payload alongside the entity (for example, by updating audit records or
+    /// exposing signature details in the UI) to ensure downstream services receive the same signature
+    /// context that was accepted at save time.
+    /// </summary>
+    public SignatureMetadataDto? SignatureMetadata { get; }
+}

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -50,6 +50,7 @@
 - 2025-11-18: Test electronic signature dialog service now assigns incremental signature ids, clones persisted results, and records hash/method/status/note metadata for assertions while dotnet CLI access remains blocked.
 - 2025-11-19: WPF test CRUD fakes now capture create/update snapshots with contexts to simplify module assertions; dotnet restore/build retries still fail because the CLI is absent in the container.
 - 2025-11-20: WPF module regression tests now pin signature dialog ids, assert CRUD contexts surface signature hash/method/status/note metadata, and confirm persisted signature ids are returned from the enhanced dialog service while dotnet CLI access remains unavailable.
+- 2025-11-28: Added a shared `CrudSaveResult` payload so adapters can return the persisted identifier together with captured signature metadata, keeping downstream editors and audit logging aligned once save operations complete.
 - `scripts/bootstrap-dotnet9.ps1` added to guide host setup *(installs/verifies .NET 9, Windows SDK, runs restore/build, seeds smoke test fixture).* 
 - `YasGMP.Wpf` already targets .NET 9 and references pinned packages; validate once builds are possible.
 - `tests/fixtures/hello.txt` seeded for upcoming smoke harness scenarios.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -81,7 +81,7 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "fix: rehydrate signature metadata before persistence",
+  "lastCommitSummary": "feat: add CrudSaveResult payload for save results",
   "notes": [
     "Need to restore/install dotnet 9 SDK to proceed with Batch 0 validation steps.",
     "tests/fixtures/hello.txt seeded for smoke harness bootstrap",
@@ -153,6 +153,7 @@
     "2025-11-24: ElectronicSignatureDialogService now resolves AuditService, emitting capture and persistence audit events with reason metadata; new WPF dialog service tests assert both audit calls and signature persistence while dotnet CLI access remains blocked.",
     "2025-11-25: DataDrivenModuleDocumentViewModel gains an optional AuditService injection so every WPF module can share audit helpers, and Work Orders now records CREATE/UPDATE audit events with signature/user/IP/device/session details post-save; unit tests inject the service while dotnet CLI access remains unavailable.",
     "2025-11-26: RecordingAuditService test double added to the WPF harness so Work Orders save and attachment tests assert audit payloads with signer context while dotnet restore/build stay blocked.",
-    "2025-11-27: Module save flows now rehydrate adapter-supplied signature metadata and skip redundant dialog persistence when ids are present so the stored record matches the UX status messaging."
+    "2025-11-27: Module save flows now rehydrate adapter-supplied signature metadata and skip redundant dialog persistence when ids are present so the stored record matches the UX status messaging.",
+    "2025-11-28: Introduced a shared CrudSaveResult record so adapters can return the persisted identifier together with signature metadata, keeping downstream editors and audit logging aligned once saves complete."
   ]
 }


### PR DESCRIPTION
## Summary
- add a shared `CrudSaveResult` record for adapters to return the persisted identifier together with captured signature metadata
- update the Codex plan and progress artifacts to track the new save result payload work

## Testing
- `dotnet restore` *(fails: `dotnet` CLI is not installed in the container environment)*
- `dotnet build yasgmp.sln` *(fails: `dotnet` CLI is not installed in the container environment)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence).
- [ ] MAUI builds/runs unaffected.
- [ ] Shared AppCore extraction complete where required; adapters compiled.
- [ ] ModulesPane lists every module and opens feature-parity editors.
- [ ] B1 FormModes & command enablement wired across editors.
- [ ] CFL pickers + Golden Arrow navigation working.
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end.
- [ ] Warehouse ledger with running balance and alerts.
- [ ] Audit surfacing + e-signature prompts on critical saves.
- [ ] Attachments DB-backed with upload/preview/download.
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented.
- [ ] Smoke tests succeed and log output.
- [ ] `README_WPF_SHELL.md` and `/docs/WPF_MAPPING.md` kept current.

------
https://chatgpt.com/codex/tasks/task_e_68dcd7ea390c83318498b5524228f15e