### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.AppCore/Services/DatabaseService.Validations.Extensions.cs
+++ b/YasGMP.AppCore/Services/DatabaseService.Validations.Extensions.cs
@@ -76,9 +76,9 @@ namespace YasGMP.Services
             {
                 const string ins = @"
 INSERT INTO validations
-(code, type, machine_id, component_id, date_start, date_end, documentation, comment, status, digital_signature, next_due)
+(code, type, machine_id, component_id, date_start, date_end, documentation, comment, status, digital_signature, next_due, source_ip, session_id)
 VALUES
-(@code,@type,@machine,@comp,@ds,@de,@doc,@comm,@status,@sig,@next);";
+(@code,@type,@machine,@comp,@ds,@de,@doc,@comm,@status,@sig,@next,@source_ip,@session);";
                 var insPars = BuildParameters(v, includeId: false);
                 await db.ExecuteNonQueryAsync(ins, insPars, token).ConfigureAwait(false);
 
@@ -103,7 +103,8 @@ VALUES
                 const string upd = @"
 UPDATE validations SET
  code=@code, type=@type, machine_id=@machine, component_id=@comp, date_start=@ds, date_end=@de,
- documentation=@doc, comment=@comm, status=@status, digital_signature=@sig, next_due=@next
+ documentation=@doc, comment=@comm, status=@status, digital_signature=@sig, next_due=@next,
+ source_ip=@source_ip, session_id=@session
 WHERE id=@id;";
                 var updPars = BuildParameters(v, includeId: true);
                 await db.ExecuteNonQueryAsync(upd, updPars, token).ConfigureAwait(false);
@@ -368,6 +369,8 @@ VALUES
                 new("@status", v.Status ?? string.Empty),
                 new("@sig",    v.DigitalSignature ?? string.Empty),
                 new("@next",   v.NextDue ?? (object)DBNull.Value),
+                new("@source_ip", string.IsNullOrWhiteSpace(v.SourceIp) ? (object)DBNull.Value : v.SourceIp),
+                new("@session",   string.IsNullOrWhiteSpace(v.SessionId) ? (object)DBNull.Value : v.SessionId),
             };
             if (includeId) list.Add(new MySqlParameter("@id", v.Id));
             return list.ToArray();

--- a/YasGMP.Tests/ValidationServiceTests.cs
+++ b/YasGMP.Tests/ValidationServiceTests.cs
@@ -19,45 +19,100 @@ namespace YasGMP.Tests
         public async Task CreateAsync_PreservesExistingDigitalSignature()
         {
             var db = new DatabaseService("Server=localhost;Database=test;Uid=root;Pwd=test;");
-            string? capturedSignature = null;
+            var parameters = new Dictionary<string, object?>();
 
-            db.ExecuteNonQueryOverride = CaptureSignature(ref capturedSignature);
+            db.ExecuteNonQueryOverride = CaptureParameters(parameters);
             db.ExecuteScalarOverride = (_, _, _) => Task.FromResult<object?>(123);
 
             var service = new ValidationService(db, new StubValidationAuditService());
             var validation = CreateValidation();
             validation.DigitalSignature = "adapter-hash";
+            validation.SourceIp = "adapter-ip";
+            validation.SessionId = "adapter-session";
 
             await service.CreateAsync(validation, userId: 7);
 
             Assert.Equal("adapter-hash", validation.DigitalSignature);
-            Assert.Equal("adapter-hash", capturedSignature);
+            Assert.Equal("adapter-hash", parameters["@sig"]);
         }
 
         [Fact]
         public async Task UpdateAsync_PreservesExistingDigitalSignature()
         {
             var db = new DatabaseService("Server=localhost;Database=test;Uid=root;Pwd=test;");
-            string? capturedSignature = null;
+            var parameters = new Dictionary<string, object?>();
 
-            db.ExecuteNonQueryOverride = CaptureSignature(ref capturedSignature);
+            db.ExecuteNonQueryOverride = CaptureParameters(parameters);
 
             var service = new ValidationService(db, new StubValidationAuditService());
             var validation = CreateValidation();
             validation.Id = 77;
             validation.DigitalSignature = "adapter-update-hash";
+            validation.SourceIp = "adapter-ip";
+            validation.SessionId = "adapter-session";
 
             await service.UpdateAsync(validation, userId: 11);
 
             Assert.Equal("adapter-update-hash", validation.DigitalSignature);
-            Assert.Equal("adapter-update-hash", capturedSignature);
+            Assert.Equal("adapter-update-hash", parameters["@sig"]);
         }
 
