### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf.Tests/AssetsModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/AssetsModuleViewModelTests.cs
@@ -23,7 +23,11 @@ public class AssetsModuleViewModelTests
         var audit = new AuditService(database);
         var audit = new AuditService(database);
         var audit = new AuditService(database);
-        var machineAdapter = new FakeMachineCrudService();
+        const int adapterSignatureId = 4321;
+        var machineAdapter = new FakeMachineCrudService
+        {
+            SignatureMetadataIdSource = _ => adapterSignatureId
+        };
         var auth = new TestAuthContext
         {
             CurrentUser = new User { Id = 7, FullName = "QA" },
@@ -53,6 +57,7 @@ public class AssetsModuleViewModelTests
         var saved = await InvokeSaveAsync(viewModel);
 
         Assert.True(saved);
+        Assert.Equal("Electronic signature captured (QA Reason).", viewModel.StatusMessage);
         Assert.False(viewModel.IsDirty);
         Assert.Single(machineAdapter.Saved);
         var persisted = machineAdapter.Saved[0];
@@ -72,18 +77,12 @@ public class AssetsModuleViewModelTests
             Assert.Equal("machines", ctx.TableName);
             Assert.Equal(0, ctx.RecordId);
         });
-        Assert.Single(signatureDialog.PersistedResults);
-        var persistedSignature = signatureDialog.PersistedResults[0];
-        Assert.Equal(machineAdapter.Saved[0].Id, persistedSignature.Signature.RecordId);
-        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
-        Assert.True(persistedSignature.Signature.Id > 0);
-        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
-        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
-        Assert.Equal(machineAdapter.Saved[0].Id, persistedMetadata.RecordId);
-        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
-        Assert.Equal("password", persistedMetadata.Method);
-        Assert.Equal("valid", persistedMetadata.Status);
-        Assert.Equal("Automated test", persistedMetadata.Note);
+        var capturedResult = Assert.Single(signatureDialog.CapturedResults);
+        var signatureResult = Assert.NotNull(capturedResult);
+        Assert.Equal(machineAdapter.Saved[0].Id, signatureResult.Signature.RecordId);
+        Assert.Equal(adapterSignatureId, signatureResult.Signature.Id);
+        Assert.Empty(signatureDialog.PersistedResults);
+        Assert.Equal(0, signatureDialog.PersistInvocationCount);
     }
 
     [Fact]

--- a/YasGMP.Wpf.Tests/ChangeControlModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/ChangeControlModuleViewModelTests.cs
@@ -23,7 +23,11 @@ public class ChangeControlModuleViewModelTests
         var audit = new AuditService(database);
         var audit = new AuditService(database);
         var audit = new AuditService(database);
-        var crud = new FakeChangeControlCrudService();
+        const int adapterSignatureId = 7813;
+        var crud = new FakeChangeControlCrudService
+        {
+            SignatureMetadataIdSource = _ => adapterSignatureId
+        };
         var auth = new TestAuthContext { CurrentUser = new User { Id = 7, FullName = "Quality Lead" } };
         var filePicker = new TestFilePicker();
         var attachments = new TestAttachmentService();
@@ -44,6 +48,7 @@ public class ChangeControlModuleViewModelTests
         var saved = await InvokeSaveAsync(viewModel);
 
         Assert.True(saved);
+        Assert.Equal("Electronic signature captured (QA Reason).", viewModel.StatusMessage);
         var created = Assert.Single(crud.Saved);
         Assert.Equal("Validate HVAC filters", created.Title);
         Assert.Equal("CC-UNIT-100", created.Code);
@@ -58,18 +63,12 @@ public class ChangeControlModuleViewModelTests
             Assert.Equal("change_controls", ctx.TableName);
             Assert.Equal(0, ctx.RecordId);
         });
-        Assert.Single(signatureDialog.PersistedResults);
-        var persistedSignature = signatureDialog.PersistedResults[0];
-        Assert.Equal(crud.Saved[0].Id, persistedSignature.Signature.RecordId);
-        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
-        Assert.True(persistedSignature.Signature.Id > 0);
-        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
-        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
-        Assert.Equal(crud.Saved[0].Id, persistedMetadata.RecordId);
-        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
-        Assert.Equal("password", persistedMetadata.Method);
-        Assert.Equal("valid", persistedMetadata.Status);
-        Assert.Equal("Automated test", persistedMetadata.Note);
+        var capturedResult = Assert.Single(signatureDialog.CapturedResults);
+        var signatureResult = Assert.NotNull(capturedResult);
+        Assert.Equal(crud.Saved[0].Id, signatureResult.Signature.RecordId);
+        Assert.Equal(adapterSignatureId, signatureResult.Signature.Id);
+        Assert.Empty(signatureDialog.PersistedResults);
+        Assert.Equal(0, signatureDialog.PersistInvocationCount);
         Assert.False(viewModel.IsDirty);
     }
 

