### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/ViewModels/ComponentViewModel.cs
+++ b/ViewModels/ComponentViewModel.cs
@@ -237,9 +237,10 @@ namespace YasGMP.ViewModels
                     SelectedComponent,
                     isUpdate: false,
                     _authService.CurrentUser?.Id ?? 1,
-                    _currentIpAddress ?? string.Empty,
-                    _currentDeviceInfo ?? string.Empty,
-                    default
+                    ip: _currentIpAddress ?? string.Empty,
+                    deviceInfo: _currentDeviceInfo ?? string.Empty,
+                    sessionId: null,
+                    cancellationToken: default
                 ).ConfigureAwait(false);
 
                 StatusMessage = $"Component '{SelectedComponent.Name}' added.";
@@ -269,9 +270,10 @@ namespace YasGMP.ViewModels
                     SelectedComponent,
                     isUpdate: true,
                     _authService.CurrentUser?.Id ?? 1,
-                    _currentIpAddress ?? string.Empty,
-                    _currentDeviceInfo ?? string.Empty,
-                    default
+                    ip: _currentIpAddress ?? string.Empty,
+                    deviceInfo: _currentDeviceInfo ?? string.Empty,
+                    sessionId: null,
+                    cancellationToken: default
                 ).ConfigureAwait(false);
 
                 StatusMessage = $"Component '{SelectedComponent.Name}' updated.";

--- a/YasGMP.AppCore/Services/ComponentSaveContext.cs
+++ b/YasGMP.AppCore/Services/ComponentSaveContext.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace YasGMP.Services
+{
+    /// <summary>
+    /// Context metadata supplied by UI adapters when persisting components.
+    /// Captures the electronic signature hash plus client network/session info
+    /// so the database write can retain the adapter-provided values without
+    /// recomputing hashes inside <see cref="ComponentService"/>.
+    /// </summary>
+    public sealed record class ComponentSaveContext
+    {
+        /// <summary>Optional persisted signature hash supplied by the adapter.</summary>
+        public string? SignatureHash { get; init; }
+
+        /// <summary>Client IP address associated with the save.</summary>
+        public string? IpAddress { get; init; }
+
+        /// <summary>Client device descriptor (workstation, terminal, etc.).</summary>
+        public string? DeviceInfo { get; init; }
+
+        /// <summary>Client session identifier for traceability.</summary>
+        public string? SessionId { get; init; }
+
+        /// <summary>
+        /// Creates a normalized context, trimming values and returning
+        /// <c>null</c> for empty inputs so downstream persistence writes
+        /// <see cref="DBNull.Value"/> instead of blank strings.
+        /// </summary>
+        public static ComponentSaveContext Create(
+            string? signatureHash,
+            string? ipAddress,
+            string? deviceInfo,
+            string? sessionId)
+            => new()
+            {
+                SignatureHash = Normalize(signatureHash),
+                IpAddress = Normalize(ipAddress),
+                DeviceInfo = Normalize(deviceInfo),
+                SessionId = Normalize(sessionId)
+            };
+
+        private static string? Normalize(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            return value.Trim();
+        }
+    }
+}
+

--- a/YasGMP.AppCore/Services/DatabaseService.ComponentExtensions.cs
+++ b/YasGMP.AppCore/Services/DatabaseService.ComponentExtensions.cs
@@ -32,7 +32,14 @@ namespace YasGMP.Services
         {
             // Forward to the robust instance implementation (maps domain -> low-level inside).
             // Actor/comment are recorded via LogSystemEventAsync in the instance method.
-            return db.InsertOrUpdateComponentAsync(component, isUpdate, userId, actor, cancellationToken);
+            return db.InsertOrUpdateComponentAsync(
+                component,
+                isUpdate,
+                userId,
+                ip: actor,
+                deviceInfo: comment,
+                sessionId: null,
+                token: cancellationToken);
         }
 
         /// <summary>Upsert using IP/Device context.</summary>
@@ -48,7 +55,13 @@ namespace YasGMP.Services
         {
             var actor = $"IP:{ipAddress}|Device:{deviceInfo}";
             return db.InsertOrUpdateComponentAsync(
-                component, isUpdate, userId, actor, comment ?? "Component upsert", cancellationToken);
+                component,
+                isUpdate,
+                userId,
+                ip: ipAddress,
+                deviceInfo: deviceInfo,
+                sessionId: null,
+                token: cancellationToken);
         }
 
         // =========================================================================
@@ -67,7 +80,14 @@ namespace YasGMP.Services
         {
             // Convert to domain model and forward to instance method that accepts actor context.
             var domain = Helpers.ComponentMapper.ToComponent(component);
-            return db.InsertOrUpdateComponentAsync(domain, isUpdate, userId, actor, cancellationToken);
+            return db.InsertOrUpdateComponentAsync(
+                domain,
+                isUpdate,
+                userId,
+                ip: actor,
+                deviceInfo: comment,
+                sessionId: null,
+                token: cancellationToken);
         }
 
         /// <summary>Upsert MachineComponent using IP/Device context.</summary>