-        private static Func<string, IEnumerable<MySqlParameter>?, CancellationToken, Task<int>> CaptureSignature(ref string? captured)
+        [Fact]
+        public async Task CreateAsync_PassesSourceMetadataToDatabase()
+        {
+            var db = new DatabaseService("Server=localhost;Database=test;Uid=root;Pwd=test;");
+            var parameters = new Dictionary<string, object?>();
+
+            db.ExecuteNonQueryOverride = CaptureParameters(parameters);
+            db.ExecuteScalarOverride = (_, _, _) => Task.FromResult<object?>(321);
+
+            var service = new ValidationService(db, new StubValidationAuditService());
+            var validation = CreateValidation();
+            validation.SourceIp = "10.1.2.3";
+            validation.SessionId = "sess-create";
+
+            await service.CreateAsync(validation, userId: 3);
+
+            Assert.Equal("10.1.2.3", validation.SourceIp);
+            Assert.Equal("sess-create", validation.SessionId);
+            Assert.Equal("10.1.2.3", parameters["@source_ip"]);
+            Assert.Equal("sess-create", parameters["@session"]);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_PassesSourceMetadataToDatabase()
+        {
+            var db = new DatabaseService("Server=localhost;Database=test;Uid=root;Pwd=test;");
+            var parameters = new Dictionary<string, object?>();
+
+            db.ExecuteNonQueryOverride = CaptureParameters(parameters);
+
+            var service = new ValidationService(db, new StubValidationAuditService());
+            var validation = CreateValidation();
+            validation.Id = 55;
+            validation.SourceIp = "10.4.5.6";
+            validation.SessionId = "sess-update";
+
+            await service.UpdateAsync(validation, userId: 9);
+
+            Assert.Equal("10.4.5.6", validation.SourceIp);
+            Assert.Equal("sess-update", validation.SessionId);
+            Assert.Equal("10.4.5.6", parameters["@source_ip"]);
+            Assert.Equal("sess-update", parameters["@session"]);
+        }
+
+        private static Func<string, IEnumerable<MySqlParameter>?, CancellationToken, Task<int>> CaptureParameters(Dictionary<string, object?> store)
         {
             return (_, parameters, _) =>
             {
-                captured = parameters?.FirstOrDefault(p => p.ParameterName == "@sig")?.Value?.ToString();
+                store.Clear();
+                if (parameters != null)
+                {
+                    foreach (var p in parameters)
+                    {
+                        store[p.ParameterName] = p.Value;
+                    }
+                }
                 return Task.FromResult(1);
             };
         }

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -1,10 +1,10 @@
 # Codex Plan — WPF Shell & Full Integration
 
 ## Current Compile Status
-- [ ] Dotnet SDKs detected and recorded *(blocked: `dotnet` CLI not available in container PATH`; `dotnet --info` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-28, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-04, 2025-11-07, 2025-11-09, and 2025-11-18, 2025-11-19, 2025-11-30 → **command not found**)*
-- [ ] Solution restores *(pending SDK availability; `dotnet restore` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, 2025-11-07, 2025-11-09, and 2025-11-18, 2025-11-19, 2025-11-30 → **command not found**)*
-- [ ] MAUI builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, 2025-11-07, 2025-11-09, and 2025-11-18, 2025-11-19, 2025-11-30 → **command not found**)*
-- [ ] WPF builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, 2025-11-07, 2025-11-09, and 2025-11-18, 2025-11-19, 2025-11-30 → **command not found**)*
+- [ ] Dotnet SDKs detected and recorded *(blocked: `dotnet` CLI not available in container PATH`; `dotnet --info` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-28, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-04, 2025-11-07, 2025-11-09, and 2025-11-18, 2025-11-19, 2025-11-30, 2025-12-04 → **command not found**)*
+- [ ] Solution restores *(pending SDK availability; `dotnet restore` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, 2025-11-07, 2025-11-09, and 2025-11-18, 2025-11-19, 2025-11-30, 2025-12-04 → **command not found**)*
+- [ ] MAUI builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, 2025-11-07, 2025-11-09, and 2025-11-18, 2025-11-19, 2025-11-30, 2025-12-04 → **command not found**)*
+- [ ] WPF builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, 2025-11-07, 2025-11-09, and 2025-11-18, 2025-11-19, 2025-11-30, 2025-12-04 → **command not found**)*
 
 ## Decisions & Pins
 - Preferred WPF target: **net9.0-windows10.0.19041.0** (retain once .NET 9 SDK is installed).