--- a/YasGMP.Wpf.Tests/PartsModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/PartsModuleViewModelTests.cs
@@ -23,7 +23,11 @@ public class PartsModuleViewModelTests
         var audit = new AuditService(database);
         var audit = new AuditService(database);
         var audit = new AuditService(database);
-        var partAdapter = new FakePartCrudService();
+        const int adapterSignatureId = 6172;
+        var partAdapter = new FakePartCrudService
+        {
+            SignatureMetadataIdSource = _ => adapterSignatureId
+        };
         var auth = new TestAuthContext
         {
             CurrentUser = new User { Id = 8, FullName = "QA" },
@@ -54,6 +58,7 @@ public class PartsModuleViewModelTests
         var saved = await InvokeSaveAsync(viewModel);
 
         Assert.True(saved);
+        Assert.Equal("Electronic signature captured (QA Reason).", viewModel.StatusMessage);
         Assert.Single(partAdapter.Saved);
         var persisted = partAdapter.Saved[0];
         Assert.Equal("Pressure Gauge", persisted.Name);
@@ -70,18 +75,12 @@ public class PartsModuleViewModelTests
             Assert.Equal("parts", ctx.TableName);
             Assert.Equal(0, ctx.RecordId);
         });
-        Assert.Single(signatureDialog.PersistedResults);
-        var persistedSignature = signatureDialog.PersistedResults[0];
-        Assert.Equal(partAdapter.Saved[0].Id, persistedSignature.Signature.RecordId);
-        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
-        Assert.True(persistedSignature.Signature.Id > 0);
-        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
-        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
-        Assert.Equal(partAdapter.Saved[0].Id, persistedMetadata.RecordId);
-        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
-        Assert.Equal("password", persistedMetadata.Method);
-        Assert.Equal("valid", persistedMetadata.Status);
-        Assert.Equal("Automated test", persistedMetadata.Note);
+        var capturedResult = Assert.Single(signatureDialog.CapturedResults);
+        var signatureResult = Assert.NotNull(capturedResult);
+        Assert.Equal(partAdapter.Saved[0].Id, signatureResult.Signature.RecordId);
+        Assert.Equal(adapterSignatureId, signatureResult.Signature.Id);
+        Assert.Empty(signatureDialog.PersistedResults);
+        Assert.Equal(0, signatureDialog.PersistInvocationCount);
     }
 
     [Fact]

--- a/YasGMP.Wpf.Tests/SuppliersModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/SuppliersModuleViewModelTests.cs
@@ -21,7 +21,11 @@ public class SuppliersModuleViewModelTests
     {
         var database = new DatabaseService();
         var audit = new AuditService(database);
-        var supplierAdapter = new FakeSupplierCrudService();
+        const int adapterSignatureId = 5511;
+        var supplierAdapter = new FakeSupplierCrudService
+        {
+            SignatureMetadataIdSource = _ => adapterSignatureId
+        };
         var auth = new TestAuthContext
         {
             CurrentUser = new User { Id = 7, FullName = "QA" },
@@ -50,6 +54,7 @@ public class SuppliersModuleViewModelTests
         var saved = await InvokeSaveAsync(viewModel);
 
         Assert.True(saved);
+        Assert.Equal("Electronic signature captured (QA Reason).", viewModel.StatusMessage);
         Assert.Single(supplierAdapter.Saved);
         var supplier = supplierAdapter.Saved[0];
         Assert.Equal("contoso", supplier.Name.ToLowerInvariant());
@@ -66,18 +71,12 @@ public class SuppliersModuleViewModelTests
             Assert.Equal("suppliers", ctx.TableName);
             Assert.Equal(0, ctx.RecordId);
         });
