### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf.Tests/CalibrationModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/CalibrationModuleViewModelTests.cs
@@ -23,7 +23,7 @@ public class CalibrationModuleViewModelTests
         var calibrationAdapter = new FakeCalibrationCrudService();
         var componentAdapter = new FakeComponentCrudService();
 
-        await componentAdapter.CreateAsync(new Component
+        _ = await componentAdapter.CreateAsync(new Component
         {
             Id = 3,
             MachineId = 1,
@@ -115,7 +115,7 @@ public class CalibrationModuleViewModelTests
         var calibrationAdapter = new FakeCalibrationCrudService();
         var componentAdapter = new FakeComponentCrudService();
 
-        await componentAdapter.CreateAsync(new Component
+        _ = await componentAdapter.CreateAsync(new Component
         {
             Id = 21,
             MachineId = 4,
@@ -188,7 +188,7 @@ public class CalibrationModuleViewModelTests
         var calibrationAdapter = new FakeCalibrationCrudService();
         var componentAdapter = new FakeComponentCrudService();
 
-        await componentAdapter.CreateAsync(new Component
+        _ = await componentAdapter.CreateAsync(new Component
         {
             Id = 31,
             MachineId = 6,
@@ -261,7 +261,7 @@ public class CalibrationModuleViewModelTests
         var calibrationAdapter = new FakeCalibrationCrudService();
         var componentAdapter = new FakeComponentCrudService();
 
-        await componentAdapter.CreateAsync(new Component
+        _ = await componentAdapter.CreateAsync(new Component
         {
             Id = 11,
             MachineId = 2,

--- a/YasGMP.Wpf.Tests/ComponentsModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/ComponentsModuleViewModelTests.cs
@@ -23,7 +23,7 @@ public class ComponentsModuleViewModelTests
         var componentAdapter = new FakeComponentCrudService();
         var machineAdapter = new FakeMachineCrudService();
 
-        await machineAdapter.CreateAsync(new Machine
+        _ = await machineAdapter.CreateAsync(new Machine
         {
             Id = 1,
             Code = "AST-001",
@@ -99,7 +99,7 @@ public class ComponentsModuleViewModelTests
         var componentAdapter = new FakeComponentCrudService();
         var machineAdapter = new FakeMachineCrudService();
 
-        await machineAdapter.CreateAsync(new Machine
+        _ = await machineAdapter.CreateAsync(new Machine
         {
             Id = 1,
             Code = "AST-001",
@@ -151,7 +151,7 @@ public class ComponentsModuleViewModelTests
         var componentAdapter = new FakeComponentCrudService();
         var machineAdapter = new FakeMachineCrudService();
 
-        await machineAdapter.CreateAsync(new Machine
+        _ = await machineAdapter.CreateAsync(new Machine
         {
             Id = 1,
             Code = "AST-001",

--- a/YasGMP.Wpf.Tests/ExternalServicerCrudSaveResults.cs
+++ b/YasGMP.Wpf.Tests/ExternalServicerCrudSaveResults.cs
@@ -1,0 +1,34 @@
+using System.Threading.Tasks;
+using YasGMP.AppCore.Models.Signatures;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Models
+{
+    public sealed partial class FakeExternalServicerCrudService
+    {
+        public async Task<CrudSaveResult> CreateAsync(ExternalServicer servicer, ExternalServicerCrudContext context)
+        {
+            var id = await CreateCoreAsync(servicer, context).ConfigureAwait(false);
+            return new CrudSaveResult(id, BuildMetadata(context, servicer.DigitalSignature));
+        }
+
+        public async Task<CrudSaveResult> UpdateAsync(ExternalServicer servicer, ExternalServicerCrudContext context)
+        {
+            await UpdateCoreAsync(servicer, context).ConfigureAwait(false);
+            return new CrudSaveResult(servicer.Id, BuildMetadata(context, servicer.DigitalSignature));
+        }
+
+        private static SignatureMetadataDto BuildMetadata(ExternalServicerCrudContext context, string? signature)
+            => new()
+            {
+                Id = context.SignatureId,
+                Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
+                Method = context.SignatureMethod,
+                Status = context.SignatureStatus,
+                Note = context.SignatureNote,
+                Session = context.SessionId,
+                Device = context.DeviceInfo,
+                IpAddress = context.Ip
+            };
+    }
+}

--- a/YasGMP.Wpf.Tests/ExternalServicerTestStubs.cs
+++ b/YasGMP.Wpf.Tests/ExternalServicerTestStubs.cs
@@ -29,7 +29,7 @@ namespace YasGMP.Models
 
 namespace YasGMP.Wpf.Services
 {
-    public sealed class FakeExternalServicerCrudService : IExternalServicerCrudService
+    public sealed partial class FakeExternalServicerCrudService : IExternalServicerCrudService
     {
         private readonly List<ExternalServicer> _store = new();
 
@@ -41,7 +41,7 @@ namespace YasGMP.Wpf.Services
         public Task<ExternalServicer?> TryGetByIdAsync(int id)
             => Task.FromResult<ExternalServicer?>(_store.FirstOrDefault(s => s.Id == id));
 
-        public Task<int> CreateAsync(ExternalServicer servicer, ExternalServicerCrudContext context)
+        public Task<int> CreateCoreAsync(ExternalServicer servicer, ExternalServicerCrudContext context)
         {
             if (servicer.Id == 0)
             {
@@ -52,7 +52,7 @@ namespace YasGMP.Wpf.Services
             return Task.FromResult(servicer.Id);
         }
 
-        public Task UpdateAsync(ExternalServicer servicer, ExternalServicerCrudContext context)
+        public Task UpdateCoreAsync(ExternalServicer servicer, ExternalServicerCrudContext context)
         {
             var existing = _store.FirstOrDefault(s => s.Id == servicer.Id);
             if (existing is null)

--- a/YasGMP.Wpf.Tests/TestStubs.CrudSaveResults.cs
+++ b/YasGMP.Wpf.Tests/TestStubs.CrudSaveResults.cs
@@ -1,0 +1,370 @@
+using System.Threading.Tasks;
+using YasGMP.AppCore.Models.Signatures;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Models
+{
+    public sealed partial class FakeMachineCrudService
+    {
+        public async Task<CrudSaveResult> CreateAsync(Machine machine, MachineCrudContext context)
+        {
+            var id = await CreateCoreAsync(machine, context).ConfigureAwait(false);
+            return new CrudSaveResult(id, BuildMetadata(context, machine.DigitalSignature));
+        }
+
+        public async Task<CrudSaveResult> UpdateAsync(Machine machine, MachineCrudContext context)
+        {
+            await UpdateCoreAsync(machine, context).ConfigureAwait(false);
+            return new CrudSaveResult(machine.Id, BuildMetadata(context, machine.DigitalSignature));
+        }
+
+        private static SignatureMetadataDto BuildMetadata(MachineCrudContext context, string? signature)
+            => new()
+            {
+                Id = context.SignatureId,
+                Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
+                Method = context.SignatureMethod,
+                Status = context.SignatureStatus,
+                Note = context.SignatureNote,
+                Session = context.SessionId,
+                Device = context.DeviceInfo,
+                IpAddress = context.Ip
+            };
+    }
+
+    public sealed partial class FakeComponentCrudService
+    {
+        public async Task<CrudSaveResult> CreateAsync(Component component, ComponentCrudContext context)
+        {
+            var id = await CreateCoreAsync(component, context).ConfigureAwait(false);
+            return new CrudSaveResult(id, BuildMetadata(context, component.DigitalSignature));
+        }
+
+        public async Task<CrudSaveResult> UpdateAsync(Component component, ComponentCrudContext context)
+        {
+            await UpdateCoreAsync(component, context).ConfigureAwait(false);
+            return new CrudSaveResult(component.Id, BuildMetadata(context, component.DigitalSignature));
+        }
+
+        private static SignatureMetadataDto BuildMetadata(ComponentCrudContext context, string? signature)
+            => new()
+            {
+                Id = context.SignatureId,
+                Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
+                Method = context.SignatureMethod,
+                Status = context.SignatureStatus,
+                Note = context.SignatureNote,
+                Session = context.SessionId,
+                Device = context.DeviceInfo,
+                IpAddress = context.Ip
+            };
+    }
+
+    public sealed partial class FakeCalibrationCrudService
+    {
+        public async Task<CrudSaveResult> CreateAsync(Calibration calibration, CalibrationCrudContext context)
+        {
+            var id = await CreateCoreAsync(calibration, context).ConfigureAwait(false);
+            return new CrudSaveResult(id, BuildMetadata(context, calibration.DigitalSignature));
+        }
+
+        public async Task<CrudSaveResult> UpdateAsync(Calibration calibration, CalibrationCrudContext context)
+        {
+            await UpdateCoreAsync(calibration, context).ConfigureAwait(false);
+            return new CrudSaveResult(calibration.Id, BuildMetadata(context, calibration.DigitalSignature));
+        }
+
+        private static SignatureMetadataDto BuildMetadata(CalibrationCrudContext context, string? signature)
+            => new()
+            {
+                Id = context.SignatureId,
+                Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
+                Method = context.SignatureMethod,
+                Status = context.SignatureStatus,
+                Note = context.SignatureNote,
+                Session = context.SessionId,
+                Device = context.DeviceInfo,
+                IpAddress = context.Ip
+            };
+    }
+
+    public sealed partial class FakeIncidentCrudService
+    {
+        public async Task<CrudSaveResult> CreateAsync(Incident incident, IncidentCrudContext context)
+        {
+            var id = await CreateCoreAsync(incident, context).ConfigureAwait(false);
+            return new CrudSaveResult(id, BuildMetadata(context, incident.DigitalSignature));
+        }
+
+        public async Task<CrudSaveResult> UpdateAsync(Incident incident, IncidentCrudContext context)
+        {
+            await UpdateCoreAsync(incident, context).ConfigureAwait(false);
+            return new CrudSaveResult(incident.Id, BuildMetadata(context, incident.DigitalSignature));
+        }
+
+        private static SignatureMetadataDto BuildMetadata(IncidentCrudContext context, string? signature)
+            => new()
+            {
+                Id = context.SignatureId,
+                Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
+                Method = context.SignatureMethod,
+                Status = context.SignatureStatus,
+                Note = context.SignatureNote,
+                Session = context.SessionId,
+                Device = context.DeviceInfo,
+                IpAddress = context.Ip
+            };
+    }
+
+    public sealed partial class FakeChangeControlCrudService
+    {
+        public async Task<CrudSaveResult> CreateAsync(ChangeControl changeControl, ChangeControlCrudContext context)
+        {
+            var id = await CreateCoreAsync(changeControl, context).ConfigureAwait(false);
+            return new CrudSaveResult(id, BuildMetadata(context, changeControl.DigitalSignature));
+        }
+
+        public async Task<CrudSaveResult> UpdateAsync(ChangeControl changeControl, ChangeControlCrudContext context)
+        {
+            await UpdateCoreAsync(changeControl, context).ConfigureAwait(false);
+            return new CrudSaveResult(changeControl.Id, BuildMetadata(context, changeControl.DigitalSignature));
+        }
+
+        private static SignatureMetadataDto BuildMetadata(ChangeControlCrudContext context, string? signature)
+            => new()
+            {
+                Id = context.SignatureId,
+                Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
+                Method = context.SignatureMethod,
+                Status = context.SignatureStatus,
+                Note = context.SignatureNote,
+                Session = context.SessionId,
+                Device = context.DeviceInfo,
+                IpAddress = context.IpAddress
+            };
+    }
+
+    public sealed partial class FakeCapaCrudService
+    {
+        public async Task<CrudSaveResult> CreateAsync(CapaCase capa, CapaCrudContext context)
+        {
+            var id = await CreateCoreAsync(capa, context).ConfigureAwait(false);
+            return new CrudSaveResult(id, BuildMetadata(context, capa.DigitalSignature));
+        }
+
+        public async Task<CrudSaveResult> UpdateAsync(CapaCase capa, CapaCrudContext context)
+        {
+            await UpdateCoreAsync(capa, context).ConfigureAwait(false);
+            return new CrudSaveResult(capa.Id, BuildMetadata(context, capa.DigitalSignature));
+        }
+
+        private static SignatureMetadataDto BuildMetadata(CapaCrudContext context, string? signature)
+            => new()
+            {
+                Id = context.SignatureId,
+                Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
+                Method = context.SignatureMethod,
+                Status = context.SignatureStatus,
+                Note = context.SignatureNote,
+                Session = context.SessionId,
+                Device = context.DeviceInfo,
+                IpAddress = context.Ip
+            };
+    }
+
+    public sealed partial class FakeValidationCrudService
+    {
+        public async Task<CrudSaveResult> CreateAsync(Validation validation, ValidationCrudContext context)
+        {
+            var id = await CreateCoreAsync(validation, context).ConfigureAwait(false);
+            return new CrudSaveResult(id, BuildMetadata(context, validation.DigitalSignature));
+        }
+
+        public async Task<CrudSaveResult> UpdateAsync(Validation validation, ValidationCrudContext context)
+        {
+            await UpdateCoreAsync(validation, context).ConfigureAwait(false);
+            return new CrudSaveResult(validation.Id, BuildMetadata(context, validation.DigitalSignature));
+        }
+
+        private static SignatureMetadataDto BuildMetadata(ValidationCrudContext context, string? signature)
+            => new()
+            {
+                Id = context.SignatureId,
+                Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
+                Method = context.SignatureMethod,
+                Status = context.SignatureStatus,
+                Note = context.SignatureNote,
+                Session = context.SessionId,
+                Device = context.DeviceInfo,
+                IpAddress = context.Ip
+            };
+    }
+
+    public sealed partial class FakePartCrudService
+    {
+        public async Task<CrudSaveResult> CreateAsync(Part part, PartCrudContext context)
+        {
+            var id = await CreateCoreAsync(part, context).ConfigureAwait(false);
+            return new CrudSaveResult(id, BuildMetadata(context, part.DigitalSignature));
+        }
+
+        public async Task<CrudSaveResult> UpdateAsync(Part part, PartCrudContext context)
+        {
+            await UpdateCoreAsync(part, context).ConfigureAwait(false);
+            return new CrudSaveResult(part.Id, BuildMetadata(context, part.DigitalSignature));
+        }
+
+        private static SignatureMetadataDto BuildMetadata(PartCrudContext context, string? signature)
+            => new()
+            {
+                Id = context.SignatureId,
+                Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
+                Method = context.SignatureMethod,
+                Status = context.SignatureStatus,
+                Note = context.SignatureNote,
+                Session = context.SessionId,
+                Device = context.DeviceInfo,
+                IpAddress = context.Ip
+            };
+    }
+
+    public sealed partial class FakeSupplierCrudService
+    {
+        public async Task<CrudSaveResult> CreateAsync(Supplier supplier, SupplierCrudContext context)
+        {
+            var id = await CreateCoreAsync(supplier, context).ConfigureAwait(false);
+            return new CrudSaveResult(id, BuildMetadata(context, supplier.DigitalSignature));
+        }
+
+        public async Task<CrudSaveResult> UpdateAsync(Supplier supplier, SupplierCrudContext context)
+        {
+            await UpdateCoreAsync(supplier, context).ConfigureAwait(false);
+            return new CrudSaveResult(supplier.Id, BuildMetadata(context, supplier.DigitalSignature));
+        }
+
+        private static SignatureMetadataDto BuildMetadata(SupplierCrudContext context, string? signature)
+            => new()
+            {
+                Id = context.SignatureId,
+                Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
+                Method = context.SignatureMethod,
+                Status = context.SignatureStatus,
+                Note = context.SignatureNote,
+                Session = context.SessionId,
+                Device = context.DeviceInfo,
+                IpAddress = context.Ip
+            };
+    }
+
+    public sealed partial class FakeWarehouseCrudService
+    {
+        public async Task<CrudSaveResult> CreateAsync(Warehouse warehouse, WarehouseCrudContext context)
+        {
+            var id = await CreateCoreAsync(warehouse, context).ConfigureAwait(false);
+            return new CrudSaveResult(id, BuildMetadata(context, warehouse.DigitalSignature));
+        }
+
+        public async Task<CrudSaveResult> UpdateAsync(Warehouse warehouse, WarehouseCrudContext context)
+        {
+            await UpdateCoreAsync(warehouse, context).ConfigureAwait(false);
+            return new CrudSaveResult(warehouse.Id, BuildMetadata(context, warehouse.DigitalSignature));
+        }
+
+        private static SignatureMetadataDto BuildMetadata(WarehouseCrudContext context, string? signature)
+            => new()
+            {
+                Id = context.SignatureId,
+                Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
+                Method = context.SignatureMethod,
+                Status = context.SignatureStatus,
+                Note = context.SignatureNote,
+                Session = context.SessionId,
+                Device = context.DeviceInfo,
+                IpAddress = context.Ip
+            };
+    }
+
+    public sealed partial class FakeScheduledJobCrudService
+    {
+        public async Task<CrudSaveResult> CreateAsync(ScheduledJob job, ScheduledJobCrudContext context)
+        {
+            var id = await CreateCoreAsync(job, context).ConfigureAwait(false);
+            return new CrudSaveResult(id, BuildMetadata(context, job.DigitalSignature));
+        }
+
+        public async Task<CrudSaveResult> UpdateAsync(ScheduledJob job, ScheduledJobCrudContext context)
+        {
+            await UpdateCoreAsync(job, context).ConfigureAwait(false);
+            return new CrudSaveResult(job.Id, BuildMetadata(context, job.DigitalSignature));
+        }
+
+        private static SignatureMetadataDto BuildMetadata(ScheduledJobCrudContext context, string? signature)
+            => new()
+            {
+                Id = context.SignatureId,
+                Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
+                Method = context.SignatureMethod,
+                Status = context.SignatureStatus,
+                Note = context.SignatureNote,
+                Session = context.SessionId,
+                Device = context.DeviceInfo,
+                IpAddress = context.Ip
+            };
+    }
+
+    public sealed partial class FakeUserCrudService
+    {
+        public async Task<CrudSaveResult> CreateAsync(User user, string password, UserCrudContext context)
+        {
+            var id = await CreateCoreAsync(user, password, context).ConfigureAwait(false);
+            return new CrudSaveResult(id, BuildMetadata(context, user.DigitalSignature));
+        }
+
+        public async Task<CrudSaveResult> UpdateAsync(User user, string? password, UserCrudContext context)
+        {
+            await UpdateCoreAsync(user, password, context).ConfigureAwait(false);
+            return new CrudSaveResult(user.Id, BuildMetadata(context, user.DigitalSignature));
+        }
+
+        private static SignatureMetadataDto BuildMetadata(UserCrudContext context, string? signature)
+            => new()
+            {
+                Id = context.SignatureId,
+                Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
+                Method = context.SignatureMethod,
+                Status = context.SignatureStatus,
+                Note = context.SignatureNote,
+                Session = context.SessionId,
+                Device = context.DeviceInfo,
+                IpAddress = context.Ip
+            };
+    }
+
+    public sealed partial class FakeWorkOrderCrudService
+    {
+        public async Task<CrudSaveResult> CreateAsync(WorkOrder workOrder, WorkOrderCrudContext context)
+        {
+            var id = await CreateCoreAsync(workOrder, context).ConfigureAwait(false);
+            return new CrudSaveResult(id, BuildMetadata(context, workOrder.DigitalSignature));
+        }
+
+        public async Task<CrudSaveResult> UpdateAsync(WorkOrder workOrder, WorkOrderCrudContext context)
+        {
+            await UpdateCoreAsync(workOrder, context).ConfigureAwait(false);
+            return new CrudSaveResult(workOrder.Id, BuildMetadata(context, workOrder.DigitalSignature));
+        }
+
+        private static SignatureMetadataDto BuildMetadata(WorkOrderCrudContext context, string? signature)
+            => new()
+            {
+                Id = context.SignatureId,
+                Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
+                Method = context.SignatureMethod,
+                Status = context.SignatureStatus,
+                Note = context.SignatureNote,
+                Session = context.SessionId,
+                Device = context.DeviceInfo,
+                IpAddress = context.Ip
+            };
+    }
+}

--- a/YasGMP.Wpf.Tests/TestStubs.cs
+++ b/YasGMP.Wpf.Tests/TestStubs.cs
@@ -343,7 +343,7 @@ namespace YasGMP.Models
 
     }
 
-    public sealed class FakeMachineCrudService : IMachineCrudService
+public sealed partial class FakeMachineCrudService : IMachineCrudService
     {
 
         public int Id { get; set; }
@@ -627,7 +627,7 @@ namespace YasGMP.Services.Interfaces
     }
 }
 
-        public Task<int> CreateAsync(Machine machine, MachineCrudContext context)
+        public Task<int> CreateCoreAsync(Machine machine, MachineCrudContext context)
         {
             if (machine.Id == 0)
             {
@@ -638,7 +638,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(machine.Id);
         }
 
-        public Task UpdateAsync(Machine machine, MachineCrudContext context)
+        public Task UpdateCoreAsync(Machine machine, MachineCrudContext context)
         {
             var existing = _store.FirstOrDefault(m => m.Id == machine.Id);
             if (existing is null)
@@ -718,7 +718,7 @@ namespace YasGMP.Services.Interfaces
     }
 
 
-    public sealed class FakeComponentCrudService : IComponentCrudService
+    public sealed partial class FakeComponentCrudService : IComponentCrudService
     {
         private readonly List<Component> _store = new();
         private readonly List<(Component Entity, ComponentCrudContext Context)> _savedSnapshots = new();
@@ -736,7 +736,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Component?> TryGetByIdAsync(int id)
             => Task.FromResult<Component?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Component component, ComponentCrudContext context)
+        public Task<int> CreateCoreAsync(Component component, ComponentCrudContext context)
         {
             if (component.Id == 0)
             {
@@ -748,7 +748,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(component.Id);
         }
 
-        public Task UpdateAsync(Component component, ComponentCrudContext context)
+        public Task UpdateCoreAsync(Component component, ComponentCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == component.Id);
             if (existing is null)
@@ -821,7 +821,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeCalibrationCrudService : ICalibrationCrudService
+    public sealed partial class FakeCalibrationCrudService : ICalibrationCrudService
     {
         private readonly List<Calibration> _store = new();
         private readonly List<(Calibration Entity, CalibrationCrudContext Context)> _savedSnapshots = new();
@@ -839,7 +839,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Calibration?> TryGetByIdAsync(int id)
             => Task.FromResult<Calibration?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Calibration calibration, CalibrationCrudContext context)
+        public Task<int> CreateCoreAsync(Calibration calibration, CalibrationCrudContext context)
         {
             if (calibration.Id == 0)
             {
@@ -851,7 +851,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(calibration.Id);
         }
 
-        public Task UpdateAsync(Calibration calibration, CalibrationCrudContext context)
+        public Task UpdateCoreAsync(Calibration calibration, CalibrationCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == calibration.Id);
             if (existing is null)
@@ -916,7 +916,7 @@ namespace YasGMP.Services.Interfaces
     }
 
 
-    public sealed class FakeMachineCrudService : IMachineCrudService
+    public sealed partial class FakeMachineCrudService : IMachineCrudService
     {
         private readonly List<Machine> _store = new();
         private readonly List<(Machine Entity, MachineCrudContext Context)> _savedSnapshots = new();
@@ -934,7 +934,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Machine?> TryGetByIdAsync(int id)
             => Task.FromResult<Machine?>(_store.FirstOrDefault(m => m.Id == id));
 
-        public Task<int> CreateAsync(Machine machine, MachineCrudContext context)
+        public Task<int> CreateCoreAsync(Machine machine, MachineCrudContext context)
         {
             if (machine.Id == 0)
             {
@@ -945,7 +945,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(machine.Id);
         }
 
-        public Task UpdateAsync(Machine machine, MachineCrudContext context)
+        public Task UpdateCoreAsync(Machine machine, MachineCrudContext context)
         {
             var existing = _store.FirstOrDefault(m => m.Id == machine.Id);
             if (existing is null)
@@ -1024,7 +1024,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeComponentCrudService : IComponentCrudService
+    public sealed partial class FakeComponentCrudService : IComponentCrudService
     {
         private readonly List<Component> _store = new();
         private readonly List<(Component Entity, ComponentCrudContext Context)> _savedSnapshots = new();
@@ -1042,7 +1042,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Component?> TryGetByIdAsync(int id)
             => Task.FromResult<Component?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Component component, ComponentCrudContext context)
+        public Task<int> CreateCoreAsync(Component component, ComponentCrudContext context)
         {
             if (component.Id == 0)
             {
@@ -1054,7 +1054,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(component.Id);
         }
 
-        public Task UpdateAsync(Component component, ComponentCrudContext context)
+        public Task UpdateCoreAsync(Component component, ComponentCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == component.Id);
             if (existing is null)
@@ -1128,7 +1128,7 @@ namespace YasGMP.Services.Interfaces
     }
 
 
-    public sealed class FakeMachineCrudService : IMachineCrudService
+    public sealed partial class FakeMachineCrudService : IMachineCrudService
     {
         private readonly List<Machine> _store = new();
         private readonly List<(Machine Entity, MachineCrudContext Context)> _savedSnapshots = new();
@@ -1146,7 +1146,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Machine?> TryGetByIdAsync(int id)
             => Task.FromResult<Machine?>(_store.FirstOrDefault(m => m.Id == id));
 
-        public Task<int> CreateAsync(Machine machine, MachineCrudContext context)
+        public Task<int> CreateCoreAsync(Machine machine, MachineCrudContext context)
         {
             if (machine.Id == 0)
             {
@@ -1157,7 +1157,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(machine.Id);
         }
 
-        public Task UpdateAsync(Machine machine, MachineCrudContext context)
+        public Task UpdateCoreAsync(Machine machine, MachineCrudContext context)
         {
             var existing = _store.FirstOrDefault(m => m.Id == machine.Id);
             if (existing is null)
@@ -1341,7 +1341,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeComponentCrudService : IComponentCrudService
+    public sealed partial class FakeComponentCrudService : IComponentCrudService
     {
         private readonly List<Component> _store = new();
 
@@ -1365,7 +1365,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Component?> TryGetByIdAsync(int id)
             => Task.FromResult<Component?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Component component, ComponentCrudContext context)
+        public Task<int> CreateCoreAsync(Component component, ComponentCrudContext context)
         {
             if (component.Id == 0)
             {
@@ -1478,7 +1478,7 @@ namespace YasGMP.Services.Interfaces
             => Task.CompletedTask;
     }
 }
-        public Task UpdateAsync(Component component, ComponentCrudContext context)
+        public Task UpdateCoreAsync(Component component, ComponentCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == component.Id);
             if (existing is null)
@@ -1553,7 +1553,7 @@ namespace YasGMP.Services.Interfaces
     }
 
 
-    public sealed class FakeCalibrationCrudService : ICalibrationCrudService
+    public sealed partial class FakeCalibrationCrudService : ICalibrationCrudService
     {
         private readonly List<Calibration> _store = new();
         private readonly List<(Calibration Entity, CalibrationCrudContext Context)> _savedSnapshots = new();
@@ -1571,7 +1571,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Calibration?> TryGetByIdAsync(int id)
             => Task.FromResult<Calibration?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Calibration calibration, CalibrationCrudContext context)
+        public Task<int> CreateCoreAsync(Calibration calibration, CalibrationCrudContext context)
         {
             if (calibration.Id == 0)
             {
@@ -1583,7 +1583,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(calibration.Id);
         }
 
-        public Task UpdateAsync(Calibration calibration, CalibrationCrudContext context)
+        public Task UpdateCoreAsync(Calibration calibration, CalibrationCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == calibration.Id);
             if (existing is null)
@@ -1647,7 +1647,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeMachineCrudService : IMachineCrudService
+    public sealed partial class FakeMachineCrudService : IMachineCrudService
     {
         private readonly List<Machine> _store = new();
         private readonly List<(Machine Entity, MachineCrudContext Context)> _savedSnapshots = new();
@@ -1665,7 +1665,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Machine?> TryGetByIdAsync(int id)
             => Task.FromResult<Machine?>(_store.FirstOrDefault(m => m.Id == id));
 
-        public Task<int> CreateAsync(Machine machine, MachineCrudContext context)
+        public Task<int> CreateCoreAsync(Machine machine, MachineCrudContext context)
         {
             if (machine.Id == 0)
             {
@@ -1676,7 +1676,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(machine.Id);
         }
 
-        public Task UpdateAsync(Machine machine, MachineCrudContext context)
+        public Task UpdateCoreAsync(Machine machine, MachineCrudContext context)
         {
             var existing = _store.FirstOrDefault(m => m.Id == machine.Id);
             if (existing is null)
@@ -1755,7 +1755,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeComponentCrudService : IComponentCrudService
+    public sealed partial class FakeComponentCrudService : IComponentCrudService
     {
         private readonly List<Component> _store = new();
         private readonly List<(Component Entity, ComponentCrudContext Context)> _savedSnapshots = new();
@@ -1773,7 +1773,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Component?> TryGetByIdAsync(int id)
             => Task.FromResult<Component?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Component component, ComponentCrudContext context)
+        public Task<int> CreateCoreAsync(Component component, ComponentCrudContext context)
         {
             if (component.Id == 0)
             {
@@ -1785,7 +1785,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(component.Id);
         }
 
-        public Task UpdateAsync(Component component, ComponentCrudContext context)
+        public Task UpdateCoreAsync(Component component, ComponentCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == component.Id);
             if (existing is null)
@@ -1858,7 +1858,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeCalibrationCrudService : ICalibrationCrudService
+    public sealed partial class FakeCalibrationCrudService : ICalibrationCrudService
     {
         public int Id { get; set; }
         public string? FullName { get; set; }
@@ -2128,7 +2128,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeMachineCrudService : IMachineCrudService
+    public sealed partial class FakeMachineCrudService : IMachineCrudService
     {
         private readonly List<Machine> _store = new();
         private readonly List<(Machine Entity, MachineCrudContext Context)> _savedSnapshots = new();
@@ -2146,7 +2146,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Machine?> TryGetByIdAsync(int id)
             => Task.FromResult<Machine?>(_store.FirstOrDefault(m => m.Id == id));
 
-        public Task<int> CreateAsync(Machine machine, MachineCrudContext context)
+        public Task<int> CreateCoreAsync(Machine machine, MachineCrudContext context)
         {
             if (machine.Id == 0)
             {
@@ -2157,7 +2157,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(machine.Id);
         }
 
-        public Task UpdateAsync(Machine machine, MachineCrudContext context)
+        public Task UpdateCoreAsync(Machine machine, MachineCrudContext context)
         {
             var existing = _store.FirstOrDefault(m => m.Id == machine.Id);
             if (existing is null)
@@ -2236,7 +2236,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeComponentCrudService : IComponentCrudService
+    public sealed partial class FakeComponentCrudService : IComponentCrudService
     {
         private readonly List<Component> _store = new();
         private readonly List<(Component Entity, ComponentCrudContext Context)> _savedSnapshots = new();
@@ -2254,7 +2254,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Component?> TryGetByIdAsync(int id)
             => Task.FromResult<Component?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Component component, ComponentCrudContext context)
+        public Task<int> CreateCoreAsync(Component component, ComponentCrudContext context)
         {
             if (component.Id == 0)
             {
@@ -2266,7 +2266,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(component.Id);
         }
 
-        public Task UpdateAsync(Component component, ComponentCrudContext context)
+        public Task UpdateCoreAsync(Component component, ComponentCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == component.Id);
             if (existing is null)
@@ -2468,7 +2468,7 @@ namespace YasGMP.Services.Interfaces
         public List<Warehouse> Warehouses { get; } = new();
         public List<Incident> Incidents { get; } = new();
 
-        public Task<int> CreateAsync(Calibration calibration, CalibrationCrudContext context)
+        public Task<int> CreateCoreAsync(Calibration calibration, CalibrationCrudContext context)
         {
             if (calibration.Id == 0)
             {
@@ -2629,7 +2629,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeMachineCrudService : IMachineCrudService
+    public sealed partial class FakeMachineCrudService : IMachineCrudService
     {
         private readonly List<Machine> _store = new();
         private readonly List<(Machine Entity, MachineCrudContext Context)> _savedSnapshots = new();
@@ -2647,7 +2647,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Machine?> TryGetByIdAsync(int id)
             => Task.FromResult<Machine?>(_store.FirstOrDefault(m => m.Id == id));
 
-        public Task<int> CreateAsync(Machine machine, MachineCrudContext context)
+        public Task<int> CreateCoreAsync(Machine machine, MachineCrudContext context)
         {
             if (machine.Id == 0)
             {
@@ -2658,7 +2658,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(machine.Id);
         }
 
-        public Task UpdateAsync(Machine machine, MachineCrudContext context)
+        public Task UpdateCoreAsync(Machine machine, MachineCrudContext context)
         {
             var existing = _store.FirstOrDefault(m => m.Id == machine.Id);
             if (existing is null)
@@ -2737,7 +2737,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeComponentCrudService : IComponentCrudService
+    public sealed partial class FakeComponentCrudService : IComponentCrudService
     {
         private readonly List<Component> _store = new();
         private readonly List<(Component Entity, ComponentCrudContext Context)> _savedSnapshots = new();
@@ -2755,7 +2755,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Component?> TryGetByIdAsync(int id)
             => Task.FromResult<Component?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Component component, ComponentCrudContext context)
+        public Task<int> CreateCoreAsync(Component component, ComponentCrudContext context)
         {
             if (component.Id == 0)
             {
@@ -2767,7 +2767,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(component.Id);
         }
 
-        public Task UpdateAsync(Component component, ComponentCrudContext context)
+        public Task UpdateCoreAsync(Component component, ComponentCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == component.Id);
             if (existing is null)
@@ -2840,7 +2840,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeCalibrationCrudService : ICalibrationCrudService
+    public sealed partial class FakeCalibrationCrudService : ICalibrationCrudService
     {
         private readonly List<Calibration> _store = new();
         private readonly List<(Calibration Entity, CalibrationCrudContext Context)> _savedSnapshots = new();
@@ -2858,7 +2858,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Calibration?> TryGetByIdAsync(int id)
             => Task.FromResult<Calibration?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Calibration calibration, CalibrationCrudContext context)
+        public Task<int> CreateCoreAsync(Calibration calibration, CalibrationCrudContext context)
         {
             if (calibration.Id == 0)
             {
@@ -2870,7 +2870,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(calibration.Id);
         }
 
-        public Task UpdateAsync(Calibration calibration, CalibrationCrudContext context)
+        public Task UpdateCoreAsync(Calibration calibration, CalibrationCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == calibration.Id);
             if (existing is null)
@@ -3015,7 +3015,7 @@ namespace YasGMP.Services.Interfaces
         public DateTime? RetainUntil { get; set; }
     }
 
-    public sealed class FakeMachineCrudService : IMachineCrudService
+    public sealed partial class FakeMachineCrudService : IMachineCrudService
     {
         public int Id { get; set; }
         public int ComponentId { get; set; }
@@ -3233,7 +3233,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeIncidentCrudService : IIncidentCrudService
+    public sealed partial class FakeIncidentCrudService : IIncidentCrudService
     {
         private readonly List<Incident> _store = new();
         private readonly List<(Incident Entity, IncidentCrudContext Context)> _savedSnapshots = new();
@@ -3248,7 +3248,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Incident?> TryGetByIdAsync(int id)
             => Task.FromResult(_store.FirstOrDefault(i => i.Id == id));
 
-        public Task<int> CreateAsync(Incident incident, IncidentCrudContext context)
+        public Task<int> CreateCoreAsync(Incident incident, IncidentCrudContext context)
         {
             if (incident.Id == 0)
             {
@@ -3260,7 +3260,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(incident.Id);
         }
 
-        public Task UpdateAsync(Incident incident, IncidentCrudContext context)
+        public Task UpdateCoreAsync(Incident incident, IncidentCrudContext context)
         {
             var existing = _store.FirstOrDefault(i => i.Id == incident.Id);
             if (existing is null)
@@ -3349,7 +3349,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeComponentCrudService : IComponentCrudService
+    public sealed partial class FakeComponentCrudService : IComponentCrudService
     {
         private readonly List<Component> _store = new();
         private readonly List<(Component Entity, ComponentCrudContext Context)> _savedSnapshots = new();
@@ -3367,7 +3367,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Component?> TryGetByIdAsync(int id)
             => Task.FromResult<Component?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Component component, ComponentCrudContext context)
+        public Task<int> CreateCoreAsync(Component component, ComponentCrudContext context)
         {
             if (component.Id == 0)
             {
@@ -3379,7 +3379,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(component.Id);
         }
 
-        public Task UpdateAsync(Component component, ComponentCrudContext context)
+        public Task UpdateCoreAsync(Component component, ComponentCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == component.Id);
             if (existing is null)
@@ -3452,7 +3452,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeCalibrationCrudService : ICalibrationCrudService
+    public sealed partial class FakeCalibrationCrudService : ICalibrationCrudService
     {
         private readonly List<Calibration> _store = new();
         private readonly List<(Calibration Entity, CalibrationCrudContext Context)> _savedSnapshots = new();
@@ -3470,7 +3470,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Calibration?> TryGetByIdAsync(int id)
             => Task.FromResult<Calibration?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Calibration calibration, CalibrationCrudContext context)
+        public Task<int> CreateCoreAsync(Calibration calibration, CalibrationCrudContext context)
         {
             if (calibration.Id == 0)
             {
@@ -3482,7 +3482,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(calibration.Id);
         }
 
-        public Task UpdateAsync(Calibration calibration, CalibrationCrudContext context)
+        public Task UpdateCoreAsync(Calibration calibration, CalibrationCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == calibration.Id);
             if (existing is null)
@@ -3911,7 +3911,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeCapaCrudService : ICapaCrudService
+    public sealed partial class FakeCapaCrudService : ICapaCrudService
     {
         private readonly List<CapaCase> _store = new();
         private readonly List<(CapaCase Entity, CapaCrudContext Context)> _savedSnapshots = new();
@@ -3929,7 +3929,7 @@ namespace YasGMP.Services.Interfaces
         public Task<CapaCase?> TryGetByIdAsync(int id)
             => Task.FromResult<CapaCase?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(CapaCase capa, CapaCrudContext context)
+        public Task<int> CreateCoreAsync(CapaCase capa, CapaCrudContext context)
         {
             if (capa.Id == 0)
             {
@@ -3941,7 +3941,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(capa.Id);
         }
 
-        public Task UpdateAsync(CapaCase capa, CapaCrudContext context)
+        public Task UpdateCoreAsync(CapaCase capa, CapaCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == capa.Id);
             if (existing is null)
@@ -4031,7 +4031,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeComponentCrudService : IComponentCrudService
+    public sealed partial class FakeComponentCrudService : IComponentCrudService
     {
         private readonly List<Component> _store = new();
         private readonly List<(Component Entity, ComponentCrudContext Context)> _savedSnapshots = new();
@@ -4049,7 +4049,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Component?> TryGetByIdAsync(int id)
             => Task.FromResult<Component?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Component component, ComponentCrudContext context)
+        public Task<int> CreateCoreAsync(Component component, ComponentCrudContext context)
         {
             if (component.Id == 0)
             {
@@ -4061,7 +4061,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(component.Id);
         }
 
-        public Task UpdateAsync(Component component, ComponentCrudContext context)
+        public Task UpdateCoreAsync(Component component, ComponentCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == component.Id);
             if (existing is null)
@@ -4134,7 +4134,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeCalibrationCrudService : ICalibrationCrudService
+    public sealed partial class FakeCalibrationCrudService : ICalibrationCrudService
     {
         private readonly List<Calibration> _store = new();
         private readonly List<(Calibration Entity, CalibrationCrudContext Context)> _savedSnapshots = new();
@@ -4152,7 +4152,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Calibration?> TryGetByIdAsync(int id)
             => Task.FromResult<Calibration?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Calibration calibration, CalibrationCrudContext context)
+        public Task<int> CreateCoreAsync(Calibration calibration, CalibrationCrudContext context)
         {
             if (calibration.Id == 0)
             {
@@ -4164,7 +4164,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(calibration.Id);
         }
 
-        public Task UpdateAsync(Calibration calibration, CalibrationCrudContext context)
+        public Task UpdateCoreAsync(Calibration calibration, CalibrationCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == calibration.Id);
             if (existing is null)
@@ -4228,7 +4228,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeMachineCrudService : IMachineCrudService
+    public sealed partial class FakeMachineCrudService : IMachineCrudService
     {
         private readonly List<Machine> _store = new();
         private readonly List<(Machine Entity, MachineCrudContext Context)> _savedSnapshots = new();
@@ -4246,7 +4246,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Machine?> TryGetByIdAsync(int id)
             => Task.FromResult<Machine?>(_store.FirstOrDefault(m => m.Id == id));
 
-        public Task<int> CreateAsync(Machine machine, MachineCrudContext context)
+        public Task<int> CreateCoreAsync(Machine machine, MachineCrudContext context)
         {
             if (machine.Id == 0)
             {
@@ -4257,7 +4257,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(machine.Id);
         }
 
-        public Task UpdateAsync(Machine machine, MachineCrudContext context)
+        public Task UpdateCoreAsync(Machine machine, MachineCrudContext context)
         {
             var existing = _store.FirstOrDefault(m => m.Id == machine.Id);
             if (existing is null)
@@ -4336,7 +4336,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeIncidentCrudService : IIncidentCrudService
+    public sealed partial class FakeIncidentCrudService : IIncidentCrudService
     {
         private readonly List<Incident> _store = new();
         private readonly List<(Incident Entity, IncidentCrudContext Context)> _savedSnapshots = new();
@@ -4351,7 +4351,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Incident?> TryGetByIdAsync(int id)
             => Task.FromResult(_store.FirstOrDefault(i => i.Id == id));
 
-        public Task<int> CreateAsync(Incident incident, IncidentCrudContext context)
+        public Task<int> CreateCoreAsync(Incident incident, IncidentCrudContext context)
         {
             if (incident.Id == 0)
             {
@@ -4363,7 +4363,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(incident.Id);
         }
 
-        public Task UpdateAsync(Incident incident, IncidentCrudContext context)
+        public Task UpdateCoreAsync(Incident incident, IncidentCrudContext context)
         {
             var existing = _store.FirstOrDefault(i => i.Id == incident.Id);
             if (existing is null)
@@ -4452,7 +4452,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeChangeControlCrudService : IChangeControlCrudService
+    public sealed partial class FakeChangeControlCrudService : IChangeControlCrudService
     {
         private readonly List<ChangeControl> _store = new();
         private readonly List<(ChangeControl Entity, ChangeControlCrudContext Context)> _savedSnapshots = new();
@@ -4473,7 +4473,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(match is null ? null : Clone(match));
         }
 
-        public Task<int> CreateAsync(ChangeControl changeControl, ChangeControlCrudContext context)
+        public Task<int> CreateCoreAsync(ChangeControl changeControl, ChangeControlCrudContext context)
         {
             if (changeControl.Id == 0)
             {
@@ -4485,7 +4485,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(changeControl.Id);
         }
 
-        public Task UpdateAsync(ChangeControl changeControl, ChangeControlCrudContext context)
+        public Task UpdateCoreAsync(ChangeControl changeControl, ChangeControlCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == changeControl.Id);
             if (existing is null)
@@ -4627,7 +4627,7 @@ namespace YasGMP.Services.Interfaces
         public DateTime? RetainUntil { get; set; }
     }
 
-    public sealed class FakeCapaCrudService : ICapaCrudService
+    public sealed partial class FakeCapaCrudService : ICapaCrudService
     {
         public int Id { get; set; }
         public int ComponentId { get; set; }
@@ -4826,7 +4826,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeComponentCrudService : IComponentCrudService
+    public sealed partial class FakeComponentCrudService : IComponentCrudService
     {
         private readonly List<Component> _store = new();
 
@@ -4839,7 +4839,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Component?> TryGetByIdAsync(int id)
             => Task.FromResult<Component?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Component component, ComponentCrudContext context)
+        public Task<int> CreateCoreAsync(Component component, ComponentCrudContext context)
         {
             if (component.Id == 0)
             {
@@ -4851,7 +4851,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(component.Id);
         }
 
-        public Task UpdateAsync(Component component, ComponentCrudContext context)
+        public Task UpdateCoreAsync(Component component, ComponentCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == component.Id);
             if (existing is null)
@@ -4924,7 +4924,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeCalibrationCrudService : ICalibrationCrudService
+    public sealed partial class FakeCalibrationCrudService : ICalibrationCrudService
     {
         private readonly List<Calibration> _store = new();
         private readonly List<(Calibration Entity, CalibrationCrudContext Context)> _savedSnapshots = new();
@@ -4942,7 +4942,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Calibration?> TryGetByIdAsync(int id)
             => Task.FromResult<Calibration?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Calibration calibration, CalibrationCrudContext context)
+        public Task<int> CreateCoreAsync(Calibration calibration, CalibrationCrudContext context)
         {
             if (calibration.Id == 0)
             {
@@ -4954,7 +4954,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(calibration.Id);
         }
 
-        public Task UpdateAsync(Calibration calibration, CalibrationCrudContext context)
+        public Task UpdateCoreAsync(Calibration calibration, CalibrationCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == calibration.Id);
             if (existing is null)
@@ -5018,7 +5018,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeMachineCrudService : IMachineCrudService
+    public sealed partial class FakeMachineCrudService : IMachineCrudService
     {
         private readonly List<Machine> _store = new();
         private readonly List<(Machine Entity, MachineCrudContext Context)> _savedSnapshots = new();
@@ -5036,7 +5036,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Machine?> TryGetByIdAsync(int id)
             => Task.FromResult<Machine?>(_store.FirstOrDefault(m => m.Id == id));
 
-        public Task<int> CreateAsync(Machine machine, MachineCrudContext context)
+        public Task<int> CreateCoreAsync(Machine machine, MachineCrudContext context)
         {
             if (machine.Id == 0)
             {
@@ -5047,7 +5047,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(machine.Id);
         }
 
-        public Task UpdateAsync(Machine machine, MachineCrudContext context)
+        public Task UpdateCoreAsync(Machine machine, MachineCrudContext context)
         {
             var existing = _store.FirstOrDefault(m => m.Id == machine.Id);
             if (existing is null)
@@ -5126,7 +5126,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeIncidentCrudService : IIncidentCrudService
+    public sealed partial class FakeIncidentCrudService : IIncidentCrudService
     {
         private readonly List<Incident> _store = new();
         private readonly List<(Incident Entity, IncidentCrudContext Context)> _savedSnapshots = new();
@@ -5141,7 +5141,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Incident?> TryGetByIdAsync(int id)
             => Task.FromResult(_store.FirstOrDefault(i => i.Id == id));
 
-        public Task<int> CreateAsync(Incident incident, IncidentCrudContext context)
+        public Task<int> CreateCoreAsync(Incident incident, IncidentCrudContext context)
         {
             if (incident.Id == 0)
             {
@@ -5153,7 +5153,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(incident.Id);
         }
 
-        public Task UpdateAsync(Incident incident, IncidentCrudContext context)
+        public Task UpdateCoreAsync(Incident incident, IncidentCrudContext context)
 
         {
             var existing = _store.FirstOrDefault(i => i.Id == incident.Id);
@@ -5243,7 +5243,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeChangeControlCrudService : IChangeControlCrudService
+    public sealed partial class FakeChangeControlCrudService : IChangeControlCrudService
     {
         private readonly List<ChangeControl> _store = new();
         private readonly List<(ChangeControl Entity, ChangeControlCrudContext Context)> _savedSnapshots = new();
@@ -5264,7 +5264,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(match is null ? null : Clone(match));
         }
 
-        public Task<int> CreateAsync(ChangeControl changeControl, ChangeControlCrudContext context)
+        public Task<int> CreateCoreAsync(ChangeControl changeControl, ChangeControlCrudContext context)
         {
             if (changeControl.Id == 0)
             {
@@ -5276,7 +5276,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(changeControl.Id);
         }
 
-        public Task UpdateAsync(ChangeControl changeControl, ChangeControlCrudContext context)
+        public Task UpdateCoreAsync(ChangeControl changeControl, ChangeControlCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == changeControl.Id);
             if (existing is null)
@@ -5356,7 +5356,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeValidationCrudService : IValidationCrudService
+    public sealed partial class FakeValidationCrudService : IValidationCrudService
     {
         private readonly List<Validation> _store = new();
         private readonly List<(Validation Entity, ValidationCrudContext Context)> _savedSnapshots = new();
@@ -5377,7 +5377,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(match is null ? null : Clone(match));
         }
 
-        public Task<int> CreateAsync(Validation validation, ValidationCrudContext context)
+        public Task<int> CreateCoreAsync(Validation validation, ValidationCrudContext context)
         {
             if (validation.Id == 0)
             {
@@ -5389,7 +5389,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(validation.Id);
         }
 
-        public Task UpdateAsync(Validation validation, ValidationCrudContext context)
+        public Task UpdateCoreAsync(Validation validation, ValidationCrudContext context)
         {
             var existing = _store.FirstOrDefault(v => v.Id == validation.Id);
             if (existing is null)
@@ -5467,7 +5467,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeCapaCrudService : ICapaCrudService
+    public sealed partial class FakeCapaCrudService : ICapaCrudService
     {
         private readonly List<CapaCase> _store = new();
         private readonly List<(CapaCase Entity, CapaCrudContext Context)> _savedSnapshots = new();
@@ -5485,7 +5485,7 @@ namespace YasGMP.Services.Interfaces
         public Task<CapaCase?> TryGetByIdAsync(int id)
             => Task.FromResult<CapaCase?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(CapaCase capa, CapaCrudContext context)
+        public Task<int> CreateCoreAsync(CapaCase capa, CapaCrudContext context)
         {
             if (capa.Id == 0)
             {
@@ -5497,7 +5497,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(capa.Id);
         }
 
-        public Task UpdateAsync(CapaCase capa, CapaCrudContext context)
+        public Task UpdateCoreAsync(CapaCase capa, CapaCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == capa.Id);
             if (existing is null)
@@ -5587,7 +5587,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeComponentCrudService : IComponentCrudService
+    public sealed partial class FakeComponentCrudService : IComponentCrudService
     {
         private readonly List<Component> _store = new();
         private readonly List<(Component Entity, ComponentCrudContext Context)> _savedSnapshots = new();
@@ -5605,7 +5605,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Component?> TryGetByIdAsync(int id)
             => Task.FromResult<Component?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Component component, ComponentCrudContext context)
+        public Task<int> CreateCoreAsync(Component component, ComponentCrudContext context)
         {
             if (component.Id == 0)
             {
@@ -5617,7 +5617,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(component.Id);
         }
 
-        public Task UpdateAsync(Component component, ComponentCrudContext context)
+        public Task UpdateCoreAsync(Component component, ComponentCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == component.Id);
             if (existing is null)
@@ -5690,7 +5690,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeCalibrationCrudService : ICalibrationCrudService
+    public sealed partial class FakeCalibrationCrudService : ICalibrationCrudService
     {
         private readonly List<Calibration> _store = new();
         private readonly List<(Calibration Entity, CalibrationCrudContext Context)> _savedSnapshots = new();
@@ -5708,7 +5708,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Calibration?> TryGetByIdAsync(int id)
             => Task.FromResult<Calibration?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Calibration calibration, CalibrationCrudContext context)
+        public Task<int> CreateCoreAsync(Calibration calibration, CalibrationCrudContext context)
         {
             if (calibration.Id == 0)
             {
@@ -5720,7 +5720,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(calibration.Id);
         }
 
-        public Task UpdateAsync(Calibration calibration, CalibrationCrudContext context)
+        public Task UpdateCoreAsync(Calibration calibration, CalibrationCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == calibration.Id);
             if (existing is null)
@@ -5784,7 +5784,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeMachineCrudService : IMachineCrudService
+    public sealed partial class FakeMachineCrudService : IMachineCrudService
     {
         private readonly List<Machine> _store = new();
         private readonly List<(Machine Entity, MachineCrudContext Context)> _savedSnapshots = new();
@@ -5802,7 +5802,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Machine?> TryGetByIdAsync(int id)
             => Task.FromResult<Machine?>(_store.FirstOrDefault(m => m.Id == id));
 
-        public Task<int> CreateAsync(Machine machine, MachineCrudContext context)
+        public Task<int> CreateCoreAsync(Machine machine, MachineCrudContext context)
         {
             if (machine.Id == 0)
             {
@@ -5813,7 +5813,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(machine.Id);
         }
 
-        public Task UpdateAsync(Machine machine, MachineCrudContext context)
+        public Task UpdateCoreAsync(Machine machine, MachineCrudContext context)
         {
             var existing = _store.FirstOrDefault(m => m.Id == machine.Id);
             if (existing is null)
@@ -5892,7 +5892,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeIncidentCrudService : IIncidentCrudService
+    public sealed partial class FakeIncidentCrudService : IIncidentCrudService
     {
         private readonly List<Incident> _store = new();
         private readonly List<(Incident Entity, IncidentCrudContext Context)> _savedSnapshots = new();
@@ -5907,7 +5907,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Incident?> TryGetByIdAsync(int id)
             => Task.FromResult(_store.FirstOrDefault(i => i.Id == id));
 
-        public Task<int> CreateAsync(Incident incident, IncidentCrudContext context)
+        public Task<int> CreateCoreAsync(Incident incident, IncidentCrudContext context)
         {
             if (incident.Id == 0)
             {
@@ -5919,7 +5919,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(incident.Id);
         }
 
-        public Task UpdateAsync(Incident incident, IncidentCrudContext context)
+        public Task UpdateCoreAsync(Incident incident, IncidentCrudContext context)
 
         {
             var existing = _store.FirstOrDefault(i => i.Id == incident.Id);
@@ -6009,7 +6009,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeChangeControlCrudService : IChangeControlCrudService
+    public sealed partial class FakeChangeControlCrudService : IChangeControlCrudService
     {
         private readonly List<ChangeControl> _store = new();
         private readonly List<(ChangeControl Entity, ChangeControlCrudContext Context)> _savedSnapshots = new();
@@ -6030,7 +6030,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(match is null ? null : Clone(match));
         }
 
-        public Task<int> CreateAsync(ChangeControl changeControl, ChangeControlCrudContext context)
+        public Task<int> CreateCoreAsync(ChangeControl changeControl, ChangeControlCrudContext context)
         {
             if (changeControl.Id == 0)
             {
@@ -6042,7 +6042,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(changeControl.Id);
         }
 
-        public Task UpdateAsync(ChangeControl changeControl, ChangeControlCrudContext context)
+        public Task UpdateCoreAsync(ChangeControl changeControl, ChangeControlCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == changeControl.Id);
             if (existing is null)
@@ -6122,7 +6122,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeValidationCrudService : IValidationCrudService
+    public sealed partial class FakeValidationCrudService : IValidationCrudService
     {
         private readonly List<Validation> _store = new();
         private readonly List<(Validation Entity, ValidationCrudContext Context)> _savedSnapshots = new();
@@ -6143,7 +6143,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(match is null ? null : Clone(match));
         }
 
-        public Task<int> CreateAsync(Validation validation, ValidationCrudContext context)
+        public Task<int> CreateCoreAsync(Validation validation, ValidationCrudContext context)
         {
             if (validation.Id == 0)
             {
@@ -6155,7 +6155,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(validation.Id);
         }
 
-        public Task UpdateAsync(Validation validation, ValidationCrudContext context)
+        public Task UpdateCoreAsync(Validation validation, ValidationCrudContext context)
         {
             var existing = _store.FirstOrDefault(v => v.Id == validation.Id);
             if (existing is null)
@@ -6233,7 +6233,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeCapaCrudService : ICapaCrudService
+    public sealed partial class FakeCapaCrudService : ICapaCrudService
     {
         private readonly List<CapaCase> _store = new();
         private readonly List<(CapaCase Entity, CapaCrudContext Context)> _savedSnapshots = new();
@@ -6251,7 +6251,7 @@ namespace YasGMP.Services.Interfaces
         public Task<CapaCase?> TryGetByIdAsync(int id)
             => Task.FromResult<CapaCase?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(CapaCase capa, CapaCrudContext context)
+        public Task<int> CreateCoreAsync(CapaCase capa, CapaCrudContext context)
         {
             if (capa.Id == 0)
             {
@@ -6263,7 +6263,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(capa.Id);
         }
 
-        public Task UpdateAsync(CapaCase capa, CapaCrudContext context)
+        public Task UpdateCoreAsync(CapaCase capa, CapaCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == capa.Id);
             if (existing is null)
@@ -6353,7 +6353,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeComponentCrudService : IComponentCrudService
+    public sealed partial class FakeComponentCrudService : IComponentCrudService
     {
         private readonly List<Component> _store = new();
         private readonly List<(Component Entity, ComponentCrudContext Context)> _savedSnapshots = new();
@@ -6371,7 +6371,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Component?> TryGetByIdAsync(int id)
             => Task.FromResult<Component?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Component component, ComponentCrudContext context)
+        public Task<int> CreateCoreAsync(Component component, ComponentCrudContext context)
         {
             if (component.Id == 0)
             {
@@ -6383,7 +6383,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(component.Id);
         }
 
-        public Task UpdateAsync(Component component, ComponentCrudContext context)
+        public Task UpdateCoreAsync(Component component, ComponentCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == component.Id);
             if (existing is null)
@@ -6456,7 +6456,7 @@ namespace YasGMP.Services.Interfaces
         }
     }
 
-    public sealed class FakeCalibrationCrudService : ICalibrationCrudService
+    public sealed partial class FakeCalibrationCrudService : ICalibrationCrudService
     {
         private readonly List<Calibration> _store = new();
         private readonly List<(Calibration Entity, CalibrationCrudContext Context)> _savedSnapshots = new();
@@ -6474,7 +6474,7 @@ namespace YasGMP.Services.Interfaces
         public Task<Calibration?> TryGetByIdAsync(int id)
             => Task.FromResult<Calibration?>(_store.FirstOrDefault(c => c.Id == id));
 
-        public Task<int> CreateAsync(Calibration calibration, CalibrationCrudContext context)
+        public Task<int> CreateCoreAsync(Calibration calibration, CalibrationCrudContext context)
         {
             if (calibration.Id == 0)
             {
@@ -6486,7 +6486,7 @@ namespace YasGMP.Services.Interfaces
             return Task.FromResult(calibration.Id);
         }
 
-        public Task UpdateAsync(Calibration calibration, CalibrationCrudContext context)
+        public Task UpdateCoreAsync(Calibration calibration, CalibrationCrudContext context)
         {
             var existing = _store.FirstOrDefault(c => c.Id == calibration.Id);
             if (existing is null)
@@ -6737,7 +6737,7 @@ namespace YasGMP.Wpf.ViewModels.Modules
     }
 }
 
-    public sealed class FakePartCrudService : IPartCrudService
+    public sealed partial class FakePartCrudService : IPartCrudService
     {
         private readonly List<Part> _store = new();
         private readonly List<(Part Entity, PartCrudContext Context)> _savedSnapshots = new();
@@ -6755,7 +6755,7 @@ namespace YasGMP.Wpf.ViewModels.Modules
         public Task<Part?> TryGetByIdAsync(int id)
             => Task.FromResult<Part?>(_store.FirstOrDefault(p => p.Id == id));
 
-        public Task<int> CreateAsync(Part part, PartCrudContext context)
+        public Task<int> CreateCoreAsync(Part part, PartCrudContext context)
         {
             if (part.Id == 0)
             {
@@ -6767,7 +6767,7 @@ namespace YasGMP.Wpf.ViewModels.Modules
             return Task.FromResult(part.Id);
         }
 
-        public Task UpdateAsync(Part part, PartCrudContext context)
+        public Task UpdateCoreAsync(Part part, PartCrudContext context)
         {
             var existing = _store.FirstOrDefault(p => p.Id == part.Id);
             if (existing is null)
@@ -6836,7 +6836,7 @@ namespace YasGMP.Wpf.ViewModels.Modules
         }
     }
 
-    public sealed class FakeSupplierCrudService : ISupplierCrudService
+    public sealed partial class FakeSupplierCrudService : ISupplierCrudService
     {
         private readonly List<Supplier> _store = new();
         private readonly List<(Supplier Entity, SupplierCrudContext Context)> _savedSnapshots = new();
@@ -6854,7 +6854,7 @@ namespace YasGMP.Wpf.ViewModels.Modules
         public Task<Supplier?> TryGetByIdAsync(int id)
             => Task.FromResult<Supplier?>(_store.FirstOrDefault(s => s.Id == id));
 
-        public Task<int> CreateAsync(Supplier supplier, SupplierCrudContext context)
+        public Task<int> CreateCoreAsync(Supplier supplier, SupplierCrudContext context)
         {
             if (supplier.Id == 0)
             {
@@ -6866,7 +6866,7 @@ namespace YasGMP.Wpf.ViewModels.Modules
             return Task.FromResult(supplier.Id);
         }
 
-        public Task UpdateAsync(Supplier supplier, SupplierCrudContext context)
+        public Task UpdateCoreAsync(Supplier supplier, SupplierCrudContext context)
         {
             var existing = _store.FirstOrDefault(s => s.Id == supplier.Id);
             if (existing is null)
@@ -6950,7 +6950,7 @@ namespace YasGMP.Wpf.ViewModels.Modules
         }
     }
 
-    public sealed class FakeWarehouseCrudService : IWarehouseCrudService
+    public sealed partial class FakeWarehouseCrudService : IWarehouseCrudService
     {
         private readonly List<Warehouse> _store = new();
         private readonly List<(Warehouse Entity, WarehouseCrudContext Context)> _savedSnapshots = new();
@@ -6972,7 +6972,7 @@ namespace YasGMP.Wpf.ViewModels.Modules
         public Task<Warehouse?> TryGetByIdAsync(int id)
             => Task.FromResult<Warehouse?>(_store.FirstOrDefault(w => w.Id == id));
 
-        public Task<int> CreateAsync(Warehouse warehouse, WarehouseCrudContext context)
+        public Task<int> CreateCoreAsync(Warehouse warehouse, WarehouseCrudContext context)
         {
             if (warehouse.Id == 0)
             {
@@ -6984,7 +6984,7 @@ namespace YasGMP.Wpf.ViewModels.Modules
             return Task.FromResult(warehouse.Id);
         }
 
-        public Task UpdateAsync(Warehouse warehouse, WarehouseCrudContext context)
+        public Task UpdateCoreAsync(Warehouse warehouse, WarehouseCrudContext context)
         {
             var existing = _store.FirstOrDefault(w => w.Id == warehouse.Id);
             if (existing is null)
@@ -7064,7 +7064,7 @@ namespace YasGMP.Wpf.ViewModels.Modules
         }
     }
 
-    public sealed class FakeScheduledJobCrudService : IScheduledJobCrudService
+    public sealed partial class FakeScheduledJobCrudService : IScheduledJobCrudService
     {
         private readonly List<ScheduledJob> _store = new();
         private readonly List<(ScheduledJob Entity, ScheduledJobCrudContext Context)> _savedSnapshots = new();
@@ -7096,7 +7096,7 @@ namespace YasGMP.Wpf.ViewModels.Modules
         public Task<ScheduledJob?> TryGetByIdAsync(int id)
             => Task.FromResult<ScheduledJob?>(_store.FirstOrDefault(j => j.Id == id));
 
-        public Task<int> CreateAsync(ScheduledJob job, ScheduledJobCrudContext context)
+        public Task<int> CreateCoreAsync(ScheduledJob job, ScheduledJobCrudContext context)
         {
             if (job.Id == 0)
             {
@@ -7108,7 +7108,7 @@ namespace YasGMP.Wpf.ViewModels.Modules
             return Task.FromResult(job.Id);
         }
 
-        public Task UpdateAsync(ScheduledJob job, ScheduledJobCrudContext context)
+        public Task UpdateCoreAsync(ScheduledJob job, ScheduledJobCrudContext context)
         {
             var existing = _store.FirstOrDefault(j => j.Id == job.Id);
             if (existing is null)
@@ -7232,7 +7232,7 @@ namespace YasGMP.Wpf.ViewModels.Modules
         }
     }
 
-    public sealed class FakeUserCrudService : IUserCrudService
+    public sealed partial class FakeUserCrudService : IUserCrudService
     {
         private readonly List<User> _users = new();
         private readonly List<Role> _roles = new();
@@ -7289,7 +7289,7 @@ namespace YasGMP.Wpf.ViewModels.Modules
         public Task<IReadOnlyList<Role>> GetAllRolesAsync()
             => Task.FromResult<IReadOnlyList<Role>>(_roles.Select(Clone).ToList());
 
-        public Task<int> CreateAsync(User user, string password, UserCrudContext context)
+        public Task<int> CreateCoreAsync(User user, string password, UserCrudContext context)
         {
             if (user.Id == 0)
             {
@@ -7304,7 +7304,7 @@ namespace YasGMP.Wpf.ViewModels.Modules
             return Task.FromResult(user.Id);
         }
 
-        public Task UpdateAsync(User user, string? password, UserCrudContext context)
+        public Task UpdateCoreAsync(User user, string? password, UserCrudContext context)
         {
             var existing = _users.FirstOrDefault(u => u.Id == user.Id);
             if (existing is null)
@@ -7393,7 +7393,7 @@ namespace YasGMP.Wpf.ViewModels.Modules
             => new() { Id = source.Id, Name = source.Name, Description = source.Description };
     }
 
-    public sealed class FakeWorkOrderCrudService : IWorkOrderCrudService
+    public sealed partial class FakeWorkOrderCrudService : IWorkOrderCrudService
     {
         private readonly List<WorkOrder> _store = new();
         private readonly List<(WorkOrder Entity, WorkOrderCrudContext Context)> _savedSnapshots = new();
@@ -7408,7 +7408,7 @@ namespace YasGMP.Wpf.ViewModels.Modules
         public Task<WorkOrder?> TryGetByIdAsync(int id)
             => Task.FromResult<WorkOrder?>(_store.FirstOrDefault(w => w.Id == id));
 
-        public Task<int> CreateAsync(WorkOrder workOrder, WorkOrderCrudContext context)
+        public Task<int> CreateCoreAsync(WorkOrder workOrder, WorkOrderCrudContext context)
         {
             if (workOrder.Id == 0)
             {
@@ -7420,7 +7420,7 @@ namespace YasGMP.Wpf.ViewModels.Modules
             return Task.FromResult(workOrder.Id);
         }
 
-        public Task UpdateAsync(WorkOrder workOrder, WorkOrderCrudContext context)
+        public Task UpdateCoreAsync(WorkOrder workOrder, WorkOrderCrudContext context)
         {
             var existing = _store.FirstOrDefault(w => w.Id == workOrder.Id);
             if (existing is null)

--- a/YasGMP.Wpf/Services/CalibrationCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/CalibrationCrudServiceAdapter.cs
@@ -35,7 +35,7 @@ public sealed class CalibrationCrudServiceAdapter : ICalibrationCrudService
         }
     }
 
-        public async Task<int> CreateAsync(Calibration calibration, CalibrationCrudContext context)
+        public async Task<CrudSaveResult> CreateAsync(Calibration calibration, CalibrationCrudContext context)
         {
             if (calibration is null)
             {
@@ -46,10 +46,10 @@ public sealed class CalibrationCrudServiceAdapter : ICalibrationCrudService
             var metadata = CreateMetadata(context, signature);
             await _inner.CreateAsync(calibration, context.UserId, metadata).ConfigureAwait(false);
             calibration.DigitalSignature = signature;
-            return calibration.Id;
+            return new CrudSaveResult(calibration.Id, metadata);
         }
 
-        public async Task UpdateAsync(Calibration calibration, CalibrationCrudContext context)
+        public async Task<CrudSaveResult> UpdateAsync(Calibration calibration, CalibrationCrudContext context)
         {
             if (calibration is null)
             {
@@ -60,6 +60,7 @@ public sealed class CalibrationCrudServiceAdapter : ICalibrationCrudService
             var metadata = CreateMetadata(context, signature);
             await _inner.UpdateAsync(calibration, context.UserId, metadata).ConfigureAwait(false);
             calibration.DigitalSignature = signature;
+            return new CrudSaveResult(calibration.Id, metadata);
         }
 
     public void Validate(Calibration calibration)

--- a/YasGMP.Wpf/Services/CapaCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/CapaCrudServiceAdapter.cs
@@ -34,7 +34,7 @@ public sealed class CapaCrudServiceAdapter : ICapaCrudService
         }
     }
 
-    public async Task<int> CreateAsync(CapaCase capa, CapaCrudContext context)
+    public async Task<CrudSaveResult> CreateAsync(CapaCase capa, CapaCrudContext context)
     {
         if (capa is null)
         {
@@ -44,10 +44,10 @@ public sealed class CapaCrudServiceAdapter : ICapaCrudService
         Validate(capa);
         var metadata = CreateMetadata(context, capa.DigitalSignature);
         await _service.CreateAsync(capa, context.UserId, metadata).ConfigureAwait(false);
-        return capa.Id;
+        return new CrudSaveResult(capa.Id, metadata);
     }
 
-    public async Task UpdateAsync(CapaCase capa, CapaCrudContext context)
+    public async Task<CrudSaveResult> UpdateAsync(CapaCase capa, CapaCrudContext context)
     {
         if (capa is null)
         {
@@ -57,6 +57,7 @@ public sealed class CapaCrudServiceAdapter : ICapaCrudService
         Validate(capa);
         var metadata = CreateMetadata(context, capa.DigitalSignature);
         await _service.UpdateAsync(capa, context.UserId, metadata).ConfigureAwait(false);
+        return new CrudSaveResult(capa.Id, metadata);
     }
 
     public void Validate(CapaCase capa)

--- a/YasGMP.Wpf/Services/CrudSaveResult.cs
+++ b/YasGMP.Wpf/Services/CrudSaveResult.cs
@@ -5,17 +5,16 @@ namespace YasGMP.Wpf.Services;
 /// <summary>
 /// Represents the payload returned from a CRUD adapter after the entity has been persisted.
 /// </summary>
-/// <typeparam name="TIdentifier">Type used to uniquely identify the saved entity.</typeparam>
-public sealed record CrudSaveResult<TIdentifier>
+public sealed record CrudSaveResult
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="CrudSaveResult{TIdentifier}"/> record.
+    /// Initializes a new instance of the <see cref="CrudSaveResult"/> record.
     /// </summary>
-    /// <param name="identifier">Unique identifier generated for the persisted entity.</param>
+    /// <param name="id">Unique identifier generated for the persisted entity.</param>
     /// <param name="signatureMetadata">Electronic signature metadata captured alongside the save.</param>
-    public CrudSaveResult(TIdentifier identifier, SignatureMetadataDto? signatureMetadata)
+    public CrudSaveResult(int id, SignatureMetadataDto? signatureMetadata)
     {
-        Identifier = identifier;
+        Id = id;
         SignatureMetadata = signatureMetadata;
     }
 
@@ -24,7 +23,7 @@ public sealed record CrudSaveResult<TIdentifier>
     /// refresh editor state, update navigation contexts, or trigger follow-up lookups that require the
     /// persisted entity's key.
     /// </summary>
-    public TIdentifier Identifier { get; }
+    public int Id { get; }
 
     /// <summary>
     /// Gets the electronic signature metadata captured during the save operation. Callers should

--- a/YasGMP.Wpf/Services/ICalibrationCrudService.cs
+++ b/YasGMP.Wpf/Services/ICalibrationCrudService.cs
@@ -16,9 +16,15 @@ public interface ICalibrationCrudService
 
     Task<Calibration?> TryGetByIdAsync(int id);
 
-    Task<int> CreateAsync(Calibration calibration, CalibrationCrudContext context);
+    /// <summary>
+    /// Persists a new calibration entry and returns the saved identifier with signature metadata.
+    /// </summary>
+    Task<CrudSaveResult> CreateAsync(Calibration calibration, CalibrationCrudContext context);
 
-    Task UpdateAsync(Calibration calibration, CalibrationCrudContext context);
+    /// <summary>
+    /// Updates an existing calibration entry and returns the captured signature metadata.
+    /// </summary>
+    Task<CrudSaveResult> UpdateAsync(Calibration calibration, CalibrationCrudContext context);
 
     void Validate(Calibration calibration);
 }

--- a/YasGMP.Wpf/Services/ICapaCrudService.cs
+++ b/YasGMP.Wpf/Services/ICapaCrudService.cs
@@ -16,9 +16,15 @@ public interface ICapaCrudService
 
     Task<CapaCase?> TryGetByIdAsync(int id);
 
-    Task<int> CreateAsync(CapaCase capa, CapaCrudContext context);
+    /// <summary>
+    /// Persists a new CAPA case and returns the saved identifier with signature metadata.
+    /// </summary>
+    Task<CrudSaveResult> CreateAsync(CapaCase capa, CapaCrudContext context);
 
-    Task UpdateAsync(CapaCase capa, CapaCrudContext context);
+    /// <summary>
+    /// Updates an existing CAPA case and returns the signature metadata captured during persistence.
+    /// </summary>
+    Task<CrudSaveResult> UpdateAsync(CapaCase capa, CapaCrudContext context);
 
     void Validate(CapaCase capa);
 

--- a/YasGMP.Wpf/Services/IChangeControlCrudService.cs
+++ b/YasGMP.Wpf/Services/IChangeControlCrudService.cs
@@ -12,9 +12,15 @@ public interface IChangeControlCrudService
 
     Task<ChangeControl?> TryGetByIdAsync(int id);
 
-    Task<int> CreateAsync(ChangeControl changeControl, ChangeControlCrudContext context);
+    /// <summary>
+    /// Persists a new change control record and returns the saved identifier with signature metadata.
+    /// </summary>
+    Task<CrudSaveResult> CreateAsync(ChangeControl changeControl, ChangeControlCrudContext context);
 
-    Task UpdateAsync(ChangeControl changeControl, ChangeControlCrudContext context);
+    /// <summary>
+    /// Updates an existing change control record and returns the signature metadata captured during persistence.
+    /// </summary>
+    Task<CrudSaveResult> UpdateAsync(ChangeControl changeControl, ChangeControlCrudContext context);
 
     void Validate(ChangeControl changeControl);
 

--- a/YasGMP.Wpf/Services/IComponentCrudService.cs
+++ b/YasGMP.Wpf/Services/IComponentCrudService.cs
@@ -17,9 +17,17 @@ public interface IComponentCrudService
 
     Task<Component?> TryGetByIdAsync(int id);
 
-    Task<int> CreateAsync(Component component, ComponentCrudContext context);
+    /// <summary>
+    /// Persists a new <paramref name="component"/> and returns the saved identifier together with
+    /// the captured signature metadata so callers can refresh editor state.
+    /// </summary>
+    Task<CrudSaveResult> CreateAsync(Component component, ComponentCrudContext context);
 
-    Task UpdateAsync(Component component, ComponentCrudContext context);
+    /// <summary>
+    /// Updates an existing <paramref name="component"/> and returns the signature metadata that was
+    /// persisted so the caller can surface the latest signing details.
+    /// </summary>
+    Task<CrudSaveResult> UpdateAsync(Component component, ComponentCrudContext context);
 
     void Validate(Component component);
 

--- a/YasGMP.Wpf/Services/IExternalServicerCrudService.cs
+++ b/YasGMP.Wpf/Services/IExternalServicerCrudService.cs
@@ -16,9 +16,15 @@ public interface IExternalServicerCrudService
 
     Task<ExternalServicer?> TryGetByIdAsync(int id);
 
-    Task<int> CreateAsync(ExternalServicer servicer, ExternalServicerCrudContext context);
+    /// <summary>
+    /// Persists a new external servicer and returns the saved identifier with signature metadata.
+    /// </summary>
+    Task<CrudSaveResult> CreateAsync(ExternalServicer servicer, ExternalServicerCrudContext context);
 
-    Task UpdateAsync(ExternalServicer servicer, ExternalServicerCrudContext context);
+    /// <summary>
+    /// Updates an existing external servicer and returns the signature metadata captured during persistence.
+    /// </summary>
+    Task<CrudSaveResult> UpdateAsync(ExternalServicer servicer, ExternalServicerCrudContext context);
 
     Task DeleteAsync(int id, ExternalServicerCrudContext context);
 

--- a/YasGMP.Wpf/Services/IIncidentCrudService.cs
+++ b/YasGMP.Wpf/Services/IIncidentCrudService.cs
@@ -13,9 +13,15 @@ public interface IIncidentCrudService
 {
     Task<Incident?> TryGetByIdAsync(int id);
 
-    Task<int> CreateAsync(Incident incident, IncidentCrudContext context);
+    /// <summary>
+    /// Persists a new incident and returns the saved identifier with signature metadata.
+    /// </summary>
+    Task<CrudSaveResult> CreateAsync(Incident incident, IncidentCrudContext context);
 
-    Task UpdateAsync(Incident incident, IncidentCrudContext context);
+    /// <summary>
+    /// Updates an existing incident and returns the signature metadata captured during persistence.
+    /// </summary>
+    Task<CrudSaveResult> UpdateAsync(Incident incident, IncidentCrudContext context);
 
     void Validate(Incident incident);
 

--- a/YasGMP.Wpf/Services/IMachineCrudService.cs
+++ b/YasGMP.Wpf/Services/IMachineCrudService.cs
@@ -16,9 +16,15 @@ namespace YasGMP.Wpf.Services
 
         Task<Machine?> TryGetByIdAsync(int id);
 
-        Task<int> CreateAsync(Machine machine, MachineCrudContext context);
+        /// <summary>
+        /// Persists a new machine and returns the saved identifier together with captured signature metadata.
+        /// </summary>
+        Task<CrudSaveResult> CreateAsync(Machine machine, MachineCrudContext context);
 
-        Task UpdateAsync(Machine machine, MachineCrudContext context);
+        /// <summary>
+        /// Updates an existing machine and returns the updated signature metadata so callers can refresh UI state.
+        /// </summary>
+        Task<CrudSaveResult> UpdateAsync(Machine machine, MachineCrudContext context);
 
         void Validate(Machine machine);
 

--- a/YasGMP.Wpf/Services/IPartCrudService.cs
+++ b/YasGMP.Wpf/Services/IPartCrudService.cs
@@ -16,9 +16,15 @@ namespace YasGMP.Wpf.Services
 
         Task<Part?> TryGetByIdAsync(int id);
 
-        Task<int> CreateAsync(Part part, PartCrudContext context);
+        /// <summary>
+        /// Persists a new part and returns the saved identifier alongside captured signature metadata.
+        /// </summary>
+        Task<CrudSaveResult> CreateAsync(Part part, PartCrudContext context);
 
-        Task UpdateAsync(Part part, PartCrudContext context);
+        /// <summary>
+        /// Updates an existing part and returns the signature metadata that was persisted.
+        /// </summary>
+        Task<CrudSaveResult> UpdateAsync(Part part, PartCrudContext context);
 
         void Validate(Part part);
 

--- a/YasGMP.Wpf/Services/IScheduledJobCrudService.cs
+++ b/YasGMP.Wpf/Services/IScheduledJobCrudService.cs
@@ -13,9 +13,15 @@ public interface IScheduledJobCrudService
 {
     Task<ScheduledJob?> TryGetByIdAsync(int id);
 
-    Task<int> CreateAsync(ScheduledJob job, ScheduledJobCrudContext context);
+    /// <summary>
+    /// Persists a new scheduled job and returns the saved identifier with signature metadata.
+    /// </summary>
+    Task<CrudSaveResult> CreateAsync(ScheduledJob job, ScheduledJobCrudContext context);
 
-    Task UpdateAsync(ScheduledJob job, ScheduledJobCrudContext context);
+    /// <summary>
+    /// Updates an existing scheduled job and returns the signature metadata captured during persistence.
+    /// </summary>
+    Task<CrudSaveResult> UpdateAsync(ScheduledJob job, ScheduledJobCrudContext context);
 
     Task ExecuteAsync(int jobId, ScheduledJobCrudContext context);
 

--- a/YasGMP.Wpf/Services/ISupplierCrudService.cs
+++ b/YasGMP.Wpf/Services/ISupplierCrudService.cs
@@ -17,9 +17,15 @@ public interface ISupplierCrudService
 
     Task<Supplier?> TryGetByIdAsync(int id);
 
-    Task<int> CreateAsync(Supplier supplier, SupplierCrudContext context);
+    /// <summary>
+    /// Persists a new supplier and returns the saved identifier with captured signature metadata.
+    /// </summary>
+    Task<CrudSaveResult> CreateAsync(Supplier supplier, SupplierCrudContext context);
 
-    Task UpdateAsync(Supplier supplier, SupplierCrudContext context);
+    /// <summary>
+    /// Updates an existing supplier and returns the signature metadata that was persisted.
+    /// </summary>
+    Task<CrudSaveResult> UpdateAsync(Supplier supplier, SupplierCrudContext context);
 
     void Validate(Supplier supplier);
 

--- a/YasGMP.Wpf/Services/IUserCrudService.cs
+++ b/YasGMP.Wpf/Services/IUserCrudService.cs
@@ -18,9 +18,15 @@ namespace YasGMP.Wpf.Services
 
         Task<IReadOnlyList<Role>> GetAllRolesAsync();
 
-        Task<int> CreateAsync(User user, string password, UserCrudContext context);
+        /// <summary>
+        /// Persists a new user and returns the saved identifier with signature metadata.
+        /// </summary>
+        Task<CrudSaveResult> CreateAsync(User user, string password, UserCrudContext context);
 
-        Task UpdateAsync(User user, string? password, UserCrudContext context);
+        /// <summary>
+        /// Updates an existing user and returns the signature metadata captured during persistence.
+        /// </summary>
+        Task<CrudSaveResult> UpdateAsync(User user, string? password, UserCrudContext context);
 
         Task UpdateRoleAssignmentsAsync(int userId, IReadOnlyCollection<int> roleIds, UserCrudContext context);
 

--- a/YasGMP.Wpf/Services/IValidationCrudService.cs
+++ b/YasGMP.Wpf/Services/IValidationCrudService.cs
@@ -16,9 +16,15 @@ public interface IValidationCrudService
 
     Task<Validation?> TryGetByIdAsync(int id);
 
-    Task<int> CreateAsync(Validation validation, ValidationCrudContext context);
+    /// <summary>
+    /// Persists a new validation record and returns the saved identifier with signature metadata.
+    /// </summary>
+    Task<CrudSaveResult> CreateAsync(Validation validation, ValidationCrudContext context);
 
-    Task UpdateAsync(Validation validation, ValidationCrudContext context);
+    /// <summary>
+    /// Updates an existing validation record and returns the signature metadata captured during the operation.
+    /// </summary>
+    Task<CrudSaveResult> UpdateAsync(Validation validation, ValidationCrudContext context);
 
     void Validate(Validation validation);
 }

--- a/YasGMP.Wpf/Services/IWarehouseCrudService.cs
+++ b/YasGMP.Wpf/Services/IWarehouseCrudService.cs
@@ -15,9 +15,15 @@ namespace YasGMP.Wpf.Services
 
         Task<Warehouse?> TryGetByIdAsync(int id);
 
-        Task<int> CreateAsync(Warehouse warehouse, WarehouseCrudContext context);
+        /// <summary>
+        /// Persists a new warehouse and returns the saved identifier together with signature metadata.
+        /// </summary>
+        Task<CrudSaveResult> CreateAsync(Warehouse warehouse, WarehouseCrudContext context);
 
-        Task UpdateAsync(Warehouse warehouse, WarehouseCrudContext context);
+        /// <summary>
+        /// Updates an existing warehouse and returns the signature metadata captured during persistence.
+        /// </summary>
+        Task<CrudSaveResult> UpdateAsync(Warehouse warehouse, WarehouseCrudContext context);
 
         void Validate(Warehouse warehouse);
 

--- a/YasGMP.Wpf/Services/IWorkOrderCrudService.cs
+++ b/YasGMP.Wpf/Services/IWorkOrderCrudService.cs
@@ -14,9 +14,15 @@ public interface IWorkOrderCrudService
 {
     Task<WorkOrder?> TryGetByIdAsync(int id);
 
-    Task<int> CreateAsync(WorkOrder workOrder, WorkOrderCrudContext context);
+    /// <summary>
+    /// Persists a new work order and returns the saved identifier with signature metadata.
+    /// </summary>
+    Task<CrudSaveResult> CreateAsync(WorkOrder workOrder, WorkOrderCrudContext context);
 
-    Task UpdateAsync(WorkOrder workOrder, WorkOrderCrudContext context);
+    /// <summary>
+    /// Updates an existing work order and returns the signature metadata that was persisted.
+    /// </summary>
+    Task<CrudSaveResult> UpdateAsync(WorkOrder workOrder, WorkOrderCrudContext context);
 
     void Validate(WorkOrder workOrder);
 }

--- a/YasGMP.Wpf/Services/MachineCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/MachineCrudServiceAdapter.cs
@@ -35,7 +35,7 @@ namespace YasGMP.Wpf.Services
             }
         }
 
-        public async Task<int> CreateAsync(Machine machine, MachineCrudContext context)
+        public async Task<CrudSaveResult> CreateAsync(Machine machine, MachineCrudContext context)
         {
             if (machine is null) throw new ArgumentNullException(nameof(machine));
 
@@ -47,10 +47,10 @@ namespace YasGMP.Wpf.Services
 
             // Preserve the captured signature metadata for the caller until core services accept it directly.
             machine.DigitalSignature = signature;
-            return machine.Id;
+            return new CrudSaveResult(machine.Id, metadata);
         }
 
-        public async Task UpdateAsync(Machine machine, MachineCrudContext context)
+        public async Task<CrudSaveResult> UpdateAsync(Machine machine, MachineCrudContext context)
         {
             if (machine is null) throw new ArgumentNullException(nameof(machine));
 
@@ -61,6 +61,7 @@ namespace YasGMP.Wpf.Services
                 .ConfigureAwait(false);
 
             machine.DigitalSignature = signature;
+            return new CrudSaveResult(machine.Id, metadata);
         }
 
         public void Validate(Machine machine)

--- a/YasGMP.Wpf/Services/PartCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/PartCrudServiceAdapter.cs
@@ -45,7 +45,7 @@ namespace YasGMP.Wpf.Services
             }
         }
 
-        public async Task<int> CreateAsync(Part part, PartCrudContext context)
+        public async Task<CrudSaveResult> CreateAsync(Part part, PartCrudContext context)
         {
             var signature = ApplyContext(part, context);
             var metadata = CreateMetadata(context, signature);
@@ -54,10 +54,10 @@ namespace YasGMP.Wpf.Services
 
             part.DigitalSignature = signature;
             await StampAsync(part, context, signature).ConfigureAwait(false);
-            return part.Id;
+            return new CrudSaveResult(part.Id, metadata);
         }
 
-        public async Task UpdateAsync(Part part, PartCrudContext context)
+        public async Task<CrudSaveResult> UpdateAsync(Part part, PartCrudContext context)
         {
             var signature = ApplyContext(part, context);
             var metadata = CreateMetadata(context, signature);
@@ -66,6 +66,7 @@ namespace YasGMP.Wpf.Services
 
             part.DigitalSignature = signature;
             await StampAsync(part, context, signature).ConfigureAwait(false);
+            return new CrudSaveResult(part.Id, metadata);
         }
 
         public void Validate(Part part)

--- a/YasGMP.Wpf/Services/SupplierCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/SupplierCrudServiceAdapter.cs
@@ -32,7 +32,7 @@ public sealed class SupplierCrudServiceAdapter : ISupplierCrudService
 
     public Task<Supplier?> TryGetByIdAsync(int id) => _supplierService.GetByIdAsync(id);
 
-    public async Task<int> CreateAsync(Supplier supplier, SupplierCrudContext context)
+    public async Task<CrudSaveResult> CreateAsync(Supplier supplier, SupplierCrudContext context)
     {
         if (supplier is null)
         {
@@ -46,10 +46,10 @@ public sealed class SupplierCrudServiceAdapter : ISupplierCrudService
 
         supplier.DigitalSignature = signature;
         await StampAsync(supplier, context, "CREATE", signature).ConfigureAwait(false);
-        return supplier.Id;
+        return new CrudSaveResult(supplier.Id, metadata);
     }
 
-    public async Task UpdateAsync(Supplier supplier, SupplierCrudContext context)
+    public async Task<CrudSaveResult> UpdateAsync(Supplier supplier, SupplierCrudContext context)
     {
         if (supplier is null)
         {
@@ -63,6 +63,7 @@ public sealed class SupplierCrudServiceAdapter : ISupplierCrudService
 
         supplier.DigitalSignature = signature;
         await StampAsync(supplier, context, "UPDATE", signature).ConfigureAwait(false);
+        return new CrudSaveResult(supplier.Id, metadata);
     }
 
     public void Validate(Supplier supplier)

--- a/YasGMP.Wpf/Services/WorkOrderCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/WorkOrderCrudServiceAdapter.cs
@@ -30,7 +30,7 @@ public sealed class WorkOrderCrudServiceAdapter : IWorkOrderCrudService
         }
     }
 
-        public async Task<int> CreateAsync(WorkOrder workOrder, WorkOrderCrudContext context)
+        public async Task<CrudSaveResult> CreateAsync(WorkOrder workOrder, WorkOrderCrudContext context)
         {
             if (workOrder is null)
             {
@@ -45,10 +45,10 @@ public sealed class WorkOrderCrudServiceAdapter : IWorkOrderCrudService
             await _service.CreateAsync(workOrder, context.UserId, metadata).ConfigureAwait(false);
 
             workOrder.DigitalSignature = signature;
-            return workOrder.Id;
+            return new CrudSaveResult(workOrder.Id, metadata);
         }
 
-        public async Task UpdateAsync(WorkOrder workOrder, WorkOrderCrudContext context)
+        public async Task<CrudSaveResult> UpdateAsync(WorkOrder workOrder, WorkOrderCrudContext context)
         {
             if (workOrder is null)
             {
@@ -63,6 +63,7 @@ public sealed class WorkOrderCrudServiceAdapter : IWorkOrderCrudService
             await _service.UpdateAsync(workOrder, context.UserId, metadata).ConfigureAwait(false);
 
             workOrder.DigitalSignature = signature;
+            return new CrudSaveResult(workOrder.Id, metadata);
         }
 
     public void Validate(WorkOrder workOrder)

--- a/YasGMP.Wpf/ViewModels/Modules/CapaModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/CapaModuleViewModel.cs
@@ -277,14 +277,15 @@ public sealed partial class CapaModuleViewModel : DataDrivenModuleDocumentViewMo
             signatureResult);
 
         CapaCase adapterResult;
+        CrudSaveResult saveResult;
         try
         {
             if (Mode == FormMode.Add)
             {
-                var id = await _capaService.CreateAsync(capa, context).ConfigureAwait(false);
-                if (capa.Id == 0 && id > 0)
+                saveResult = await _capaService.CreateAsync(capa, context).ConfigureAwait(false);
+                if (capa.Id == 0 && saveResult.Id > 0)
                 {
-                    capa.Id = id;
+                    capa.Id = saveResult.Id;
                 }
 
                 adapterResult = capa;
@@ -292,7 +293,7 @@ public sealed partial class CapaModuleViewModel : DataDrivenModuleDocumentViewMo
             else if (Mode == FormMode.Update)
             {
                 capa.Id = _loadedCapa!.Id;
-                await _capaService.UpdateAsync(capa, context).ConfigureAwait(false);
+                saveResult = await _capaService.UpdateAsync(capa, context).ConfigureAwait(false);
                 adapterResult = capa;
             }
             else
@@ -312,15 +313,15 @@ public sealed partial class CapaModuleViewModel : DataDrivenModuleDocumentViewMo
             signatureResult,
             tableName: "capa_cases",
             recordId: adapterResult.Id,
-            signatureId: null,
-            signatureHash: adapterResult.DigitalSignature,
-            method: context.SignatureMethod,
-            status: context.SignatureStatus,
-            note: context.SignatureNote,
+            metadata: saveResult.SignatureMetadata,
+            fallbackSignatureHash: adapterResult.DigitalSignature,
+            fallbackMethod: context.SignatureMethod,
+            fallbackStatus: context.SignatureStatus,
+            fallbackNote: context.SignatureNote,
             signedAt: signatureResult.Signature.SignedAt,
-            deviceInfo: context.DeviceInfo,
-            ipAddress: context.Ip,
-            sessionId: context.SessionId);
+            fallbackDeviceInfo: context.DeviceInfo,
+            fallbackIpAddress: context.Ip,
+            fallbackSessionId: context.SessionId);
 
         try
         {

--- a/YasGMP.Wpf/ViewModels/Modules/ChangeControlModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/ChangeControlModuleViewModel.cs
@@ -255,19 +255,20 @@ public sealed partial class ChangeControlModuleViewModel : DataDrivenModuleDocum
             signatureResult);
 
         ChangeControl adapterResult;
+        CrudSaveResult saveResult;
         try
         {
             if (Mode == FormMode.Add)
             {
-                var id = await _changeControlService.CreateAsync(entity, context).ConfigureAwait(false);
-                entity.Id = id;
+                saveResult = await _changeControlService.CreateAsync(entity, context).ConfigureAwait(false);
+                entity.Id = saveResult.Id;
                 Records.Add(ToRecord(entity));
                 adapterResult = entity;
             }
             else if (Mode == FormMode.Update && _loadedEntity is not null)
             {
                 entity.Id = _loadedEntity.Id;
-                await _changeControlService.UpdateAsync(entity, context).ConfigureAwait(false);
+                saveResult = await _changeControlService.UpdateAsync(entity, context).ConfigureAwait(false);
                 adapterResult = entity;
             }
             else
@@ -288,15 +289,15 @@ public sealed partial class ChangeControlModuleViewModel : DataDrivenModuleDocum
             signatureResult,
             tableName: "change_controls",
             recordId: adapterResult.Id,
-            signatureId: context.SignatureId,
-            signatureHash: context.SignatureHash ?? signatureResult.Signature.SignatureHash,
-            method: context.SignatureMethod,
-            status: context.SignatureStatus,
-            note: context.SignatureNote,
+            metadata: saveResult.SignatureMetadata,
+            fallbackSignatureHash: context.SignatureHash ?? signatureResult.Signature.SignatureHash,
+            fallbackMethod: context.SignatureMethod,
+            fallbackStatus: context.SignatureStatus,
+            fallbackNote: context.SignatureNote,
             signedAt: signatureResult.Signature.SignedAt,
-            deviceInfo: context.DeviceInfo,
-            ipAddress: context.IpAddress,
-            sessionId: context.SessionId);
+            fallbackDeviceInfo: context.DeviceInfo,
+            fallbackIpAddress: context.IpAddress,
+            fallbackSessionId: context.SessionId);
 
         try
         {

--- a/YasGMP.Wpf/ViewModels/Modules/ComponentsModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/ComponentsModuleViewModel.cs
@@ -329,14 +329,15 @@ public sealed partial class ComponentsModuleViewModel : DataDrivenModuleDocument
             signatureResult);
 
         Component adapterResult;
+        CrudSaveResult saveResult;
         try
         {
             if (Mode == FormMode.Add)
             {
-                var id = await _componentService.CreateAsync(component, context).ConfigureAwait(false);
-                if (component.Id == 0 && id > 0)
+                saveResult = await _componentService.CreateAsync(component, context).ConfigureAwait(false);
+                if (component.Id == 0 && saveResult.Id > 0)
                 {
-                    component.Id = id;
+                    component.Id = saveResult.Id;
                 }
 
                 adapterResult = component;
@@ -344,7 +345,7 @@ public sealed partial class ComponentsModuleViewModel : DataDrivenModuleDocument
             else if (Mode == FormMode.Update)
             {
                 component.Id = _loadedComponent!.Id;
-                await _componentService.UpdateAsync(component, context).ConfigureAwait(false);
+                saveResult = await _componentService.UpdateAsync(component, context).ConfigureAwait(false);
                 adapterResult = component;
             }
             else
@@ -364,15 +365,15 @@ public sealed partial class ComponentsModuleViewModel : DataDrivenModuleDocument
             signatureResult,
             tableName: "components",
             recordId: adapterResult.Id,
-            signatureId: null,
-            signatureHash: adapterResult.DigitalSignature,
-            method: context.SignatureMethod,
-            status: context.SignatureStatus,
-            note: context.SignatureNote,
+            metadata: saveResult.SignatureMetadata,
+            fallbackSignatureHash: adapterResult.DigitalSignature,
+            fallbackMethod: context.SignatureMethod,
+            fallbackStatus: context.SignatureStatus,
+            fallbackNote: context.SignatureNote,
             signedAt: signatureResult.Signature.SignedAt,
-            deviceInfo: context.DeviceInfo,
-            ipAddress: context.Ip,
-            sessionId: context.SessionId);
+            fallbackDeviceInfo: context.DeviceInfo,
+            fallbackIpAddress: context.Ip,
+            fallbackSessionId: context.SessionId);
 
         try
         {

--- a/YasGMP.Wpf/ViewModels/Modules/ExternalServicersModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/ExternalServicersModuleViewModel.cs
@@ -294,18 +294,19 @@ public sealed partial class ExternalServicersModuleViewModel : ModuleDocumentVie
             signatureResult);
 
         ExternalServicer adapterResult;
+        CrudSaveResult saveResult;
         try
         {
             if (Mode == FormMode.Add)
             {
-                var id = await _servicerService.CreateAsync(servicer, context).ConfigureAwait(false);
-                servicer.Id = id;
+                saveResult = await _servicerService.CreateAsync(servicer, context).ConfigureAwait(false);
+                servicer.Id = saveResult.Id;
                 adapterResult = servicer;
             }
             else if (Mode == FormMode.Update)
             {
                 servicer.Id = _loadedServicer.Id;
-                await _servicerService.UpdateAsync(servicer, context).ConfigureAwait(false);
+                saveResult = await _servicerService.UpdateAsync(servicer, context).ConfigureAwait(false);
                 adapterResult = servicer;
             }
             else
@@ -327,15 +328,15 @@ public sealed partial class ExternalServicersModuleViewModel : ModuleDocumentVie
             signatureResult,
             tableName: "external_contractors",
             recordId: adapterResult.Id,
-            signatureId: null,
-            signatureHash: adapterResult.DigitalSignature,
-            method: context.SignatureMethod,
-            status: context.SignatureStatus,
-            note: context.SignatureNote,
+            metadata: saveResult.SignatureMetadata,
+            fallbackSignatureHash: adapterResult.DigitalSignature,
+            fallbackMethod: context.SignatureMethod,
+            fallbackStatus: context.SignatureStatus,
+            fallbackNote: context.SignatureNote,
             signedAt: signatureResult.Signature.SignedAt,
-            deviceInfo: context.DeviceInfo,
-            ipAddress: context.Ip,
-            sessionId: context.SessionId);
+            fallbackDeviceInfo: context.DeviceInfo,
+            fallbackIpAddress: context.Ip,
+            fallbackSessionId: context.SessionId);
 
         try
         {

--- a/YasGMP.Wpf/ViewModels/Modules/IncidentsModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/IncidentsModuleViewModel.cs
@@ -391,14 +391,15 @@ public sealed partial class IncidentsModuleViewModel : DataDrivenModuleDocumentV
             signatureResult);
 
         Incident adapterResult;
+        CrudSaveResult saveResult;
         try
         {
             if (Mode == FormMode.Add)
             {
-                var id = await _incidentService.CreateAsync(incident, context).ConfigureAwait(false);
-                if (incident.Id == 0 && id > 0)
+                saveResult = await _incidentService.CreateAsync(incident, context).ConfigureAwait(false);
+                if (incident.Id == 0 && saveResult.Id > 0)
                 {
-                    incident.Id = id;
+                    incident.Id = saveResult.Id;
                 }
 
                 adapterResult = incident;
@@ -406,7 +407,7 @@ public sealed partial class IncidentsModuleViewModel : DataDrivenModuleDocumentV
             else if (Mode == FormMode.Update)
             {
                 incident.Id = _loadedIncident!.Id;
-                await _incidentService.UpdateAsync(incident, context).ConfigureAwait(false);
+                saveResult = await _incidentService.UpdateAsync(incident, context).ConfigureAwait(false);
                 adapterResult = incident;
             }
             else
@@ -426,15 +427,15 @@ public sealed partial class IncidentsModuleViewModel : DataDrivenModuleDocumentV
             signatureResult,
             tableName: "incidents",
             recordId: adapterResult.Id,
-            signatureId: null,
-            signatureHash: adapterResult.DigitalSignature,
-            method: context.SignatureMethod,
-            status: context.SignatureStatus,
-            note: context.SignatureNote,
+            metadata: saveResult.SignatureMetadata,
+            fallbackSignatureHash: adapterResult.DigitalSignature,
+            fallbackMethod: context.SignatureMethod,
+            fallbackStatus: context.SignatureStatus,
+            fallbackNote: context.SignatureNote,
             signedAt: signatureResult.Signature.SignedAt,
-            deviceInfo: context.DeviceInfo,
-            ipAddress: context.Ip,
-            sessionId: context.SessionId);
+            fallbackDeviceInfo: context.DeviceInfo,
+            fallbackIpAddress: context.Ip,
+            fallbackSessionId: context.SessionId);
 
         try
         {

--- a/YasGMP.Wpf/ViewModels/Modules/SchedulingModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/SchedulingModuleViewModel.cs
@@ -259,17 +259,18 @@ public sealed partial class SchedulingModuleViewModel : DataDrivenModuleDocument
             signatureResult);
 
         ScheduledJob adapterResult;
+        CrudSaveResult saveResult;
         try
         {
             if (Mode == FormMode.Add)
             {
-                var id = await _scheduledJobService.CreateAsync(entity, context).ConfigureAwait(false);
-                entity.Id = id;
+                saveResult = await _scheduledJobService.CreateAsync(entity, context).ConfigureAwait(false);
+                entity.Id = saveResult.Id;
                 adapterResult = entity;
             }
             else if (Mode == FormMode.Update)
             {
-                await _scheduledJobService.UpdateAsync(entity, context).ConfigureAwait(false);
+                saveResult = await _scheduledJobService.UpdateAsync(entity, context).ConfigureAwait(false);
                 adapterResult = entity;
             }
             else
@@ -290,15 +291,15 @@ public sealed partial class SchedulingModuleViewModel : DataDrivenModuleDocument
             signatureResult,
             tableName: "scheduled_jobs",
             recordId: adapterResult.Id,
-            signatureId: null,
-            signatureHash: adapterResult.DigitalSignature,
-            method: context.SignatureMethod,
-            status: context.SignatureStatus,
-            note: context.SignatureNote,
+            metadata: saveResult.SignatureMetadata,
+            fallbackSignatureHash: adapterResult.DigitalSignature,
+            fallbackMethod: context.SignatureMethod,
+            fallbackStatus: context.SignatureStatus,
+            fallbackNote: context.SignatureNote,
             signedAt: signatureResult.Signature.SignedAt,
-            deviceInfo: context.DeviceInfo,
-            ipAddress: context.Ip,
-            sessionId: context.SessionId);
+            fallbackDeviceInfo: context.DeviceInfo,
+            fallbackIpAddress: context.Ip,
+            fallbackSessionId: context.SessionId);
 
         try
         {

--- a/YasGMP.Wpf/ViewModels/Modules/SecurityModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/SecurityModuleViewModel.cs
@@ -335,6 +335,7 @@ public sealed partial class SecurityModuleViewModel : DataDrivenModuleDocumentVi
         user.LastModifiedById = _authContext.CurrentUser?.Id;
 
         User adapterResult = user;
+        CrudSaveResult saveResult;
         try
         {
             if (user.Id == 0)
@@ -344,10 +345,10 @@ public sealed partial class SecurityModuleViewModel : DataDrivenModuleDocumentVi
                     throw new InvalidOperationException("Password is required for new users.");
                 }
 
-                var newId = await _userService.CreateAsync(user, password, context).ConfigureAwait(false);
-                if (user.Id == 0 && newId > 0)
+                saveResult = await _userService.CreateAsync(user, password, context).ConfigureAwait(false);
+                if (user.Id == 0 && saveResult.Id > 0)
                 {
-                    user.Id = newId;
+                    user.Id = saveResult.Id;
                 }
             }
             else
@@ -357,7 +358,7 @@ public sealed partial class SecurityModuleViewModel : DataDrivenModuleDocumentVi
                     user.PasswordHash = _loadedUser.PasswordHash;
                 }
 
-                await _userService.UpdateAsync(user, password, context).ConfigureAwait(false);
+                saveResult = await _userService.UpdateAsync(user, password, context).ConfigureAwait(false);
             }
 
             await _userService.UpdateRoleAssignmentsAsync(user.Id, user.RoleIds, context).ConfigureAwait(false);
@@ -382,15 +383,15 @@ public sealed partial class SecurityModuleViewModel : DataDrivenModuleDocumentVi
             signatureResult,
             tableName: "users",
             recordId: adapterResult.Id,
-            signatureId: context.SignatureId,
-            signatureHash: adapterResult.DigitalSignature,
-            method: context.SignatureMethod,
-            status: context.SignatureStatus,
-            note: context.SignatureNote,
+            metadata: saveResult.SignatureMetadata,
+            fallbackSignatureHash: adapterResult.DigitalSignature,
+            fallbackMethod: context.SignatureMethod,
+            fallbackStatus: context.SignatureStatus,
+            fallbackNote: context.SignatureNote,
             signedAt: signatureResult.Signature.SignedAt,
-            deviceInfo: context.DeviceInfo,
-            ipAddress: context.Ip,
-            sessionId: context.SessionId);
+            fallbackDeviceInfo: context.DeviceInfo,
+            fallbackIpAddress: context.Ip,
+            fallbackSessionId: context.SessionId);
 
         try
         {

--- a/YasGMP.Wpf/ViewModels/Modules/SignaturePersistenceHelper.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/SignaturePersistenceHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using YasGMP.AppCore.Models.Signatures;
 using YasGMP.Wpf.Services;
 using YasGMP.Wpf.ViewModels.Dialogs;
 
@@ -12,15 +13,15 @@ internal static class SignaturePersistenceHelper
         ElectronicSignatureDialogResult signatureResult,
         string tableName,
         int recordId,
-        int? signatureId,
-        string? signatureHash,
-        string? method,
-        string? status,
-        string? note,
+        SignatureMetadataDto? metadata,
+        string? fallbackSignatureHash,
+        string? fallbackMethod,
+        string? fallbackStatus,
+        string? fallbackNote,
         DateTime? signedAt,
-        string? deviceInfo,
-        string? ipAddress,
-        string? sessionId)
+        string? fallbackDeviceInfo,
+        string? fallbackIpAddress,
+        string? fallbackSessionId)
     {
         if (signatureResult is null)
         {
@@ -36,26 +37,38 @@ internal static class SignaturePersistenceHelper
         signature.TableName = tableName ?? signature.TableName;
         signature.RecordId = recordId;
 
-        if (signatureId.HasValue && signatureId.Value > 0)
+        if (metadata?.Id is { } metadataId && metadataId > 0)
         {
-            signature.Id = signatureId.Value;
+            signature.Id = metadataId;
         }
 
+        var signatureHash = !string.IsNullOrWhiteSpace(metadata?.Hash)
+            ? metadata!.Hash
+            : fallbackSignatureHash;
         if (!string.IsNullOrWhiteSpace(signatureHash))
         {
             signature.SignatureHash = signatureHash;
         }
 
+        var method = !string.IsNullOrWhiteSpace(metadata?.Method)
+            ? metadata!.Method
+            : fallbackMethod;
         if (!string.IsNullOrWhiteSpace(method))
         {
             signature.Method = method;
         }
 
+        var status = !string.IsNullOrWhiteSpace(metadata?.Status)
+            ? metadata!.Status
+            : fallbackStatus;
         if (!string.IsNullOrWhiteSpace(status))
         {
             signature.Status = status;
         }
 
+        var note = !string.IsNullOrWhiteSpace(metadata?.Note)
+            ? metadata!.Note
+            : fallbackNote;
         if (!string.IsNullOrWhiteSpace(note))
         {
             signature.Note = note;
@@ -66,16 +79,25 @@ internal static class SignaturePersistenceHelper
             signature.SignedAt = signedAt;
         }
 
+        var deviceInfo = !string.IsNullOrWhiteSpace(metadata?.Device)
+            ? metadata!.Device
+            : fallbackDeviceInfo;
         if (!string.IsNullOrWhiteSpace(deviceInfo))
         {
             signature.DeviceInfo = deviceInfo;
         }
 
+        var ipAddress = !string.IsNullOrWhiteSpace(metadata?.IpAddress)
+            ? metadata!.IpAddress
+            : fallbackIpAddress;
         if (!string.IsNullOrWhiteSpace(ipAddress))
         {
             signature.IpAddress = ipAddress;
         }
 
+        var sessionId = !string.IsNullOrWhiteSpace(metadata?.Session)
+            ? metadata!.Session
+            : fallbackSessionId;
         if (!string.IsNullOrWhiteSpace(sessionId))
         {
             signature.SessionId = sessionId;

--- a/YasGMP.Wpf/ViewModels/Modules/SuppliersModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/SuppliersModuleViewModel.cs
@@ -178,6 +178,11 @@ public sealed partial class SuppliersModuleViewModel : DataDrivenModuleDocumentV
             return;
         }
 
+        if (saveResult.SignatureMetadata?.Id is { } signatureId)
+        {
+            adapterResult.DigitalSignatureId = signatureId;
+        }
+
         _loadedSupplier = supplier;
         LoadEditor(supplier);
         UpdateAttachmentCommandState();
@@ -278,18 +283,19 @@ public sealed partial class SuppliersModuleViewModel : DataDrivenModuleDocumentV
             signatureResult);
 
         Supplier adapterResult;
+        CrudSaveResult saveResult;
         try
         {
             if (Mode == FormMode.Add)
             {
-                var id = await _supplierService.CreateAsync(supplier, context).ConfigureAwait(false);
-                supplier.Id = id;
+                saveResult = await _supplierService.CreateAsync(supplier, context).ConfigureAwait(false);
+                supplier.Id = saveResult.Id;
                 adapterResult = supplier;
             }
             else if (Mode == FormMode.Update)
             {
                 supplier.Id = _loadedSupplier!.Id;
-                await _supplierService.UpdateAsync(supplier, context).ConfigureAwait(false);
+                saveResult = await _supplierService.UpdateAsync(supplier, context).ConfigureAwait(false);
                 adapterResult = supplier;
             }
             else
@@ -312,15 +318,15 @@ public sealed partial class SuppliersModuleViewModel : DataDrivenModuleDocumentV
             signatureResult,
             tableName: "suppliers",
             recordId: adapterResult.Id,
-            signatureId: adapterResult.DigitalSignatureId,
-            signatureHash: adapterResult.DigitalSignature,
-            method: context.SignatureMethod,
-            status: context.SignatureStatus,
-            note: context.SignatureNote,
+            metadata: saveResult.SignatureMetadata,
+            fallbackSignatureHash: adapterResult.DigitalSignature,
+            fallbackMethod: context.SignatureMethod,
+            fallbackStatus: context.SignatureStatus,
+            fallbackNote: context.SignatureNote,
             signedAt: signatureResult.Signature.SignedAt,
-            deviceInfo: context.DeviceInfo,
-            ipAddress: context.Ip,
-            sessionId: context.SessionId);
+            fallbackDeviceInfo: context.DeviceInfo,
+            fallbackIpAddress: context.Ip,
+            fallbackSessionId: context.SessionId);
 
         try
         {

--- a/YasGMP.Wpf/ViewModels/Modules/ValidationsModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/ValidationsModuleViewModel.cs
@@ -334,6 +334,7 @@ public sealed partial class ValidationsModuleViewModel : DataDrivenModuleDocumen
             signatureResult);
 
         Validation adapterResult;
+        CrudSaveResult saveResult;
         try
         {
             if (Mode == FormMode.Add)
@@ -343,15 +344,15 @@ public sealed partial class ValidationsModuleViewModel : DataDrivenModuleDocumen
                     entity.Code = $"VAL-{DateTime.UtcNow:yyyyMMddHHmmss}";
                 }
 
-                var id = await _validationService.CreateAsync(entity, context).ConfigureAwait(false);
-                entity.Id = id;
+                saveResult = await _validationService.CreateAsync(entity, context).ConfigureAwait(false);
+                entity.Id = saveResult.Id;
                 Records.Add(ToRecord(entity));
                 adapterResult = entity;
             }
             else if (Mode == FormMode.Update)
             {
                 entity.Id = _loadedValidation!.Id;
-                await _validationService.UpdateAsync(entity, context).ConfigureAwait(false);
+                saveResult = await _validationService.UpdateAsync(entity, context).ConfigureAwait(false);
                 ReplaceRecord(entity);
                 adapterResult = entity;
             }
@@ -373,15 +374,15 @@ public sealed partial class ValidationsModuleViewModel : DataDrivenModuleDocumen
             signatureResult,
             tableName: "validations",
             recordId: adapterResult.Id,
-            signatureId: null,
-            signatureHash: adapterResult.DigitalSignature,
-            method: context.SignatureMethod,
-            status: context.SignatureStatus,
-            note: context.SignatureNote,
+            metadata: saveResult.SignatureMetadata,
+            fallbackSignatureHash: adapterResult.DigitalSignature,
+            fallbackMethod: context.SignatureMethod,
+            fallbackStatus: context.SignatureStatus,
+            fallbackNote: context.SignatureNote,
             signedAt: signatureResult.Signature.SignedAt,
-            deviceInfo: context.DeviceInfo,
-            ipAddress: context.Ip,
-            sessionId: context.SessionId);
+            fallbackDeviceInfo: context.DeviceInfo,
+            fallbackIpAddress: context.Ip,
+            fallbackSessionId: context.SessionId);
 
         try
         {

--- a/YasGMP.Wpf/ViewModels/Modules/WarehouseModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/WarehouseModuleViewModel.cs
@@ -282,17 +282,18 @@ public sealed partial class WarehouseModuleViewModel : DataDrivenModuleDocumentV
             signatureResult);
 
         Warehouse adapterResult;
+        CrudSaveResult saveResult;
         try
         {
             if (Mode == FormMode.Add)
             {
-                await _warehouseService.CreateAsync(warehouse, context).ConfigureAwait(false);
+                saveResult = await _warehouseService.CreateAsync(warehouse, context).ConfigureAwait(false);
                 adapterResult = warehouse;
             }
             else if (Mode == FormMode.Update)
             {
                 warehouse.Id = _loadedWarehouse!.Id;
-                await _warehouseService.UpdateAsync(warehouse, context).ConfigureAwait(false);
+                saveResult = await _warehouseService.UpdateAsync(warehouse, context).ConfigureAwait(false);
                 adapterResult = warehouse;
             }
             else
@@ -312,15 +313,15 @@ public sealed partial class WarehouseModuleViewModel : DataDrivenModuleDocumentV
             signatureResult,
             tableName: "warehouses",
             recordId: adapterResult.Id,
-            signatureId: null,
-            signatureHash: adapterResult.DigitalSignature,
-            method: context.SignatureMethod,
-            status: context.SignatureStatus,
-            note: context.SignatureNote,
+            metadata: saveResult.SignatureMetadata,
+            fallbackSignatureHash: adapterResult.DigitalSignature,
+            fallbackMethod: context.SignatureMethod,
+            fallbackStatus: context.SignatureStatus,
+            fallbackNote: context.SignatureNote,
             signedAt: signatureResult.Signature.SignedAt,
-            deviceInfo: context.DeviceInfo,
-            ipAddress: context.Ip,
-            sessionId: context.SessionId);
+            fallbackDeviceInfo: context.DeviceInfo,
+            fallbackIpAddress: context.Ip,
+            fallbackSessionId: context.SessionId);
 
         try
         {

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -51,6 +51,7 @@
 - 2025-11-19: WPF test CRUD fakes now capture create/update snapshots with contexts to simplify module assertions; dotnet restore/build retries still fail because the CLI is absent in the container.
 - 2025-11-20: WPF module regression tests now pin signature dialog ids, assert CRUD contexts surface signature hash/method/status/note metadata, and confirm persisted signature ids are returned from the enhanced dialog service while dotnet CLI access remains unavailable.
 - 2025-11-28: Added a shared `CrudSaveResult` payload so adapters can return the persisted identifier together with captured signature metadata, keeping downstream editors and audit logging aligned once save operations complete.
+- 2025-11-29: WPF CRUD interfaces, adapters, and module view-models now consume the new `CrudSaveResult` record end-to-end, storing returned identifiers, refreshing editor state, and surfacing signature metadata; WPF test doubles and regression tests assert the result payload.
 - `scripts/bootstrap-dotnet9.ps1` added to guide host setup *(installs/verifies .NET 9, Windows SDK, runs restore/build, seeds smoke test fixture).* 
 - `YasGMP.Wpf` already targets .NET 9 and references pinned packages; validate once builds are possible.
 - `tests/fixtures/hello.txt` seeded for upcoming smoke harness scenarios.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -81,7 +81,7 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "feat: add CrudSaveResult payload for save results",
+  "lastCommitSummary": "feat: propagate CrudSaveResult through WPF editors",
   "notes": [
     "Need to restore/install dotnet 9 SDK to proceed with Batch 0 validation steps.",
     "tests/fixtures/hello.txt seeded for smoke harness bootstrap",
@@ -154,6 +154,7 @@
     "2025-11-25: DataDrivenModuleDocumentViewModel gains an optional AuditService injection so every WPF module can share audit helpers, and Work Orders now records CREATE/UPDATE audit events with signature/user/IP/device/session details post-save; unit tests inject the service while dotnet CLI access remains unavailable.",
     "2025-11-26: RecordingAuditService test double added to the WPF harness so Work Orders save and attachment tests assert audit payloads with signer context while dotnet restore/build stay blocked.",
     "2025-11-27: Module save flows now rehydrate adapter-supplied signature metadata and skip redundant dialog persistence when ids are present so the stored record matches the UX status messaging.",
-    "2025-11-28: Introduced a shared CrudSaveResult record so adapters can return the persisted identifier together with signature metadata, keeping downstream editors and audit logging aligned once saves complete."
+    "2025-11-28: Introduced a shared CrudSaveResult record so adapters can return the persisted identifier together with signature metadata, keeping downstream editors and audit logging aligned once saves complete.",
+    "2025-11-29: CRUD service interfaces, adapters, module view-models, and WPF test doubles now return/consume CrudSaveResult so save flows refresh ids and expose signature metadata with regression coverage validating the new payload."
   ]
 }


### PR DESCRIPTION
## Summary
- return `CrudSaveResult` from every WPF CRUD interface and adapter so create/update calls expose the saved identifier and signature metadata
- update module view-model save flows to consume the result payload, refresh editor identifiers, and route metadata through `SignaturePersistenceHelper`
- refactor WPF test doubles and regression tests to validate the new `CrudSaveResult` contract and document the batch in `codex_plan.md`/`codex_progress.json`

## Testing
- ❌ `dotnet restore` *(fails: command not found in container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence) *(blocked: dotnet CLI unavailable in container)*
- [ ] MAUI builds/runs unaffected *(blocked: dotnet CLI unavailable in container)*
- [ ] Shared AppCore extraction complete where required; adapters compiled *(awaiting build verification once SDK restored)*
- [ ] ModulesPane lists every module and opens feature-parity editors *(tracked under broader WPF shell delivery)*
- [ ] B1 FormModes & command enablement wired across editors *(ongoing regression coverage as modules evolve)*
- [ ] CFL pickers + Golden Arrow navigation working *(tracked with module validation once builds resume)*
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end *(pending integrated smoke verification)*
- [ ] Warehouse ledger with running balance and alerts *(pending full-system smoke run)*
- [ ] Audit surfacing + e-signature prompts on critical saves *(metadata propagation in place; awaiting build/test to validate end-to-end)*
- [ ] Attachments DB-backed with upload/preview/download *(awaiting integrated test pass post-SDK install)*
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented *(tracked in codex plan/progress artifacts)*
- [ ] Smoke tests succeed and log output *(blocked by missing .NET SDK)*
- [ ] `README_WPF_SHELL.md` and `/docs/WPF_MAPPING.md` kept current *(updates planned alongside future shell milestones)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd8c82a2c8331a9411d8c45493cce