@@ -84,7 +104,13 @@ namespace YasGMP.Services
             var actor = $"IP:{ipAddress}|Device:{deviceInfo}";
             var domain = Helpers.ComponentMapper.ToComponent(component);
             return db.InsertOrUpdateComponentAsync(
-                domain, isUpdate, userId, actor, comment ?? "Component upsert", cancellationToken);
+                domain,
+                isUpdate,
+                userId,
+                ip: ipAddress,
+                deviceInfo: deviceInfo,
+                sessionId: null,
+                token: cancellationToken);
         }
 
         // =========================================================================

--- a/YasGMP.Tests/ComponentServiceTests.cs
+++ b/YasGMP.Tests/ComponentServiceTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MySqlConnector;
+using Xunit;
+using YasGMP.Models;
+using YasGMP.Services;
+
+namespace YasGMP.Tests
+{
+    public class ComponentServiceTests
+    {
+        private const string ConnectionString = "Server=localhost;User Id=test;Password=test;Database=test;";
+
+        [Fact]
+        public async Task CreateAsync_UsesAdapterProvidedSignatureAndContext()
+        {
+            var db = new DatabaseService(ConnectionString);
+            var capturedCommands = new List<(string Sql, IReadOnlyDictionary<string, object?> Parameters)>();
+
+            db.ExecuteNonQueryOverride = (sql, parameters, _) =>
+            {
+                var snapshot = parameters?.ToDictionary(p => p.ParameterName, p => p.Value)
+                               ?? new Dictionary<string, object?>();
+                capturedCommands.Add((sql, snapshot));
+                return Task.FromResult(1);
+            };
+            db.ExecuteScalarOverride = (sql, _, _) =>
+            {
+                if (sql.Contains("LAST_INSERT_ID", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Task.FromResult<object?>(1);
+                }
+
+                return Task.FromResult<object?>(0);
+            };
+
+            var audit = new NoOpAuditService(db);
+            var service = new ComponentService(db, audit);
+
+            var component = new Component
+            {
+                MachineId = 7,
+                Code = "CMP-001",
+                Name = "Filter Assembly",
+                SopDoc = "SOP-FILTER-001"
+            };
+
+            var context = ComponentSaveContext.Create(
+                signatureHash: "hash-from-adapter",
+                ipAddress: "10.0.0.12",
+                deviceInfo: "UnitTestRig",
+                sessionId: "session-xyz");
+
+            try
+            {
+                await service.CreateAsync(component, userId: 42, context, CancellationToken.None).ConfigureAwait(false);
+            }
+            finally
+            {
+                db.ResetTestOverrides();
+            }
+
+            Assert.Equal("hash-from-adapter", component.DigitalSignature);
+            Assert.Equal("10.0.0.12", component.SourceIp);
+
+            var insert = capturedCommands.Single(entry =>
+                entry.Sql.Contains("machine_components", StringComparison.OrdinalIgnoreCase));
+
+            Assert.Equal("hash-from-adapter", insert.Parameters["@sig"]);
+            Assert.Equal("10.0.0.12", insert.Parameters["@ip"]);
+            Assert.Equal("UnitTestRig", insert.Parameters["@device"]);
+            Assert.Equal("session-xyz", insert.Parameters["@session"]);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_RetainsExistingSignatureWhenContextMissing()
+        {
+            var db = new DatabaseService(ConnectionString);
+            var capturedCommands = new List<(string Sql, IReadOnlyDictionary<string, object?> Parameters)>();
+
+            db.ExecuteNonQueryOverride = (sql, parameters, _) =>
+            {
+                var snapshot = parameters?.ToDictionary(p => p.ParameterName, p => p.Value)
+                               ?? new Dictionary<string, object?>();
+                capturedCommands.Add((sql, snapshot));
+                return Task.FromResult(1);
+            };
+            db.ExecuteScalarOverride = (sql, _, _) => Task.FromResult<object?>(0);
+
+            var audit = new NoOpAuditService(db);
+            var service = new ComponentService(db, audit);
+
+            var component = new Component
+            {
+                Id = 12,
+                MachineId = 5,
+                Code = "CMP-012",
+                Name = "Pump",
+                SopDoc = "SOP-PUMP-001",
+                DigitalSignature = "existing-hash",
+                SourceIp = "192.168.1.10"
+            };
+
+            try
+            {
+                await service.UpdateAsync(component, userId: 99, context: null, CancellationToken.None).ConfigureAwait(false);
+            }
+            finally
+            {
+                db.ResetTestOverrides();
+            }
+
+            Assert.Equal("existing-hash", component.DigitalSignature);
+
+            var update = capturedCommands.Single(entry =>
+                entry.Sql.Contains("UPDATE machine_components", StringComparison.OrdinalIgnoreCase));
+
+            Assert.Equal("existing-hash", update.Parameters["@sig"]);
+            Assert.Equal("192.168.1.10", update.Parameters["@ip"]);
+        }
+
+        private sealed class NoOpAuditService : AuditService
+        {
+            public NoOpAuditService(DatabaseService db) : base(db)
+            {
+            }
+
+            public override Task LogEntityAuditAsync(string? tableName, int entityId, string? action, string? details)
+                => Task.CompletedTask;
+        }
+    }
+}
+

--- a/YasGMP.Wpf/Services/ComponentCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/ComponentCrudServiceAdapter.cs
@@ -40,7 +40,12 @@ public sealed class ComponentCrudServiceAdapter : IComponentCrudService
         if (component is null) throw new ArgumentNullException(nameof(component));
 
         var signature = ApplyContext(component, context);
-        await _inner.CreateAsync(component, context.UserId).ConfigureAwait(false);
+        var saveContext = ComponentSaveContext.Create(
+            signature,
+            context.Ip,
+            context.DeviceInfo,
+            context.SessionId);
+        await _inner.CreateAsync(component, context.UserId, saveContext).ConfigureAwait(false);
 
         return new CrudSaveResult(component.Id, CreateMetadata(context, signature));
     }
@@ -50,7 +55,12 @@ public sealed class ComponentCrudServiceAdapter : IComponentCrudService
         if (component is null) throw new ArgumentNullException(nameof(component));
 
         var signature = ApplyContext(component, context);
-        await _inner.UpdateAsync(component, context.UserId).ConfigureAwait(false);
+        var saveContext = ComponentSaveContext.Create(
+            signature,
+            context.Ip,
+            context.DeviceInfo,
+            context.SessionId);
+        await _inner.UpdateAsync(component, context.UserId, saveContext).ConfigureAwait(false);
 
         return new CrudSaveResult(component.Id, CreateMetadata(context, signature));
     }

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -43,6 +43,7 @@
 
 ## Notes
 - 2025-12-01: Change Control schema/service now persist digital signature hash plus IP/session/device context so adapter metadata flows through unchanged; database scripts updated accordingly while CLI validation remains blocked.