-        Assert.Single(signatureDialog.PersistedResults);
-        var persistedSignature = signatureDialog.PersistedResults[0];
-        Assert.Equal(supplierAdapter.Saved[0].Id, persistedSignature.Signature.RecordId);
-        Assert.Equal(signatureDialog.LastPersistedSignatureId, persistedSignature.Signature.Id);
-        Assert.True(persistedSignature.Signature.Id > 0);
-        var persistedMetadata = Assert.Single(signatureDialog.PersistedSignatureRecords);
-        Assert.Equal(persistedSignature.Signature.Id, persistedMetadata.SignatureId);
-        Assert.Equal(supplierAdapter.Saved[0].Id, persistedMetadata.RecordId);
-        Assert.Equal("test-signature", persistedMetadata.SignatureHash);
-        Assert.Equal("password", persistedMetadata.Method);
-        Assert.Equal("valid", persistedMetadata.Status);
-        Assert.Equal("Automated test", persistedMetadata.Note);
+        var capturedResult = Assert.Single(signatureDialog.CapturedResults);
+        var signatureResult = Assert.NotNull(capturedResult);
+        Assert.Equal(supplierAdapter.Saved[0].Id, signatureResult.Signature.RecordId);
+        Assert.Equal(adapterSignatureId, signatureResult.Signature.Id);
+        Assert.Empty(signatureDialog.PersistedResults);
+        Assert.Equal(0, signatureDialog.PersistInvocationCount);
     }
 
     [Fact]

--- a/YasGMP.Wpf.Tests/TestStubs.CrudSaveResults.cs
+++ b/YasGMP.Wpf.Tests/TestStubs.CrudSaveResults.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using YasGMP.AppCore.Models.Signatures;
 using YasGMP.Wpf.Services;
