### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.AppCore/Models/User.cs
+++ b/YasGMP.AppCore/Models/User.cs
@@ -71,6 +71,21 @@ namespace YasGMP.Models
         [Column("digital_signature")]
         public string DigitalSignature { get; set; } = string.Empty;
 
+        /// <summary>Device fingerprint captured at the time of the last persisted change.</summary>
+        [MaxLength(255)]
+        [Column("device_info")]
+        public string DeviceInfo { get; set; } = string.Empty;
+
+        /// <summary>Source IP recorded alongside the latest signature update.</summary>
+        [MaxLength(45)]
+        [Column("source_ip")]
+        public string SourceIp { get; set; } = string.Empty;
+
+        /// <summary>Session identifier associated with the last persisted change.</summary>
+        [MaxLength(128)]
+        [Column("session_id")]
+        public string SessionId { get; set; } = string.Empty;
+
         [Column("department_id")]
         public int? DepartmentId { get; set; }
 

--- a/YasGMP.AppCore/Services/DatabaseService.Rbac.Extensions.cs
+++ b/YasGMP.AppCore/Services/DatabaseService.Rbac.Extensions.cs
@@ -53,7 +53,7 @@ namespace YasGMP.Services
             CancellationToken token = default)
         {
             const string sql = @"SELECT id, username, full_name, email, role, role_id, active, is_locked, is_two_factor_enabled,
-       last_login, last_failed_login, failed_login_attempts, digital_signature, last_modified, last_modified_by_id
+       last_login, last_failed_login, failed_login_attempts, digital_signature, last_change_signature, last_modified, last_modified_by_id, source_ip, device_info, session_id
 FROM users ORDER BY full_name, username, id;";
             var dt = await db.ExecuteSelectAsync(sql, null, token).ConfigureAwait(false);
 
@@ -106,7 +106,7 @@ FROM users ORDER BY full_name, username, id;";
             CancellationToken token = default)
         {
             const string sql = @"SELECT id, username, full_name, email, role, role_id, active, is_locked, is_two_factor_enabled,
-       last_login, last_failed_login, failed_login_attempts, digital_signature, last_modified, last_modified_by_id
+       last_login, last_failed_login, failed_login_attempts, digital_signature, last_change_signature, last_modified, last_modified_by_id, source_ip, device_info, session_id
 FROM users WHERE id=@id LIMIT 1;";
             var dt = await db.ExecuteSelectAsync(sql, new[] { new MySqlParameter("@id", id) }, token).ConfigureAwait(false);
             return dt.Rows.Count == 1 ? ParseUser(dt.Rows[0]) : null;
@@ -595,6 +595,13 @@ VALUES (NULL,@fmt,'permissions',@filter,@path,@ip,'Permissions export')",
             SetIfExists(u, nameof(User.IsLocked), GetBool(r, "is_locked") ?? false);
             SetIfExists(u, nameof(User.IsTwoFactorEnabled), GetBool(r, "is_two_factor_enabled") ?? false);
             SetIfExists(u, nameof(User.LastLogin), GetDate(r, "last_login"));
+            SetIfExists(u, nameof(User.DigitalSignature), GetString(r, "digital_signature"));
+            SetIfExists(u, nameof(User.LastChangeSignature), GetString(r, "last_change_signature"));
+            SetIfExists(u, nameof(User.LastModifiedById), GetInt(r, "last_modified_by_id"));
+            SetIfExists(u, nameof(User.LastModified), GetDate(r, "last_modified") ?? u.LastModified);
+            SetIfExists(u, nameof(User.SourceIp), GetString(r, "source_ip"));
+            SetIfExists(u, nameof(User.DeviceInfo), GetString(r, "device_info"));
+            SetIfExists(u, nameof(User.SessionId), GetString(r, "session_id"));
 
             var fail = GetInt(r, "failed_login_attempts") ?? GetInt(r, "failed_logins") ?? 0;
             SetIfExists(u, nameof(User.FailedLoginAttempts), fail);

--- a/YasGMP.Wpf.Tests/UserCrudServiceAdapterSignatureTests.cs
+++ b/YasGMP.Wpf.Tests/UserCrudServiceAdapterSignatureTests.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MySqlConnector;
+using Xunit;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Services.Interfaces;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.Tests;
+
+public class UserCrudServiceAdapterSignatureTests
+{
+    [Fact]
+    public async Task CreateAsync_PersistsSignatureAndContext()
+    {
+        var db = new DatabaseService("Server=localhost;Database=test;Uid=test;Pwd=test;");
+        var commands = new List<(string Sql, List<MySqlParameter> Parameters)>();
+        db.ExecuteNonQueryOverride = (sql, parameters, _) =>
+        {
+            commands.Add((sql, parameters?.Select(p => (MySqlParameter)p).ToList() ?? new List<MySqlParameter>()));
+            return Task.FromResult(1);
+        };
+        db.ExecuteScalarOverride = (_, _, _) => Task.FromResult<object?>(42);
+
+        var userService = new TestUserService(db);
+        var adapter = new UserCrudServiceAdapter(userService, new NullRbacService());
+
+        var user = new User
+        {
+            Username = "qa",
+            FullName = "QA Lead",
+            Role = "admin",
+            Email = "qa@example.com"
+        };
+
+        var context = new UserCrudContext(
+            UserId: 99,
+            Ip: "10.0.0.5",
+            DeviceInfo: "SurfacePro",
+            SessionId: "sess-123",
+            SignatureId: 777,
+            SignatureHash: "HASH-001",
+            SignatureMethod: "password",
+            SignatureStatus: "valid",
+            SignatureNote: "approval");
+
+        var result = await adapter.CreateAsync(user, "Password!", context).ConfigureAwait(false);
+
+        Assert.Equal(42, result.Id);
+        var command = Assert.Single(commands);
+        Assert.Contains("INSERT INTO users", command.Sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("digital_signature", command.Sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("last_change_signature", command.Sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("source_ip", command.Sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("device_info", command.Sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("session_id", command.Sql, StringComparison.OrdinalIgnoreCase);
+
+        var parameterValues = command.Parameters.ToDictionary(
+            p => p.ParameterName,
+            p => p.Value is DBNull ? null : p.Value);
+
+        Assert.Equal("HASH-001", Assert.IsType<string>(parameterValues["@sig"]!));
+        Assert.Equal("HASH-001", Assert.IsType<string>(parameterValues["@lsig"]!));
+        Assert.Equal("10.0.0.5", Assert.IsType<string>(parameterValues["@ip"]!));
+        Assert.Equal("SurfacePro", Assert.IsType<string>(parameterValues["@dev"]!));
+        Assert.Equal("sess-123", Assert.IsType<string>(parameterValues["@sid"]!));
+        Assert.Equal(99, Assert.IsType<int>(parameterValues["@lmb"]!));
+        Assert.Equal("HASH-001", user.DigitalSignature);
+        Assert.Equal("HASH-001", user.LastChangeSignature);
+        Assert.Equal("10.0.0.5", user.SourceIp);
+        Assert.Equal("SurfacePro", user.DeviceInfo);
+        Assert.Equal("sess-123", user.SessionId);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsSignatureAndContext()
+    {
+        var db = new DatabaseService("Server=localhost;Database=test;Uid=test;Pwd=test;");
+        var commands = new List<(string Sql, List<MySqlParameter> Parameters)>();
+        db.ExecuteNonQueryOverride = (sql, parameters, _) =>
+        {
+            commands.Add((sql, parameters?.Select(p => (MySqlParameter)p).ToList() ?? new List<MySqlParameter>()));
+            return Task.FromResult(1);
+        };
+
+        var userService = new TestUserService(db);
+        var adapter = new UserCrudServiceAdapter(userService, new NullRbacService());
+
+        var user = new User
+        {
+            Id = 7,
+            Username = "qa",
+            FullName = "QA Lead",
+            Role = "admin",
+            Email = "qa@example.com",
+            DigitalSignature = "OLD",
+            LastChangeSignature = "OLD"
+        };
+
+        var context = new UserCrudContext(
+            UserId: 21,
+            Ip: "192.168.1.10",
+            DeviceInfo: "ThinkPad",
+            SessionId: "sess-999",
+            SignatureId: 888,
+            SignatureHash: "HASH-002",
+            SignatureMethod: "password",
+            SignatureStatus: "valid",
+            SignatureNote: "edit");
+
+        var result = await adapter.UpdateAsync(user, password: null, context).ConfigureAwait(false);
+
+        Assert.Equal(7, result.Id);
+        var command = Assert.Single(commands);
+        Assert.Contains("UPDATE users", command.Sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("WHERE id=@id", command.Sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("digital_signature=@sig", command.Sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("last_change_signature=@lsig", command.Sql, StringComparison.OrdinalIgnoreCase);
+
+        var parameterValues = command.Parameters.ToDictionary(
+            p => p.ParameterName,
+            p => p.Value is DBNull ? null : p.Value);
+
+        Assert.Equal("HASH-002", Assert.IsType<string>(parameterValues["@sig"]!));
+        Assert.Equal("HASH-002", Assert.IsType<string>(parameterValues["@lsig"]!));
+        Assert.Equal("192.168.1.10", Assert.IsType<string>(parameterValues["@ip"]!));
+        Assert.Equal("ThinkPad", Assert.IsType<string>(parameterValues["@dev"]!));
+        Assert.Equal("sess-999", Assert.IsType<string>(parameterValues["@sid"]!));
+        Assert.Equal(7, Assert.IsType<int>(parameterValues["@id"]!));
+        Assert.Equal(21, Assert.IsType<int>(parameterValues["@lmb"]!));
+    }
+
+    private sealed class TestUserService : IUserService
+    {
+        private readonly DatabaseService _db;
+
+        public TestUserService(DatabaseService db) => _db = db ?? throw new ArgumentNullException(nameof(db));
+
+        public Task<User?> AuthenticateAsync(string username, string password) => Task.FromResult<User?>(null);
+
+        public string HashPassword(string password) => password ?? string.Empty;
+
+        public Task<bool> VerifyTwoFactorCodeAsync(string username, string code) => Task.FromResult(false);
+
+        public Task LockUserAsync(int userId) => Task.CompletedTask;
+
+        public Task<List<User>> GetAllUsersAsync() => Task.FromResult(new List<User>());
+
+        public Task<User?> GetUserByIdAsync(int id) => Task.FromResult<User?>(null);
+
+        public Task<User?> GetUserByUsernameAsync(string username) => Task.FromResult<User?>(null);
+
+        public Task CreateUserAsync(User user, int adminId = 0) => _db.InsertOrUpdateUserAsync(user, update: false);
+
+        public Task UpdateUserAsync(User user, int adminId = 0) => _db.InsertOrUpdateUserAsync(user, update: true);
+
+        public Task DeleteUserAsync(int userId, int adminId = 0) => Task.CompletedTask;
+
+        public Task DeactivateUserAsync(int userId) => Task.CompletedTask;
+
+        public bool HasRole(User user, string role) => false;
+
+        public bool IsActive(User user) => user?.Active ?? false;
+
+        public Task ChangePasswordAsync(int userId, string newPassword, int adminId = 0) => Task.CompletedTask;
+
+        public string GenerateDigitalSignature(User user) => string.Empty;
+
+        public bool ValidateDigitalSignature(string signature) => !string.IsNullOrWhiteSpace(signature);
+
+        public Task LogUserEventAsync(int userId, string eventType, string details) => Task.CompletedTask;
+
+        public Task UnlockUserAsync(int userId, int adminId) => Task.CompletedTask;
+
+        public Task SetTwoFactorEnabledAsync(int userId, bool enabled) => Task.CompletedTask;
+
+        public Task UpdateUserProfileAsync(User user, int adminId = 0) => Task.CompletedTask;
+    }
+
+    private sealed class NullRbacService : IRBACService
+    {
+        public Task AssertPermissionAsync(int userId, string permissionCode) => Task.CompletedTask;
+
+        public Task<bool> HasPermissionAsync(int userId, string permissionCode) => Task.FromResult(true);
+
+        public Task<List<string>> GetAllUserPermissionsAsync(int userId) => Task.FromResult(new List<string>());
+
+        public Task GrantRoleAsync(int userId, int roleId, int grantedBy, DateTime? expiresAt = null, string reason = "") => Task.CompletedTask;
+
+        public Task RevokeRoleAsync(int userId, int roleId, int revokedBy, string reason = "") => Task.CompletedTask;
+
+        public Task<List<Role>> GetRolesForUserAsync(int userId) => Task.FromResult(new List<Role>());
+
+        public Task<List<Role>> GetAvailableRolesForUserAsync(int userId) => Task.FromResult(new List<Role>());
+
+        public Task GrantPermissionAsync(int userId, string permissionCode, int grantedBy, DateTime? expiresAt = null, string reason = "") => Task.CompletedTask;
+
+        public Task RevokePermissionAsync(int userId, string permissionCode, int revokedBy, string reason = "") => Task.CompletedTask;
+
+        public Task DelegatePermissionAsync(int fromUserId, int toUserId, string permissionCode, int grantedBy, DateTime expiresAt, string reason = "") => Task.CompletedTask;
+
+        public Task RevokeDelegatedPermissionAsync(int delegatedPermissionId, int revokedBy, string reason = "") => Task.CompletedTask;
+
+        public Task<List<Role>> GetAllRolesAsync() => Task.FromResult(new List<Role>());
+
+        public Task<List<Permission>> GetAllPermissionsAsync() => Task.FromResult(new List<Permission>());
+
+        public Task<List<Permission>> GetPermissionsForRoleAsync(int roleId) => Task.FromResult(new List<Permission>());
+
+        public Task<List<Permission>> GetPermissionsNotInRoleAsync(int roleId) => Task.FromResult(new List<Permission>());
+
+        public Task AddPermissionToRoleAsync(int roleId, int permissionId, int adminUserId, string reason = "") => Task.CompletedTask;
+
+        public Task RemovePermissionFromRoleAsync(int roleId, int permissionId, int adminUserId, string reason = "") => Task.CompletedTask;
+
+        public Task<int> CreateRoleAsync(Role role, int adminUserId) => Task.FromResult(0);
+
+        public Task UpdateRoleAsync(Role role, int adminUserId) => Task.CompletedTask;
+
+        public Task DeleteRoleAsync(int roleId, int adminUserId, string reason = "") => Task.CompletedTask;
+
+        public Task<int> RequestPermissionAsync(int userId, string permissionCode, string reason) => Task.FromResult(0);
+
+        public Task ApprovePermissionRequestAsync(int requestId, int approvedBy, string comment) => Task.CompletedTask;
+
+        public Task DenyPermissionRequestAsync(int requestId, int deniedBy, string comment) => Task.CompletedTask;
+    }
+}

--- a/YasGMP.Wpf/Services/UserCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/UserCrudServiceAdapter.cs
@@ -118,6 +118,9 @@ namespace YasGMP.Wpf.Services
             var signature = context.SignatureHash ?? user.DigitalSignature ?? string.Empty;
             user.DigitalSignature = signature;
             user.LastChangeSignature = signature;
+            user.SourceIp = context.Ip;
+            user.DeviceInfo = context.DeviceInfo;
+            user.SessionId = context.SessionId ?? user.SessionId;
             user.LastModifiedById = context.UserId;
             user.LastModified = DateTime.UtcNow;
             return signature;

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -45,6 +45,7 @@
 - 2025-12-05: Added WPF unit coverage exercising ValidationCrudServiceAdapter context propagation, updated the validation CRUD
   fake to retain signature/IP/session metadata, and asserted CrudSaveResult mirrors the persisted entity so regressions surface
   quickly while dotnet CLI access remains blocked.
+- 2025-12-06: Security persistence now writes `digital_signature`/`last_change_signature` along with IP/device/session metadata via DatabaseService.Users extensions, and new UserCrudServiceAdapter tests assert the context and signatures persist end-to-end while the dotnet CLI gap continues to block restore/build.
 - 2025-12-04: Validation persistence now writes `source_ip`/`session_id` on insert/update and ValidationService unit tests assert the metadata survives adapter calls; dotnet CLI still missing so restore/build/test remain blocked.
 - 2025-12-01: Change Control schema/service now persist digital signature hash plus IP/session/device context so adapter metadata flows through unchanged; database scripts updated accordingly while CLI validation remains blocked.
 - 2025-12-03: ValidationService now preserves adapter-provided digital signature hashes on create/update paths, only regenerating during forced transitions (e.g., Execute); unit coverage added to confirm the adapter hash survives persistence while dotnet CLI access remains blocked.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -87,8 +87,9 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "fix: persist validation source metadata",
+  "lastCommitSummary": "feat: persist user signature context",
   "notes": [
+    "2025-12-06: DatabaseService.Users insert/update now persist digital_signature/last_change_signature with IP/device/session metadata, and new UserCrudServiceAdapter tests verify the context flows end-to-end while the dotnet CLI remains unavailable for restore/build/test.",
     "2025-12-05: Added WPF ValidationCrudServiceAdapter test to confirm signature hash/IP/session metadata persists and matches returned CrudSaveResult while validation CRUD fakes retain the fields; dotnet CLI remains unavailable for restore/build/test.",
     "2025-12-04: Validation persistence now writes source_ip/session_id columns and ValidationService tests assert metadata pass-through while dotnet CLI access remains unavailable for restore/build/test.",
     "2025-12-03: ValidationService now preserves adapter-supplied validation signature hashes during create/update and forces regeneration only when executing a validation; unit tests cover the persistence path while dotnet CLI access remains unavailable for restore/build/test.",


### PR DESCRIPTION
## Summary
- persist `digital_signature` and `last_change_signature` along with IP/device/session context when saving users through `DatabaseService.Users`
- flow signature context from `UserCrudServiceAdapter` into the user entity and add coverage verifying the adapter writes the expected SQL metadata
- update Codex plan/progress logs with the new security persistence work

## Testing
- `dotnet restore yasgmp.sln` *(fails: `dotnet` CLI not available in container)*
- `dotnet build yasgmp.csproj -f net8.0-windows10.0.19041.0` *(fails: `dotnet` CLI not available in container)*
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj -f net9.0-windows10.0.19041.0` *(fails: `dotnet` CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf4e433988331a588de3368d32c58