### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -45,6 +45,7 @@
 - 2025-12-05: Added WPF unit coverage exercising ValidationCrudServiceAdapter context propagation, updated the validation CRUD
   fake to retain signature/IP/session metadata, and asserted CrudSaveResult mirrors the persisted entity so regressions surface
   quickly while dotnet CLI access remains blocked.
+- 2025-12-07: External Servicer CRUD fake now records saved snapshots alongside contexts, cleans up deleted entries, and confirms CrudSaveResult metadata still flows from the provided context; attempted dotnet restore/build/smoke remain blocked because the CLI is still missing in the container.
 - 2025-12-06: Security persistence now writes `digital_signature`/`last_change_signature` along with IP/device/session metadata via DatabaseService.Users extensions, and new UserCrudServiceAdapter tests assert the context and signatures persist end-to-end while the dotnet CLI gap continues to block restore/build.
 - 2025-12-04: Validation persistence now writes `source_ip`/`session_id` on insert/update and ValidationService unit tests assert the metadata survives adapter calls; dotnet CLI still missing so restore/build/test remain blocked.
 - 2025-12-01: Change Control schema/service now persist digital signature hash plus IP/session/device context so adapter metadata flows through unchanged; database scripts updated accordingly while CLI validation remains blocked.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -26,7 +26,8 @@
       "2025-11-18: dotnet restore/build retried; CLI remains unavailable in the container so commands exit with 'command not found'.",
       "2025-11-19: dotnet restore/build retried; CLI remains unavailable in the container so commands exit with 'command not found'.",
       "2025-11-30: dotnet restore retried; CLI still missing so commands exit with \"command not found\".",
-      "2025-12-04: dotnet --info/restore/build retried; CLI remains unavailable in the container so commands exit with 'command not found'."
+      "2025-12-04: dotnet --info/restore/build retried; CLI remains unavailable in the container so commands exit with 'command not found'.",
+      "2025-12-07: dotnet restore/build attempted again for yasgmp.sln; CLI still missing in container so commands exit with 'command not found'."
     ]
   },
   "batches": [
@@ -87,8 +88,9 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "feat: persist user signature context",
+  "lastCommitSummary": "test: track external servicer snapshots",
   "notes": [
+    "2025-12-07: External Servicer CRUD fake now mirrors other module doubles by capturing saved snapshots with contexts, cloning entities for assertions, and clearing deleted entries; CrudSaveResult coverage confirms metadata still flows from the provided context while dotnet CLI access remains blocked for restore/build/smoke.",
     "2025-12-06: DatabaseService.Users insert/update now persist digital_signature/last_change_signature with IP/device/session metadata, and new UserCrudServiceAdapter tests verify the context flows end-to-end while the dotnet CLI remains unavailable for restore/build/test.",
     "2025-12-05: Added WPF ValidationCrudServiceAdapter test to confirm signature hash/IP/session metadata persists and matches returned CrudSaveResult while validation CRUD fakes retain the fields; dotnet CLI remains unavailable for restore/build/test.",
     "2025-12-04: Validation persistence now writes source_ip/session_id columns and ValidationService tests assert metadata pass-through while dotnet CLI access remains unavailable for restore/build/test.",


### PR DESCRIPTION
## Summary
- align the External Servicer CRUD test double with other module fakes by snapshotting saved entities with their contexts, cloning them for later assertions, and clearing snapshots on delete
- refresh codex planning/progress logs to record the snapshot tracking work and the continued dotnet CLI outage that blocks restore/build/smoke runs

## Testing
- `dotnet restore yasgmp.sln` *(fails: `dotnet` command is not available in the container)*
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj` *(fails: `dotnet` command is not available in the container)*
- `dotnet build yasgmp.csproj -f net9.0-windows10.0.19041.0` *(fails: `dotnet` command is not available in the container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence) *(blocked: dotnet CLI unavailable in container)*
- [ ] MAUI builds/runs unaffected *(blocked: dotnet CLI unavailable in container)*
- [ ] Shared AppCore extraction complete where required; adapters compiled *(blocked pending build validation once dotnet CLI returns)*
- [ ] ModulesPane lists every module and opens feature-parity editors *(pending verification in a runnable shell)*
- [ ] B1 FormModes & command enablement wired across editors *(pending verification in a runnable shell)*
- [ ] CFL pickers + Golden Arrow navigation working *(pending verification in a runnable shell)*
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end *(pending verification in a runnable shell)*
- [ ] Warehouse ledger with running balance and alerts *(pending verification in a runnable shell)*
- [ ] Audit surfacing + e-signature prompts on critical saves *(pending verification in a runnable shell)*
- [ ] Attachments DB-backed with upload/preview/download *(pending verification in a runnable shell)*
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented *(ongoing documentation updates)*
- [ ] Smoke tests succeed and log output *(blocked: dotnet CLI unavailable in container)*
- [ ] README_WPF_SHELL.md and /docs/WPF_MAPPING.md kept current *(pending broader WPF shell updates)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0e4785188331b9626dcc5209e5b0