@@ -6,6 +7,8 @@ namespace YasGMP.Models
 {
     public sealed partial class FakeMachineCrudService
     {
+        public Func<int?, int?>? SignatureMetadataIdSource { get; set; }
+
         public async Task<CrudSaveResult> CreateAsync(Machine machine, MachineCrudContext context)
         {
             var id = await CreateCoreAsync(machine, context).ConfigureAwait(false);
@@ -18,10 +21,10 @@ namespace YasGMP.Models
             return new CrudSaveResult(machine.Id, BuildMetadata(context, machine.DigitalSignature));
         }
 
-        private static SignatureMetadataDto BuildMetadata(MachineCrudContext context, string? signature)
+        private SignatureMetadataDto BuildMetadata(MachineCrudContext context, string? signature)
             => new()
             {
-                Id = context.SignatureId,
+                Id = ResolveMetadataId(context.SignatureId),
                 Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
                 Method = context.SignatureMethod,
                 Status = context.SignatureStatus,
@@ -30,10 +33,15 @@ namespace YasGMP.Models
                 Device = context.DeviceInfo,
                 IpAddress = context.Ip
             };
+
+        private int? ResolveMetadataId(int? contextSignatureId)
+            => SignatureMetadataIdSource?.Invoke(contextSignatureId) ?? contextSignatureId;
     }
 
     public sealed partial class FakeComponentCrudService
     {
+        public Func<int?, int?>? SignatureMetadataIdSource { get; set; }
+
         public async Task<CrudSaveResult> CreateAsync(Component component, ComponentCrudContext context)
         {
             var id = await CreateCoreAsync(component, context).ConfigureAwait(false);
@@ -46,10 +54,10 @@ namespace YasGMP.Models
             return new CrudSaveResult(component.Id, BuildMetadata(context, component.DigitalSignature));
         }
 
-        private static SignatureMetadataDto BuildMetadata(ComponentCrudContext context, string? signature)
+        private SignatureMetadataDto BuildMetadata(ComponentCrudContext context, string? signature)
             => new()
             {
-                Id = context.SignatureId,
+                Id = ResolveMetadataId(context.SignatureId),
                 Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
                 Method = context.SignatureMethod,
                 Status = context.SignatureStatus,
@@ -58,10 +66,15 @@ namespace YasGMP.Models
                 Device = context.DeviceInfo,
                 IpAddress = context.Ip
             };
+
+        private int? ResolveMetadataId(int? contextSignatureId)
+            => SignatureMetadataIdSource?.Invoke(contextSignatureId) ?? contextSignatureId;
     }
 
     public sealed partial class FakeCalibrationCrudService
     {
+        public Func<int?, int?>? SignatureMetadataIdSource { get; set; }
+
         public async Task<CrudSaveResult> CreateAsync(Calibration calibration, CalibrationCrudContext context)
         {
             var id = await CreateCoreAsync(calibration, context).ConfigureAwait(false);
@@ -74,10 +87,10 @@ namespace YasGMP.Models
             return new CrudSaveResult(calibration.Id, BuildMetadata(context, calibration.DigitalSignature));
         }
 
-        private static SignatureMetadataDto BuildMetadata(CalibrationCrudContext context, string? signature)
+        private SignatureMetadataDto BuildMetadata(CalibrationCrudContext context, string? signature)
             => new()
             {
-                Id = context.SignatureId,
+                Id = ResolveMetadataId(context.SignatureId),
                 Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
                 Method = context.SignatureMethod,
                 Status = context.SignatureStatus,
@@ -86,10 +99,15 @@ namespace YasGMP.Models
                 Device = context.DeviceInfo,
                 IpAddress = context.Ip
             };
+
+        private int? ResolveMetadataId(int? contextSignatureId)
+            => SignatureMetadataIdSource?.Invoke(contextSignatureId) ?? contextSignatureId;
     }
 
     public sealed partial class FakeIncidentCrudService
     {
+        public Func<int?, int?>? SignatureMetadataIdSource { get; set; }
+
         public async Task<CrudSaveResult> CreateAsync(Incident incident, IncidentCrudContext context)
         {
             var id = await CreateCoreAsync(incident, context).ConfigureAwait(false);
@@ -102,10 +120,10 @@ namespace YasGMP.Models
             return new CrudSaveResult(incident.Id, BuildMetadata(context, incident.DigitalSignature));
         }
 
-        private static SignatureMetadataDto BuildMetadata(IncidentCrudContext context, string? signature)
+        private SignatureMetadataDto BuildMetadata(IncidentCrudContext context, string? signature)
             => new()
             {
-                Id = context.SignatureId,
+                Id = ResolveMetadataId(context.SignatureId),
                 Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
                 Method = context.SignatureMethod,
                 Status = context.SignatureStatus,
@@ -114,10 +132,15 @@ namespace YasGMP.Models
                 Device = context.DeviceInfo,
                 IpAddress = context.Ip
             };
+
+        private int? ResolveMetadataId(int? contextSignatureId)
+            => SignatureMetadataIdSource?.Invoke(contextSignatureId) ?? contextSignatureId;
     }
 
     public sealed partial class FakeChangeControlCrudService
     {
+        public Func<int?, int?>? SignatureMetadataIdSource { get; set; }
+
         public async Task<CrudSaveResult> CreateAsync(ChangeControl changeControl, ChangeControlCrudContext context)
         {
             var id = await CreateCoreAsync(changeControl, context).ConfigureAwait(false);
@@ -130,10 +153,10 @@ namespace YasGMP.Models
             return new CrudSaveResult(changeControl.Id, BuildMetadata(context, changeControl.DigitalSignature));
         }
 
-        private static SignatureMetadataDto BuildMetadata(ChangeControlCrudContext context, string? signature)
+        private SignatureMetadataDto BuildMetadata(ChangeControlCrudContext context, string? signature)
             => new()
             {
-                Id = context.SignatureId,
+                Id = ResolveMetadataId(context.SignatureId),
                 Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
                 Method = context.SignatureMethod,
                 Status = context.SignatureStatus,
@@ -142,10 +165,15 @@ namespace YasGMP.Models
                 Device = context.DeviceInfo,
                 IpAddress = context.IpAddress
             };
+
+        private int? ResolveMetadataId(int? contextSignatureId)
+            => SignatureMetadataIdSource?.Invoke(contextSignatureId) ?? contextSignatureId;
     }
 
     public sealed partial class FakeCapaCrudService
     {
+        public Func<int?, int?>? SignatureMetadataIdSource { get; set; }
+
         public async Task<CrudSaveResult> CreateAsync(CapaCase capa, CapaCrudContext context)
         {
             var id = await CreateCoreAsync(capa, context).ConfigureAwait(false);
@@ -158,10 +186,10 @@ namespace YasGMP.Models
             return new CrudSaveResult(capa.Id, BuildMetadata(context, capa.DigitalSignature));
         }
 
-        private static SignatureMetadataDto BuildMetadata(CapaCrudContext context, string? signature)
+        private SignatureMetadataDto BuildMetadata(CapaCrudContext context, string? signature)
             => new()
             {
-                Id = context.SignatureId,
+                Id = ResolveMetadataId(context.SignatureId),
                 Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
                 Method = context.SignatureMethod,
                 Status = context.SignatureStatus,
@@ -170,10 +198,15 @@ namespace YasGMP.Models
                 Device = context.DeviceInfo,
                 IpAddress = context.Ip
             };
+
+        private int? ResolveMetadataId(int? contextSignatureId)
+            => SignatureMetadataIdSource?.Invoke(contextSignatureId) ?? contextSignatureId;
     }
 
     public sealed partial class FakeValidationCrudService
     {
+        public Func<int?, int?>? SignatureMetadataIdSource { get; set; }
+
         public async Task<CrudSaveResult> CreateAsync(Validation validation, ValidationCrudContext context)
         {
             var id = await CreateCoreAsync(validation, context).ConfigureAwait(false);
@@ -186,10 +219,10 @@ namespace YasGMP.Models
             return new CrudSaveResult(validation.Id, BuildMetadata(context, validation.DigitalSignature));
         }
 
-        private static SignatureMetadataDto BuildMetadata(ValidationCrudContext context, string? signature)
+        private SignatureMetadataDto BuildMetadata(ValidationCrudContext context, string? signature)
             => new()
             {
-                Id = context.SignatureId,
+                Id = ResolveMetadataId(context.SignatureId),
                 Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
                 Method = context.SignatureMethod,
                 Status = context.SignatureStatus,
@@ -198,10 +231,15 @@ namespace YasGMP.Models
                 Device = context.DeviceInfo,
                 IpAddress = context.Ip
             };
+
+        private int? ResolveMetadataId(int? contextSignatureId)
+            => SignatureMetadataIdSource?.Invoke(contextSignatureId) ?? contextSignatureId;
     }
 
     public sealed partial class FakePartCrudService
     {
+        public Func<int?, int?>? SignatureMetadataIdSource { get; set; }
+
         public async Task<CrudSaveResult> CreateAsync(Part part, PartCrudContext context)
         {
             var id = await CreateCoreAsync(part, context).ConfigureAwait(false);
@@ -214,10 +252,10 @@ namespace YasGMP.Models
             return new CrudSaveResult(part.Id, BuildMetadata(context, part.DigitalSignature));
         }
 
-        private static SignatureMetadataDto BuildMetadata(PartCrudContext context, string? signature)
+        private SignatureMetadataDto BuildMetadata(PartCrudContext context, string? signature)
             => new()
             {
-                Id = context.SignatureId,
+                Id = ResolveMetadataId(context.SignatureId),
                 Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
                 Method = context.SignatureMethod,
                 Status = context.SignatureStatus,
@@ -226,10 +264,15 @@ namespace YasGMP.Models
                 Device = context.DeviceInfo,
                 IpAddress = context.Ip
             };
+
+        private int? ResolveMetadataId(int? contextSignatureId)
+            => SignatureMetadataIdSource?.Invoke(contextSignatureId) ?? contextSignatureId;
     }
 
     public sealed partial class FakeSupplierCrudService
     {
+        public Func<int?, int?>? SignatureMetadataIdSource { get; set; }
+
         public async Task<CrudSaveResult> CreateAsync(Supplier supplier, SupplierCrudContext context)
         {
             var id = await CreateCoreAsync(supplier, context).ConfigureAwait(false);
@@ -242,10 +285,10 @@ namespace YasGMP.Models
             return new CrudSaveResult(supplier.Id, BuildMetadata(context, supplier.DigitalSignature));
         }
 
-        private static SignatureMetadataDto BuildMetadata(SupplierCrudContext context, string? signature)
+        private SignatureMetadataDto BuildMetadata(SupplierCrudContext context, string? signature)
             => new()
             {
-                Id = context.SignatureId,
+                Id = ResolveMetadataId(context.SignatureId),
                 Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
                 Method = context.SignatureMethod,
                 Status = context.SignatureStatus,
@@ -254,10 +297,15 @@ namespace YasGMP.Models
                 Device = context.DeviceInfo,
                 IpAddress = context.Ip
             };
+
+        private int? ResolveMetadataId(int? contextSignatureId)
+            => SignatureMetadataIdSource?.Invoke(contextSignatureId) ?? contextSignatureId;
     }
 
     public sealed partial class FakeWarehouseCrudService
     {
+        public Func<int?, int?>? SignatureMetadataIdSource { get; set; }
+
         public async Task<CrudSaveResult> CreateAsync(Warehouse warehouse, WarehouseCrudContext context)
         {
             var id = await CreateCoreAsync(warehouse, context).ConfigureAwait(false);
@@ -270,10 +318,10 @@ namespace YasGMP.Models
             return new CrudSaveResult(warehouse.Id, BuildMetadata(context, warehouse.DigitalSignature));
         }
 
-        private static SignatureMetadataDto BuildMetadata(WarehouseCrudContext context, string? signature)
+        private SignatureMetadataDto BuildMetadata(WarehouseCrudContext context, string? signature)
             => new()
             {
-                Id = context.SignatureId,
+                Id = ResolveMetadataId(context.SignatureId),
                 Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
                 Method = context.SignatureMethod,
                 Status = context.SignatureStatus,
@@ -282,10 +330,15 @@ namespace YasGMP.Models
                 Device = context.DeviceInfo,
                 IpAddress = context.Ip
             };
+
+        private int? ResolveMetadataId(int? contextSignatureId)
+            => SignatureMetadataIdSource?.Invoke(contextSignatureId) ?? contextSignatureId;
     }
 
     public sealed partial class FakeScheduledJobCrudService
     {
+        public Func<int?, int?>? SignatureMetadataIdSource { get; set; }
+
         public async Task<CrudSaveResult> CreateAsync(ScheduledJob job, ScheduledJobCrudContext context)
         {
             var id = await CreateCoreAsync(job, context).ConfigureAwait(false);
@@ -298,10 +351,10 @@ namespace YasGMP.Models
             return new CrudSaveResult(job.Id, BuildMetadata(context, job.DigitalSignature));
         }
 
-        private static SignatureMetadataDto BuildMetadata(ScheduledJobCrudContext context, string? signature)
+        private SignatureMetadataDto BuildMetadata(ScheduledJobCrudContext context, string? signature)
             => new()
             {
-                Id = context.SignatureId,
+                Id = ResolveMetadataId(context.SignatureId),
                 Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
                 Method = context.SignatureMethod,
                 Status = context.SignatureStatus,
@@ -310,10 +363,15 @@ namespace YasGMP.Models
                 Device = context.DeviceInfo,
                 IpAddress = context.Ip
             };
+
+        private int? ResolveMetadataId(int? contextSignatureId)
+            => SignatureMetadataIdSource?.Invoke(contextSignatureId) ?? contextSignatureId;
     }
 
     public sealed partial class FakeUserCrudService
     {
+        public Func<int?, int?>? SignatureMetadataIdSource { get; set; }
+
         public async Task<CrudSaveResult> CreateAsync(User user, string password, UserCrudContext context)
         {
             var id = await CreateCoreAsync(user, password, context).ConfigureAwait(false);
@@ -326,10 +384,10 @@ namespace YasGMP.Models
             return new CrudSaveResult(user.Id, BuildMetadata(context, user.DigitalSignature));
         }
 
-        private static SignatureMetadataDto BuildMetadata(UserCrudContext context, string? signature)
+        private SignatureMetadataDto BuildMetadata(UserCrudContext context, string? signature)
             => new()
             {
-                Id = context.SignatureId,
+                Id = ResolveMetadataId(context.SignatureId),
                 Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
                 Method = context.SignatureMethod,
                 Status = context.SignatureStatus,
@@ -338,10 +396,15 @@ namespace YasGMP.Models
                 Device = context.DeviceInfo,
                 IpAddress = context.Ip
             };
+
+        private int? ResolveMetadataId(int? contextSignatureId)
+            => SignatureMetadataIdSource?.Invoke(contextSignatureId) ?? contextSignatureId;
     }
 
     public sealed partial class FakeWorkOrderCrudService
     {
+        public Func<int?, int?>? SignatureMetadataIdSource { get; set; }
+
         public async Task<CrudSaveResult> CreateAsync(WorkOrder workOrder, WorkOrderCrudContext context)
         {
             var id = await CreateCoreAsync(workOrder, context).ConfigureAwait(false);
@@ -354,10 +417,10 @@ namespace YasGMP.Models
             return new CrudSaveResult(workOrder.Id, BuildMetadata(context, workOrder.DigitalSignature));
         }
 
-        private static SignatureMetadataDto BuildMetadata(WorkOrderCrudContext context, string? signature)
+        private SignatureMetadataDto BuildMetadata(WorkOrderCrudContext context, string? signature)
             => new()
             {
-                Id = context.SignatureId,
+                Id = ResolveMetadataId(context.SignatureId),
                 Hash = string.IsNullOrWhiteSpace(signature) ? context.SignatureHash : signature,
                 Method = context.SignatureMethod,
                 Status = context.SignatureStatus,
@@ -366,5 +429,8 @@ namespace YasGMP.Models
                 Device = context.DeviceInfo,
                 IpAddress = context.Ip
             };
+
+        private int? ResolveMetadataId(int? contextSignatureId)
+            => SignatureMetadataIdSource?.Invoke(contextSignatureId) ?? contextSignatureId;
     }
 }

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -1,10 +1,10 @@
 # Codex Plan — WPF Shell & Full Integration
 
 ## Current Compile Status
