### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf.Tests/TestStubs.cs
+++ b/YasGMP.Wpf.Tests/TestStubs.cs
@@ -5448,6 +5448,9 @@ namespace YasGMP.Services.Interfaces
                 DateEnd = source.DateEnd,
                 Status = source.Status,
                 Documentation = source.Documentation,
+                DigitalSignature = source.DigitalSignature,
+                SourceIp = source.SourceIp,
+                SessionId = source.SessionId,
                 Comment = source.Comment,
                 NextDue = source.NextDue
             };
@@ -5462,6 +5465,9 @@ namespace YasGMP.Services.Interfaces
             destination.DateEnd = source.DateEnd;
             destination.Status = source.Status;
             destination.Documentation = source.Documentation;
+            destination.DigitalSignature = source.DigitalSignature;
+            destination.SourceIp = source.SourceIp;
+            destination.SessionId = source.SessionId;
             destination.Comment = source.Comment;
             destination.NextDue = source.NextDue;
         }
@@ -6214,6 +6220,9 @@ namespace YasGMP.Services.Interfaces
                 DateEnd = source.DateEnd,
                 Status = source.Status,
                 Documentation = source.Documentation,
+                DigitalSignature = source.DigitalSignature,
+                SourceIp = source.SourceIp,
+                SessionId = source.SessionId,
                 Comment = source.Comment,
                 NextDue = source.NextDue
             };
@@ -6228,6 +6237,9 @@ namespace YasGMP.Services.Interfaces
             destination.DateEnd = source.DateEnd;
             destination.Status = source.Status;
             destination.Documentation = source.Documentation;
+            destination.DigitalSignature = source.DigitalSignature;
+            destination.SourceIp = source.SourceIp;
+            destination.SessionId = source.SessionId;
             destination.Comment = source.Comment;
             destination.NextDue = source.NextDue;
         }

--- a/YasGMP.Wpf.Tests/ValidationCrudServiceAdapterTests.cs
+++ b/YasGMP.Wpf.Tests/ValidationCrudServiceAdapterTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MySqlConnector;
+using Xunit;
+using YasGMP.Models;
+using YasGMP.Models.Enums;
+using YasGMP.Services;
+using YasGMP.Services.Interfaces;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.Tests;
+
+public class ValidationCrudServiceAdapterTests
+{
+    [Fact]
+    public async Task CreateAsync_PersistsContextMetadataAndReturnsMatchingSignature()
+    {
+        var captured = new Dictionary<string, object?>();
+        var db = new DatabaseService("Server=localhost;Database=test;Uid=root;Pwd=test;");
+        db.ExecuteNonQueryOverride = (sql, parameters, _) =>
+        {
+            if (sql.Contains("INSERT INTO validations", StringComparison.OrdinalIgnoreCase))
+            {
+                Capture(parameters, captured);
+            }
+
+            return Task.FromResult(1);
+        };
+        db.ExecuteScalarOverride = (_, _, _) => Task.FromResult<object?>(321);
+
+        var adapter = new ValidationCrudServiceAdapter(new ValidationService(db, new StubValidationAuditService()));
+        var validation = new Validation
+        {
+            Code = "VAL-CTX",
+            Type = "PQ",
+            MachineId = 5,
+            Status = "DRAFT",
+            DateStart = DateTime.UtcNow
+        };
+
+        var context = new ValidationCrudContext(
+            userId: 17,
+            ip: "172.20.0.77",
+            deviceInfo: "TestHarness",
+            sessionId: "session-ctx",
+            signatureId: 44,
+            signatureHash: "sig-hash-ctx",
+            signatureMethod: "password",
+            signatureStatus: "valid",
+            signatureNote: "ok");
+
+        var result = await adapter.CreateAsync(validation, context).ConfigureAwait(false);
+
+        Assert.Equal("sig-hash-ctx", validation.DigitalSignature);
+        Assert.Equal("172.20.0.77", validation.SourceIp);
+        Assert.Equal("session-ctx", validation.SessionId);
+
+        Assert.Equal("sig-hash-ctx", captured["@sig"]);
+        Assert.Equal("172.20.0.77", captured["@source_ip"]);
+        Assert.Equal("session-ctx", captured["@session"]);
+
+        Assert.NotNull(result.SignatureMetadata);
+        Assert.Equal(validation.DigitalSignature, result.SignatureMetadata?.Hash);
+        Assert.Equal(validation.SourceIp, result.SignatureMetadata?.IpAddress);
+        Assert.Equal(validation.SessionId, result.SignatureMetadata?.Session);
+        Assert.Equal(context.SignatureId, result.SignatureMetadata?.Id);
+    }
+
+    private static void Capture(IEnumerable<MySqlParameter>? parameters, IDictionary<string, object?> store)
+    {
+        store.Clear();
+        if (parameters == null)
+        {
+            return;
+        }
+
+        foreach (var parameter in parameters)
+        {
+            store[parameter.ParameterName] = parameter.Value;
+        }
+    }
+
+    private sealed class StubValidationAuditService : IValidationAuditService
+    {
+        public Task CreateAsync(ValidationAudit audit) => Task.CompletedTask;
+
+        public Task LogAsync(int validationId, int userId, ValidationActionType action, string details)
+            => Task.CompletedTask;
+    }
+}

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -42,6 +42,9 @@
   - 2025-09-24: Batch 0 rerun inside container confirmed `.NET 9` CLI is still missing; all `dotnet` commands fail immediately. Remains a prerequisite before module CRUD refactors can progress.
 
 ## Notes