@@ -42,6 +42,7 @@
   - 2025-09-24: Batch 0 rerun inside container confirmed `.NET 9` CLI is still missing; all `dotnet` commands fail immediately. Remains a prerequisite before module CRUD refactors can progress.
 
 ## Notes
+- 2025-12-04: Validation persistence now writes `source_ip`/`session_id` on insert/update and ValidationService unit tests assert the metadata survives adapter calls; dotnet CLI still missing so restore/build/test remain blocked.
 - 2025-12-01: Change Control schema/service now persist digital signature hash plus IP/session/device context so adapter metadata flows through unchanged; database scripts updated accordingly while CLI validation remains blocked.
 - 2025-12-03: ValidationService now preserves adapter-provided digital signature hashes on create/update paths, only regenerating during forced transitions (e.g., Execute); unit coverage added to confirm the adapter hash survives persistence while dotnet CLI access remains blocked.
 - 2025-12-02: ComponentService now accepts a ComponentSaveContext so WPF adapters can persist signature hash/IP/device/session without regeneration; machine_components INSERT/UPDATE now write digital_signature/source_ip/device/session columns and unit coverage asserts the stored hash matches the adapter payload while dotnet CLI validation remains blocked.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -25,7 +25,8 @@
       "2025-11-17: dotnet restore/build retried; CLI still missing in container so commands exit with 'command not found'.",
       "2025-11-18: dotnet restore/build retried; CLI remains unavailable in the container so commands exit with 'command not found'.",
       "2025-11-19: dotnet restore/build retried; CLI remains unavailable in the container so commands exit with 'command not found'.",
-      "2025-11-30: dotnet restore retried; CLI still missing so commands exit with \"command not found\"."
+      "2025-11-30: dotnet restore retried; CLI still missing so commands exit with \"command not found\".",
+      "2025-12-04: dotnet --info/restore/build retried; CLI remains unavailable in the container so commands exit with 'command not found'."
     ]
   },
   "batches": [
@@ -85,8 +86,9 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "fix: preserve validation signature metadata",
+  "lastCommitSummary": "fix: persist validation source metadata",
   "notes": [
+    "2025-12-04: Validation persistence now writes source_ip/session_id columns and ValidationService tests assert metadata pass-through while dotnet CLI access remains unavailable for restore/build/test.",
     "2025-12-03: ValidationService now preserves adapter-supplied validation signature hashes during create/update and forces regeneration only when executing a validation; unit tests cover the persistence path while dotnet CLI access remains unavailable for restore/build/test.",
     "2025-12-02: ComponentService and DatabaseService.ComponentOverloads now persist adapter-supplied component signature hash/IP/device/session metadata with new unit coverage verifying the stored hash matches the adapter payload; dotnet CLI still unavailable for restore/build/smoke runs.",
     "2025-12-01: dotnet restore/build/smoke harness attempts blocked by missing CLI while validating Change Control signature metadata persistence; rerun once .NET 9 SDK installed.",


### PR DESCRIPTION
## Summary
- Extend validation insert and update SQL to persist `source_ip` and `session_id` metadata alongside other columns.
- Append the new parameters in `BuildParameters` and expand `ValidationService` unit coverage to assert source metadata flows through database calls.
- Record the latest dotnet CLI blockers and validation metadata work in `docs/codex_plan.md` and `docs/codex_progress.json`.

## Testing
- `dotnet --info`
- `dotnet restore`
- `dotnet build yasgmp.sln -c Release -f net9.0-windows10.0.19041.0`
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj -c Release`

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence).
- [ ] MAUI builds/runs unaffected.
- [ ] Shared AppCore extraction complete where required; adapters compiled.
- [ ] ModulesPane lists every module and opens feature-parity editors.
- [ ] B1 FormModes & command enablement wired across editors.
- [ ] CFL pickers + Golden Arrow navigation working.
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end.
- [ ] Warehouse ledger with running balance and alerts.
- [ ] Audit surfacing + e-signature prompts on critical saves.
- [ ] Attachments DB-backed with upload/preview/download.
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented.
- [ ] Smoke tests succeed and log output.
- [ ] `README_WPF_SHELL.md` and `/docs/WPF_MAPPING.md` kept current.

------
https://chatgpt.com/codex/tasks/task_e_68dcf15efc3c83318dc6014114dae009