-- [ ] Dotnet SDKs detected and recorded *(blocked: `dotnet` CLI not available in container PATH`; `dotnet --info` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-28, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-04, 2025-11-07, 2025-11-09, and 2025-11-18, 2025-11-19, 2025-11-30, 2025-12-04 → **command not found**)*
-- [ ] Solution restores *(pending SDK availability; `dotnet restore` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, 2025-11-07, 2025-11-09, and 2025-11-18, 2025-11-19, 2025-11-30, 2025-12-04 → **command not found**)*
-- [ ] MAUI builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, 2025-11-07, 2025-11-09, and 2025-11-18, 2025-11-19, 2025-11-30, 2025-12-04 → **command not found**)*
-- [ ] WPF builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, 2025-11-07, 2025-11-09, and 2025-11-18, 2025-11-19, 2025-11-30, 2025-12-04 → **command not found**)*
+- [ ] Dotnet SDKs detected and recorded *(blocked: `dotnet` CLI not available in container PATH`; `dotnet --info` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-28, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-04, 2025-11-07, 2025-11-09, and 2025-11-18, 2025-11-19, 2025-11-30, 2025-12-04, 2025-12-08 → **command not found**)*
+- [ ] Solution restores *(pending SDK availability; `dotnet restore` retried 2025-09-24, 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, 2025-11-07, 2025-11-09, and 2025-11-18, 2025-11-19, 2025-11-30, 2025-12-04, 2025-12-08 → **command not found**)*
+- [ ] MAUI builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, 2025-11-07, 2025-11-09, and 2025-11-18, 2025-11-19, 2025-11-30, 2025-12-04, 2025-12-08 → **command not found**)*
+- [ ] WPF builds *(pending SDK availability; `dotnet build` retried 2025-09-25, 2025-09-26, 2025-09-27, 2025-09-29, 2025-10-14, 2025-10-17, 2025-10-23, 2025-10-24, 2025-10-30, 2025-11-01, 2025-11-02, 2025-11-04, 2025-11-07, 2025-11-09, and 2025-11-18, 2025-11-19, 2025-11-30, 2025-12-04, 2025-12-08 → **command not found**)*
 
 ## Decisions & Pins
 - Preferred WPF target: **net9.0-windows10.0.19041.0** (retain once .NET 9 SDK is installed).