+- 2025-12-05: Added WPF unit coverage exercising ValidationCrudServiceAdapter context propagation, updated the validation CRUD
+  fake to retain signature/IP/session metadata, and asserted CrudSaveResult mirrors the persisted entity so regressions surface
+  quickly while dotnet CLI access remains blocked.
 - 2025-12-04: Validation persistence now writes `source_ip`/`session_id` on insert/update and ValidationService unit tests assert the metadata survives adapter calls; dotnet CLI still missing so restore/build/test remain blocked.
 - 2025-12-01: Change Control schema/service now persist digital signature hash plus IP/session/device context so adapter metadata flows through unchanged; database scripts updated accordingly while CLI validation remains blocked.
 - 2025-12-03: ValidationService now preserves adapter-provided digital signature hashes on create/update paths, only regenerating during forced transitions (e.g., Execute); unit coverage added to confirm the adapter hash survives persistence while dotnet CLI access remains blocked.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -55,7 +55,8 @@
         "DataDrivenModuleDocumentViewModel exposes a shared AuditService hook and Work Orders now logs CREATE/UPDATE audit entries with signature, user, IP, device, and session context immediately after successful persistence.",
         "WPF test harness now uses a RecordingAuditService spy so Work Orders save and attachment flows assert audit payloads with signer context while the dotnet CLI remains unavailable.",
         "Module save flows now rehydrate adapter-provided signature ids/hashes before optional persistence, skipping redundant dialog writes when a signature already exists while preserving current UX messaging.",
-        "ValidationService now keeps adapter-supplied validation signature hashes intact on create/update and only regenerates when explicitly forced (e.g., MarkExecuted), with new unit coverage confirming the stored hash matches the adapter payload."
+        "ValidationService now keeps adapter-supplied validation signature hashes intact on create/update and only regenerates when explicitly forced (e.g., MarkExecuted), with new unit coverage confirming the stored hash matches the adapter payload.",
+        "WPF ValidationCrudServiceAdapter test now asserts signature hash/IP/session context persist alongside CrudSaveResult metadata, and validation CRUD fakes retain those fields for downstream assertions while CLI validation stays blocked."
       ]
     },
     {
@@ -88,6 +89,7 @@
   },
   "lastCommitSummary": "fix: persist validation source metadata",
   "notes": [
+    "2025-12-05: Added WPF ValidationCrudServiceAdapter test to confirm signature hash/IP/session metadata persists and matches returned CrudSaveResult while validation CRUD fakes retain the fields; dotnet CLI remains unavailable for restore/build/test.",
     "2025-12-04: Validation persistence now writes source_ip/session_id columns and ValidationService tests assert metadata pass-through while dotnet CLI access remains unavailable for restore/build/test.",
     "2025-12-03: ValidationService now preserves adapter-supplied validation signature hashes during create/update and forces regeneration only when executing a validation; unit tests cover the persistence path while dotnet CLI access remains unavailable for restore/build/test.",
     "2025-12-02: ComponentService and DatabaseService.ComponentOverloads now persist adapter-supplied component signature hash/IP/device/session metadata with new unit coverage verifying the stored hash matches the adapter payload; dotnet CLI still unavailable for restore/build/smoke runs.",


### PR DESCRIPTION
## Summary
- add a WPF unit test that exercises ValidationCrudServiceAdapter with a known context and validates the persisted entity and CrudSaveResult signature metadata
- update the FakeValidationCrudService test double so stored snapshots retain digital signature, source IP, and session identifiers for downstream assertions
- refresh codex plan/progress notes to capture the new adapter coverage and ongoing dotnet CLI limitation

## Testing
- `dotnet restore` *(fails: `dotnet` CLI is unavailable in the container)*
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj` *(fails: `dotnet` CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf34a821c8331967a9ef2c2a8abc7