+- 2025-12-02: ComponentService now accepts a ComponentSaveContext so WPF adapters can persist signature hash/IP/device/session without regeneration; machine_components INSERT/UPDATE now write digital_signature/source_ip/device/session columns and unit coverage asserts the stored hash matches the adapter payload while dotnet CLI validation remains blocked.
 - 2025-12-01: dotnet restore/build and WPF smoke harness still blocked by missing dotnet CLI; rerun once host installs .NET 9/Windows SDK.
 - 2025-11-30: Assets save flow now applies CrudSaveResult digital signature ids immediately after persistence and removes the stale OnRecordSelected signature block; build validation remains blocked pending dotnet CLI access.
 - 2025-11-13: Completed signature metadata DTO propagation through Machine, Work Order, Calibration, Supplier, and Part services plus DatabaseService helpers; persistence now accepts optional metadata and falls back to the legacy hash generator when absent, while WPF adapters feed DTOs downstream.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -47,6 +47,7 @@
       "name": "Cross-cutting services",
       "status": "in-progress",
       "notes": [
+        "ComponentService persistence now threads adapter-supplied signature hash/IP/device/session context through ComponentSaveContext and DatabaseService.ComponentOverloads so machine_components keeps the adapter hash intact; CLI validation still blocked.",
         "Change Control persistence now stores digital signature hash/IP/session/device metadata via new columns and service plumbing; schema + CRUD helpers updated while CLI validation remains blocked.",
         "Electronic signature capture now enforced across Assets, Work Orders, Calibration, Suppliers, and Parts; WPF adapters and AppCore services propagate optional signature metadata through to persistence with legacy hash fallback when metadata is absent; audit surfacing still pending until SDK access returns",
         "Audit logging now includes signature id/hash metadata with graceful fallbacks and unit coverage for both modern and legacy schemas.",
@@ -83,8 +84,9 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "feat: persist change control signature metadata",
+  "lastCommitSummary": "feat: preserve component signature metadata",
   "notes": [
+    "2025-12-02: ComponentService and DatabaseService.ComponentOverloads now persist adapter-supplied component signature hash/IP/device/session metadata with new unit coverage verifying the stored hash matches the adapter payload; dotnet CLI still unavailable for restore/build/smoke runs.",
     "2025-12-01: dotnet restore/build/smoke harness attempts blocked by missing CLI while validating Change Control signature metadata persistence; rerun once .NET 9 SDK installed.",
     "Need to restore/install dotnet 9 SDK to proceed with Batch 0 validation steps.",
     "tests/fixtures/hello.txt seeded for smoke harness bootstrap",


### PR DESCRIPTION
## Summary
- allow ComponentService to accept ComponentSaveContext so adapter-supplied signatures/IP/device/session metadata persist without regeneration
- extend DatabaseService.ComponentOverloads insert/update to write digital_signature/source_ip/device/session columns and expose context through helper overloads
- thread context through WPF adapter/ViewModel and add unit coverage ensuring the stored hash matches the adapter payload; updated plan/progress logs

## Testing
- `dotnet restore yasgmp.sln` *(fails: command not found — dotnet CLI unavailable in container)*
- `dotnet build yasgmp.csproj -f net8.0-windows10.0.19041.0` *(fails: command not found — dotnet CLI unavailable in container)*
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj -f net9.0-windows10.0.19041.0` *(fails: command not found — dotnet CLI unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dce88d9138833195bfb2d4dabc34ac