@@ -46,6 +46,7 @@
   fake to retain signature/IP/session metadata, and asserted CrudSaveResult mirrors the persisted entity so regressions surface
   quickly while dotnet CLI access remains blocked.
 - 2025-12-07: External Servicer CRUD fake now records saved snapshots alongside contexts, cleans up deleted entries, and confirms CrudSaveResult metadata still flows from the provided context; attempted dotnet restore/build/smoke remain blocked because the CLI is still missing in the container.
+- 2025-12-08: Test signature dialog now tracks captured results/persist invocations, CRUD fakes accept configurable signature-id providers to mirror adapter-assigned identifiers, and module regression tests assert returned ids skip redundant persistence while the dotnet CLI remains unavailable.
 - 2025-12-06: Security persistence now writes `digital_signature`/`last_change_signature` along with IP/device/session metadata via DatabaseService.Users extensions, and new UserCrudServiceAdapter tests assert the context and signatures persist end-to-end while the dotnet CLI gap continues to block restore/build.
 - 2025-12-04: Validation persistence now writes `source_ip`/`session_id` on insert/update and ValidationService unit tests assert the metadata survives adapter calls; dotnet CLI still missing so restore/build/test remain blocked.
 - 2025-12-01: Change Control schema/service now persist digital signature hash plus IP/session/device context so adapter metadata flows through unchanged; database scripts updated accordingly while CLI validation remains blocked.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -27,7 +27,8 @@
       "2025-11-19: dotnet restore/build retried; CLI remains unavailable in the container so commands exit with 'command not found'.",
       "2025-11-30: dotnet restore retried; CLI still missing so commands exit with \"command not found\".",
       "2025-12-04: dotnet --info/restore/build retried; CLI remains unavailable in the container so commands exit with 'command not found'.",
-      "2025-12-07: dotnet restore/build attempted again for yasgmp.sln; CLI still missing in container so commands exit with 'command not found'."
+      "2025-12-07: dotnet restore/build attempted again for yasgmp.sln; CLI still missing in container so commands exit with 'command not found'.",
+      "2025-12-08: dotnet --version/restore/build retried; CLI still missing in container so commands exit with 'command not found'."
     ]
   },
   "batches": [
@@ -57,7 +58,8 @@
         "WPF test harness now uses a RecordingAuditService spy so Work Orders save and attachment flows assert audit payloads with signer context while the dotnet CLI remains unavailable.",
         "Module save flows now rehydrate adapter-provided signature ids/hashes before optional persistence, skipping redundant dialog writes when a signature already exists while preserving current UX messaging.",
         "ValidationService now keeps adapter-supplied validation signature hashes intact on create/update and only regenerates when explicitly forced (e.g., MarkExecuted), with new unit coverage confirming the stored hash matches the adapter payload.",
-        "WPF ValidationCrudServiceAdapter test now asserts signature hash/IP/session context persist alongside CrudSaveResult metadata, and validation CRUD fakes retain those fields for downstream assertions while CLI validation stays blocked."
+        "WPF ValidationCrudServiceAdapter test now asserts signature hash/IP/session context persist alongside CrudSaveResult metadata, and validation CRUD fakes retain those fields for downstream assertions while CLI validation stays blocked.",
+        "Test signature dialog now records capture results and persist calls, CRUD fakes expose configurable signature id providers, and module regression tests assert adapter-assigned ids skip redundant persistence while CLI validation remains blocked."
       ]
     },
     {
@@ -88,7 +90,7 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "test: track external servicer snapshots",
+  "lastCommitSummary": "test: honor adapter-provided signature ids",
   "notes": [
     "2025-12-07: External Servicer CRUD fake now mirrors other module doubles by capturing saved snapshots with contexts, cloning entities for assertions, and clearing deleted entries; CrudSaveResult coverage confirms metadata still flows from the provided context while dotnet CLI access remains blocked for restore/build/smoke.",
     "2025-12-06: DatabaseService.Users insert/update now persist digital_signature/last_change_signature with IP/device/session metadata, and new UserCrudServiceAdapter tests verify the context flows end-to-end while the dotnet CLI remains unavailable for restore/build/test.",
@@ -170,6 +172,7 @@
     "2025-11-27: Module save flows now rehydrate adapter-supplied signature metadata and skip redundant dialog persistence when ids are present so the stored record matches the UX status messaging.",
     "2025-11-28: Introduced a shared CrudSaveResult record so adapters can return the persisted identifier together with signature metadata, keeping downstream editors and audit logging aligned once saves complete.",
     "2025-11-29: CRUD service interfaces, adapters, module view-models, and WPF test doubles now return/consume CrudSaveResult so save flows refresh ids and expose signature metadata with regression coverage validating the new payload.",
-    "2025-11-30: Assets save flow now applies CrudSaveResult digital signature ids immediately after persistence and removes the stale OnRecordSelected signature block; dotnet restore/build remain blocked by missing CLI."
+    "2025-11-30: Assets save flow now applies CrudSaveResult digital signature ids immediately after persistence and removes the stale OnRecordSelected signature block; dotnet restore/build remain blocked by missing CLI.",
+    "2025-12-08: Test signature dialog now tracks captured results/persist invocations, CRUD fakes accept configurable signature id providers, and module tests assert adapter ids while dotnet CLI remains unavailable."
   ]
 }


### PR DESCRIPTION
## Summary
- update the electronic signature dialog test double to capture returned results, respect pre-populated ids, and track persistence calls
- let all CRUD fakes (including external servicers) supply adapter-defined signature metadata ids so tests can mimic database-issued values
- adjust module regression tests to seed adapter signature ids, assert captured ids and success messaging, and confirm persistence skips when ids are present

## Testing
- `dotnet --version` *(fails: command not found in container)*
- `dotnet restore` *(fails: command not found in container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence) — blocked by missing dotnet CLI
- [ ] MAUI builds/runs unaffected — blocked by missing dotnet CLI
- [ ] Shared AppCore extraction complete where required; adapters compiled — unchanged this batch
- [ ] ModulesPane lists every module and opens feature-parity editors — unchanged this batch
- [ ] B1 FormModes & command enablement wired across editors — unchanged this batch
- [ ] CFL pickers + Golden Arrow navigation working — unchanged this batch
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end — unchanged this batch
- [ ] Warehouse ledger with running balance and alerts — unchanged this batch
- [ ] Audit surfacing + e-signature prompts on critical saves — incremental e-signature coverage reinforced; audit surfacing still pending SDK access
- [ ] Attachments DB-backed with upload/preview/download — unchanged this batch
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented — unchanged this batch
- [ ] Smoke tests succeed and log output — blocked by missing dotnet CLI
- [ ] README_WPF_SHELL.md and /docs/WPF_MAPPING.md kept current — unchanged this batch


------
https://chatgpt.com/codex/tasks/task_e_68dd12cb57f48331b3193da978e66aa9