### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.AppCore/Models/DTO/ApiAuditEntryDto.cs
+++ b/YasGMP.AppCore/Models/DTO/ApiAuditEntryDto.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace YasGMP.Models.DTO
+{
+    /// <summary>
+    /// <b>ApiAuditEntryDto</b> – Strongly typed projection of <c>api_audit_log</c> rows enriched
+    /// with API key metadata and user information so the WPF shell can surface forensic details
+    /// without dynamic dictionaries.
+    /// <para>
+    /// Includes masked API key display helpers, owner/user context, timestamps, IP address, and
+    /// request/response payloads for downstream filtering and inspector views.
+    /// </para>
+    /// </summary>
+    public class ApiAuditEntryDto
+    {
+        /// <summary>Primary key of the <c>api_audit_log</c> record.</summary>
+        public int Id { get; set; }
+
+        /// <summary>Foreign key referencing <c>api_keys.id</c>.</summary>
+        public int? ApiKeyId { get; set; }
+
+        /// <summary>Raw API key value (never display directly – use <see cref="MaskedApiKey"/>).</summary>
+        [Display(Name = "API Key (raw)")]
+        public string? ApiKeyValue { get; set; }
+
+        /// <summary>Description or label attached to the API key.</summary>
+        [Display(Name = "Key Description")]
+        public string? ApiKeyDescription { get; set; }
+
+        /// <summary>Whether the linked API key is active.</summary>
+        [Display(Name = "Key Active")]
+        public bool? ApiKeyIsActive { get; set; }
+
+        /// <summary>UTC timestamp the API key was created.</summary>
+        [Display(Name = "Key Created")]
+        public DateTime? ApiKeyCreatedAt { get; set; }
+
+        /// <summary>UTC timestamp the API key record was last updated.</summary>
+        [Display(Name = "Key Updated")]
+        public DateTime? ApiKeyUpdatedAt { get; set; }
+
+        /// <summary>UTC timestamp the API key was last used.</summary>
+        [Display(Name = "Key Last Used")]
+        public DateTime? ApiKeyLastUsedAt { get; set; }
+
+        /// <summary>Owner id from <c>api_keys.owner_id</c> when populated.</summary>
+        [Display(Name = "Key Owner Id")]
+        public int? ApiKeyOwnerId { get; set; }
+
+        /// <summary>Username of the API key owner, when resolvable.</summary>
+        [Display(Name = "Key Owner Username")]
+        public string? ApiKeyOwnerUsername { get; set; }
+
+        /// <summary>Full name of the API key owner, when resolvable.</summary>
+        [Display(Name = "Key Owner Name")]
+        public string? ApiKeyOwnerFullName { get; set; }
+
+        /// <summary>User id recorded on the audit entry.</summary>
+        [Display(Name = "User Id")]
+        public int? UserId { get; set; }
+
+        /// <summary>Username associated with the audit entry.</summary>
+        [Display(Name = "Username")]
+        public string? Username { get; set; }
+
+        /// <summary>Full name for the user associated with the audit entry.</summary>
+        [Display(Name = "User Full Name")]
+        public string? UserFullName { get; set; }
+
+        /// <summary>Action/endpoint captured by the audit entry (e.g., HTTP verb + resource).</summary>
+        [Display(Name = "Action")]
+        public string? Action { get; set; }
+
+        /// <summary>Primary timestamp for the audit entry (UTC).</summary>
+        [Display(Name = "Timestamp")]
+        public DateTime? Timestamp { get; set; }
+
+        /// <summary>Creation timestamp recorded by the table (UTC).</summary>
+        [Display(Name = "Created At")]
+        public DateTime? CreatedAt { get; set; }
+
+        /// <summary>Update timestamp recorded by the table (UTC).</summary>
+        [Display(Name = "Updated At")]
+        public DateTime? UpdatedAt { get; set; }
+
+        /// <summary>IP address captured for the request.</summary>
+        [Display(Name = "IP Address")]
+        public string? IpAddress { get; set; }
+
+        /// <summary>Serialized request payload or metadata (JSON, query string, etc.).</summary>
+        [Display(Name = "Request Details")]
+        public string? RequestDetails { get; set; }
+
+        /// <summary>Additional detail payload (response summary, exception, etc.).</summary>
+        [Display(Name = "Details")]
+        public string? Details { get; set; }
+
+        /// <summary>Optional extended metadata (headers, correlation ids, etc.).</summary>
+        [Display(Name = "Extra Metadata")]
+        public IDictionary<string, string>? Metadata { get; set; }
+
+        /// <summary>Derived helper exposing the masked API key (all but last four hidden).</summary>
+        [Display(Name = "API Key")]
+        public string MaskedApiKey => MaskSensitiveValue(ApiKeyValue);
+
+        /// <summary>Last four alphanumeric characters of the key, when available.</summary>
+        public string? ApiKeyLastFour
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(ApiKeyValue))
+                {
+                    return null;
+                }
+
+                var trimmed = ApiKeyValue.Trim();
+                var buffer = new List<char>();
+                for (int i = trimmed.Length - 1; i >= 0 && buffer.Count < 4; i--)
+                {
+                    if (char.IsLetterOrDigit(trimmed[i]))
+                    {
+                        buffer.Insert(0, trimmed[i]);
+                    }
+                }
+
+                return buffer.Count == 0 ? null : new string(buffer.ToArray());
+            }
+        }
+
+        /// <summary>Display label combining masked key, description, and identifier.</summary>
+        public string ApiKeyDisplayLabel
+        {
+            get
+            {
+                var segments = new List<string>();
+                var masked = MaskedApiKey;
+                if (!string.IsNullOrWhiteSpace(masked))
+                {
+                    segments.Add(masked);
+                }
+
+                if (!string.IsNullOrWhiteSpace(ApiKeyDescription))
+                {
+                    segments.Add(ApiKeyDescription!.Trim());
+                }
+
+                if (ApiKeyId.HasValue)
+                {
+                    segments.Add($"#{ApiKeyId.Value}");
+                }
+
+                return segments.Count == 0 ? "Unknown API Key" : string.Join(" · ", segments);
+            }
+        }
+
+        /// <summary>Display helper for the associated user (username + id when available).</summary>
+        public string UserDisplay
+        {
+            get
+            {
+                var name = !string.IsNullOrWhiteSpace(Username)
+                    ? Username!
+                    : UserId?.ToString() ?? "-";
+
+                if (UserId.HasValue && !string.IsNullOrWhiteSpace(Username))
+                {
+                    return $"{Username} (#{UserId.Value})";
+                }
+
+                if (!string.IsNullOrWhiteSpace(UserFullName))
+                {
+                    return $"{UserFullName} [{name}]";
+                }
+
+                return name;
+            }
+        }
+
+        /// <summary>Owner display helper combining username, name, and id.</summary>
+        public string OwnerDisplay
+        {
+            get
+            {
+                if (!ApiKeyOwnerId.HasValue && string.IsNullOrWhiteSpace(ApiKeyOwnerUsername) && string.IsNullOrWhiteSpace(ApiKeyOwnerFullName))
+                {
+                    return "-";
+                }
+
+                var label = ApiKeyOwnerUsername;
+                if (!string.IsNullOrWhiteSpace(ApiKeyOwnerFullName))
+                {
+                    label = string.IsNullOrWhiteSpace(ApiKeyOwnerUsername)
+                        ? ApiKeyOwnerFullName
+                        : $"{ApiKeyOwnerFullName} [{ApiKeyOwnerUsername}]";
+                }
+
+                if (ApiKeyOwnerId.HasValue)
+                {
+                    label = string.IsNullOrWhiteSpace(label)
+                        ? $"#{ApiKeyOwnerId.Value}"
+                        : $"{label} (#{ApiKeyOwnerId.Value})";
+                }
+
+                return label ?? "-";
+            }
+        }
+
+        /// <summary>Best-effort timestamp for display (prefers <see cref="Timestamp"/> then fallbacks).</summary>
+        public DateTime? EffectiveTimestamp => Timestamp ?? CreatedAt ?? UpdatedAt;
+
+        private static string MaskSensitiveValue(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            var trimmed = value.Trim();
+            var chars = trimmed.ToCharArray();
+            var alphanumericCount = 0;
+
+            for (int i = chars.Length - 1; i >= 0; i--)
+            {
+                if (!char.IsLetterOrDigit(chars[i]))
+                {
+                    continue;
+                }
+
+                alphanumericCount++;
+                if (alphanumericCount > 4)
+                {
+                    chars[i] = '•';
+                }
+            }
+
+            var masked = new string(chars);
+            if (alphanumericCount <= 4)
+            {
+                var prefix = new string('•', Math.Max(0, 4 - alphanumericCount));
+                return prefix + masked;
+            }
+
+            return masked;
+        }
+    }
+}

--- a/YasGMP.Wpf.Tests/ApiAuditModuleViewModelTests.cs
+++ b/YasGMP.Wpf.Tests/ApiAuditModuleViewModelTests.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using YasGMP.Models.DTO;
+using YasGMP.Services;
+using YasGMP.Wpf.Services;
+using YasGMP.Wpf.ViewModels.Modules;
+
+namespace YasGMP.Wpf.Tests;
+
+public class ApiAuditModuleViewModelTests
+{
+    [Fact]
+    public async Task InitializeAsync_LoadsApiAuditEntries_WithInspectorDetails()
+    {
+        var database = CreateDatabaseService();
+        var auditService = new AuditService(database);
+        var cfl = new StubCflDialogService();
+        var shell = new StubShellInteractionService();
+        var navigation = new StubModuleNavigationService();
+
+        var timestamp = new DateTime(2025, 2, 15, 8, 30, 0, DateTimeKind.Utc);
+        var entries = new[]
+        {
+            new ApiAuditEntryDto
+            {
+                Id = 5,
+                ApiKeyId = 12,
+                ApiKeyValue = "INT-PRIMARY-KEY-0001",
+                ApiKeyDescription = "Integration Primary",
+                ApiKeyOwnerUsername = "integration.bot",
+                ApiKeyOwnerFullName = "Integration Bot",
+                ApiKeyIsActive = true,
+                Action = "POST /api/v1/assets",
+                Timestamp = timestamp,
+                Username = "integration.bot",
+                UserId = 88,
+                IpAddress = "198.51.100.15",
+                RequestDetails = "{\"asset\":\"A-100\"}",
+                Details = "HTTP 201 Created"
+            }
+        };
+
+        var viewModel = new TestApiAuditModuleViewModel(database, auditService, cfl, shell, navigation, entries);
+        viewModel.FilterApiKey = "INT";
+        viewModel.FilterUser = "integration";
+        viewModel.SelectedAction = "POST /api/v1/assets";
+        viewModel.FilterFrom = timestamp.Date;
+        viewModel.FilterTo = timestamp.Date;
+
+        await viewModel.RefreshAsync();
+
+        Assert.Single(viewModel.Records);
+        var record = viewModel.Records.First();
+        Assert.Equal("POST /api/v1/assets", record.Code);
+        Assert.Contains("#12", record.Title);
+        Assert.Contains("•", record.Title);
+        Assert.Equal("integration.bot (#88)", record.InspectorFields[2].Value);
+        Assert.Equal("198.51.100.15", record.InspectorFields[3].Value);
+        Assert.Equal("{\"asset\":\"A-100\"}", record.InspectorFields[4].Value);
+        Assert.Equal("HTTP 201 Created", record.Description);
+        Assert.Equal("Loaded 1 API audit entry.", viewModel.StatusMessage);
+        Assert.True(viewModel.HasResults);
+        Assert.False(viewModel.HasError);
+        Assert.Equal("INT", viewModel.LastApiKeyFilter);
+        Assert.Equal("integration", viewModel.LastUserFilter);
+        Assert.Equal("POST /api/v1/assets", viewModel.LastActionFilter);
+        Assert.Equal(timestamp.Date, viewModel.LastFromFilter);
+        Assert.Equal(timestamp.Date.AddDays(1).AddTicks(-1), viewModel.LastToFilter);
+        Assert.Contains("POST /api/v1/assets", viewModel.ActionOptions);
+        Assert.Equal("All", viewModel.ActionOptions.First());
+    }
+
+    [Fact]
+    public async Task RefreshAsync_NoEntries_SetsEmptyStatusMessageAndMaintainsAllOption()
+    {
+        var database = CreateDatabaseService();
+        var auditService = new AuditService(database);
+        var cfl = new StubCflDialogService();
+        var shell = new StubShellInteractionService();
+        var navigation = new StubModuleNavigationService();
+
+        var viewModel = new TestApiAuditModuleViewModel(database, auditService, cfl, shell, navigation, Array.Empty<ApiAuditEntryDto>());
+        viewModel.SelectedAction = "DELETE";
+
+        await viewModel.RefreshAsync();
+
+        Assert.Empty(viewModel.Records);
+        Assert.Equal("No API audit entries match the current filters.", viewModel.StatusMessage);
+        Assert.False(viewModel.HasResults);
+        Assert.False(viewModel.HasError);
+        Assert.Single(viewModel.ActionOptions);
+        Assert.Equal("All", viewModel.ActionOptions.First());
+    }
+
+    [Fact]
+    public async Task RefreshAsync_WhenQueryThrows_LoadsDesignTimeRecordsAndFlagsError()
+    {
+        var database = CreateDatabaseService();
+        var auditService = new AuditService(database);
+        var cfl = new StubCflDialogService();
+        var shell = new StubShellInteractionService();
+        var navigation = new StubModuleNavigationService();
+
+        var exception = new InvalidOperationException("forced failure");
+        var viewModel = new ThrowingApiAuditModuleViewModel(database, auditService, cfl, shell, navigation, exception);
+
+        await viewModel.RefreshAsync();
+
+        Assert.True(viewModel.HasError);
+        Assert.NotEmpty(viewModel.Records);
+        Assert.StartsWith("Offline data loaded because:", viewModel.StatusMessage);
+        Assert.Contains("forced failure", viewModel.StatusMessage);
+    }
+
+    [Fact]
+    public async Task SearchText_FiltersResultsByInspectorValues()
+    {
+        var database = CreateDatabaseService();
+        var auditService = new AuditService(database);
+        var cfl = new StubCflDialogService();
+        var shell = new StubShellInteractionService();
+        var navigation = new StubModuleNavigationService();
+
+        var entries = new[]
+        {
+            new ApiAuditEntryDto
+            {
+                Id = 10,
+                ApiKeyId = 20,
+                ApiKeyValue = "REPORTING-KEY-0002",
+                ApiKeyDescription = "Reporting",
+                Action = "GET /api/v1/audit",
+                Timestamp = DateTime.UtcNow,
+                Username = "qa.viewer",
+                UserId = 21,
+                IpAddress = "203.0.113.20",
+                RequestDetails = "{\"filter\":\"status=OK\"}",
+                Details = "HTTP 200 OK"
+            },
+            new ApiAuditEntryDto
+            {
+                Id = 11,
+                ApiKeyId = 21,
+                ApiKeyValue = "SERVICE-KEY-9999",
+                ApiKeyDescription = "Service",
+                Action = "DELETE /api/v1/assets/99",
+                Timestamp = DateTime.UtcNow,
+                Username = "service.bot",
+                UserId = 99,
+                IpAddress = "198.51.100.55",
+                RequestDetails = "{\"asset\":\"A-200\"}",
+                Details = "HTTP 401 Unauthorized"
+            }
+        };
+
+        var viewModel = new TestApiAuditModuleViewModel(database, auditService, cfl, shell, navigation, entries);
+        await viewModel.RefreshAsync();
+
+        viewModel.SearchText = "status=OK";
+        var filtered = viewModel.RecordsView.Cast<ModuleRecord>().ToList();
+
+        Assert.Single(filtered);
+        Assert.Equal("GET /api/v1/audit", filtered[0].Code);
+    }
+
+    private static DatabaseService CreateDatabaseService()
+        => new("Server=localhost;Database=unit_test;Uid=test;Pwd=test;");
+
+    private sealed class TestApiAuditModuleViewModel : ApiAuditModuleViewModel
+    {
+        private readonly IReadOnlyList<ApiAuditEntryDto> _entries;
+
+        public TestApiAuditModuleViewModel(
+            DatabaseService databaseService,
+            AuditService auditService,
+            ICflDialogService cflDialogService,
+            IShellInteractionService shellInteraction,
+            IModuleNavigationService navigation,
+            IReadOnlyList<ApiAuditEntryDto> entries)
+            : base(databaseService, auditService, cflDialogService, shellInteraction, navigation)
+        {
+            _entries = entries;
+        }
+
+        public string? LastApiKeyFilter { get; private set; }
+        public string? LastUserFilter { get; private set; }
+        public string? LastActionFilter { get; private set; }
+        public DateTime LastFromFilter { get; private set; }
+        public DateTime LastToFilter { get; private set; }
+
+        protected override Task<IReadOnlyList<ApiAuditEntryDto>> QueryApiAuditsAsync(
+            string apiKey,
+            string user,
+            string action,
+            DateTime from,
+            DateTime to,
+            int limit)
+        {
+            LastApiKeyFilter = apiKey;
+            LastUserFilter = user;
+            LastActionFilter = action;
+            LastFromFilter = from;
+            LastToFilter = to;
+            return Task.FromResult(_entries);
+        }
+    }
+
+    private sealed class ThrowingApiAuditModuleViewModel : ApiAuditModuleViewModel
+    {
+        private readonly Exception _exception;
+
+        public ThrowingApiAuditModuleViewModel(
+            DatabaseService databaseService,
+            AuditService auditService,
+            ICflDialogService cflDialogService,
+            IShellInteractionService shellInteraction,
+            IModuleNavigationService navigation,
+            Exception exception)
+            : base(databaseService, auditService, cflDialogService, shellInteraction, navigation)
+        {
+            _exception = exception;
+        }
+
+        protected override Task<IReadOnlyList<ApiAuditEntryDto>> QueryApiAuditsAsync(
+            string apiKey,
+            string user,
+            string action,
+            DateTime from,
+            DateTime to,
+            int limit)
+            => Task.FromException<IReadOnlyList<ApiAuditEntryDto>>(_exception);
+    }
+
+    private sealed class StubCflDialogService : ICflDialogService
+    {
+        public Task<CflResult?> ShowAsync(CflRequest request) => Task.FromResult<CflResult?>(null);
+    }
+
+    private sealed class StubShellInteractionService : IShellInteractionService
+    {
+        public void UpdateStatus(string message) { }
+
+        public void UpdateInspector(InspectorContext context) { }
+    }
+
+    private sealed class StubModuleNavigationService : IModuleNavigationService
+    {
+        public ModuleDocumentViewModel OpenModule(string moduleKey, object? parameter = null)
+            => throw new NotSupportedException();
+
+        public void Activate(ModuleDocumentViewModel document) { }
+    }
+}

--- a/YasGMP.Wpf.Tests/ServiceRegistrationTests.cs
+++ b/YasGMP.Wpf.Tests/ServiceRegistrationTests.cs
@@ -62,6 +62,33 @@ public class ServiceRegistrationTests
         Assert.NotNull(viewModel);
     }
 
+    [Fact]
+    public void WpfShellServices_ResolveApiAuditModuleViewModel()
+    {
+        const string connection = "Server=localhost;Database=unit_test;Uid=test;Pwd=test;";
+        var services = new ServiceCollection();
+
+        services.AddYasGmpCoreServices(core =>
+        {
+            core.UseConnectionString(connection);
+            core.UseDatabaseService<DatabaseService>((_, conn) => new DatabaseService(conn));
+
+            var svc = core.Services;
+            svc.AddSingleton<AuditService>();
+            svc.AddSingleton<ICflDialogService, StubCflDialogService>();
+            svc.AddSingleton<IShellInteractionService, StubShellInteractionService>();
+            svc.AddSingleton<IModuleNavigationService, StubModuleNavigationService>();
+            svc.AddTransient<ApiAuditModuleViewModel>();
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var descriptor = services.Single(d => d.ServiceType == typeof(AuditService));
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+
+        var viewModel = provider.GetRequiredService<ApiAuditModuleViewModel>();
+        Assert.NotNull(viewModel);
+    }
+
     private sealed class StubCflDialogService : ICflDialogService
     {
         public Task<CflResult?> ShowAsync(CflRequest request) => Task.FromResult<CflResult?>(null);

--- a/YasGMP.Wpf/App.xaml
+++ b/YasGMP.Wpf/App.xaml
@@ -54,6 +54,9 @@
         <DataTemplate DataType="{x:Type vm:AuditModuleViewModel}">
             <views:AuditModuleView />
         </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:ApiAuditModuleViewModel}">
+            <views:ApiAuditModuleView />
+        </DataTemplate>
         <DataTemplate DataType="{x:Type vm:AttachmentsModuleViewModel}">
             <views:AttachmentsModuleView />
         </DataTemplate>

--- a/YasGMP.Wpf/App.xaml.cs
+++ b/YasGMP.Wpf/App.xaml.cs
@@ -118,6 +118,7 @@ namespace YasGMP.Wpf
                         svc.AddTransient<SecurityModuleViewModel>();
                         svc.AddTransient<AdminModuleViewModel>();
                         svc.AddTransient<AuditModuleViewModel>();
+                        svc.AddTransient<ApiAuditModuleViewModel>();
                         svc.AddTransient<DiagnosticsModuleViewModel>();
                         svc.AddTransient<AttachmentsModuleViewModel>();
 
@@ -141,6 +142,7 @@ namespace YasGMP.Wpf
                             registry.Register<SecurityModuleViewModel>(SecurityModuleViewModel.ModuleKey, "Security", "Administration", "Users and security roles");
                             registry.Register<AdminModuleViewModel>(AdminModuleViewModel.ModuleKey, "Administration", "Administration", "Global configuration settings");
                             registry.Register<AuditModuleViewModel>(AuditModuleViewModel.ModuleKey, "Audit Trail", "Compliance", "System event history");
+                            registry.Register<ApiAuditModuleViewModel>(ApiAuditModuleViewModel.ModuleKey, "API Audit Trail", "Compliance", "API key activity history and forensic request payloads");
                             registry.Register<DiagnosticsModuleViewModel>(DiagnosticsModuleViewModel.ModuleKey, "Diagnostics", "Diagnostics", "Telemetry snapshots and health checks");
                             registry.Register<AttachmentsModuleViewModel>(AttachmentsModuleViewModel.ModuleKey, "Attachments", "Documents", "File attachments and certificates");
                             return registry;

--- a/YasGMP.Wpf/Services/DebugSmokeTestService.cs
+++ b/YasGMP.Wpf/Services/DebugSmokeTestService.cs
@@ -33,6 +33,7 @@ public sealed class DebugSmokeTestService
         ExternalServicersModuleViewModel.ModuleKey,
         WorkOrdersModuleViewModel.ModuleKey,
         AuditModuleViewModel.ModuleKey,
+        ApiAuditModuleViewModel.ModuleKey,
         ValidationsModuleViewModel.ModuleKey
     };
 

--- a/YasGMP.Wpf/ViewModels/Modules/ApiAuditModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/ApiAuditModuleViewModel.cs
@@ -1,0 +1,265 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using YasGMP.Models.DTO;
+using YasGMP.Services;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.ViewModels.Modules;
+
+public sealed partial class ApiAuditModuleViewModel : DataDrivenModuleDocumentViewModel
+{
+    public const string ModuleKey = "ApiAudit";
+    private const int DefaultResultLimit = 500;
+
+    public ApiAuditModuleViewModel(
+        DatabaseService databaseService,
+        AuditService auditService,
+        ICflDialogService cflDialogService,
+        IShellInteractionService shellInteraction,
+        IModuleNavigationService navigation)
+        : base(ModuleKey, "API Audit Trail", databaseService, cflDialogService, shellInteraction, navigation, auditService)
+    {
+        _auditService = auditService ?? throw new ArgumentNullException(nameof(auditService));
+
+        _actionOptions = new ObservableCollection<string>();
+        ActionOptions = new ReadOnlyObservableCollection<string>(_actionOptions);
+        _actionOptions.Add("All");
+
+        FilterFrom = DateTime.Today.AddDays(-30);
+        FilterTo = DateTime.Today;
+        SelectedAction = _actionOptions.First();
+    }
+
+    public ReadOnlyObservableCollection<string> ActionOptions { get; }
+
+    [ObservableProperty]
+    private string? _filterApiKey;
+
+    [ObservableProperty]
+    private string? _filterUser;
+
+    [ObservableProperty]
+    private string? _selectedAction;
+
+    [ObservableProperty]
+    private DateTime? _filterFrom;
+
+    [ObservableProperty]
+    private DateTime? _filterTo;
+
+    [ObservableProperty]
+    private bool _hasResults;
+
+    [ObservableProperty]
+    private bool _hasError;
+
+    private readonly AuditService _auditService;
+    private readonly ObservableCollection<string> _actionOptions;
+
+    protected override async Task<IReadOnlyList<ModuleRecord>> LoadAsync(object? parameter)
+    {
+        var normalized = NormalizeDateRange(FilterFrom, FilterTo);
+        FilterFrom = normalized.FilterFrom;
+        FilterTo = normalized.FilterTo;
+
+        var apiKeyFilter = FilterApiKey?.Trim() ?? string.Empty;
+        var userFilter = FilterUser?.Trim() ?? string.Empty;
+        var actionFilter = string.IsNullOrWhiteSpace(SelectedAction) || string.Equals(SelectedAction, "All", StringComparison.OrdinalIgnoreCase)
+            ? string.Empty
+            : SelectedAction!.Trim();
+
+        try
+        {
+            var entries = await QueryApiAuditsAsync(
+                    apiKeyFilter,
+                    userFilter,
+                    actionFilter,
+                    normalized.QueryFrom,
+                    normalized.QueryTo,
+                    DefaultResultLimit)
+                .ConfigureAwait(false);
+
+            var list = entries?.ToList() ?? new List<ApiAuditEntryDto>();
+            UpdateActionOptions(list);
+
+            var records = list.Select(MapToRecord).ToList();
+            HasResults = records.Count > 0;
+            HasError = false;
+
+            return ToReadOnlyList(records);
+        }
+        catch
+        {
+            HasResults = false;
+            HasError = true;
+            throw;
+        }
+    }
+
+    protected override IReadOnlyList<ModuleRecord> CreateDesignTimeRecords()
+        => new List<ModuleRecord>
+        {
+            MapToRecord(new ApiAuditEntryDto
+            {
+                Id = 1,
+                ApiKeyId = 101,
+                ApiKeyValue = "INT-PRIMARY-KEY-0001",
+                ApiKeyDescription = "Integration Primary Key",
+                ApiKeyOwnerUsername = "integration.bot",
+                ApiKeyOwnerFullName = "Integration Bot",
+                ApiKeyIsActive = true,
+                Action = "POST /api/v1/assets",
+                Timestamp = DateTime.UtcNow.AddMinutes(-15),
+                Username = "integration.bot",
+                UserId = 42,
+                IpAddress = "198.51.100.12",
+                RequestDetails = "{\"asset\":\"A-100\",\"action\":\"create\"}",
+                Details = "HTTP 201 Created"
+            }),
+            MapToRecord(new ApiAuditEntryDto
+            {
+                Id = 2,
+                ApiKeyId = 102,
+                ApiKeyValue = "QA-REPORTING-KEY-88",
+                ApiKeyDescription = "QA Reporting",
+                ApiKeyOwnerUsername = "qa.service",
+                ApiKeyOwnerFullName = "QA Reporting Service",
+                ApiKeyIsActive = false,
+                Action = "GET /api/v1/audit/export",
+                Timestamp = DateTime.UtcNow.AddHours(-2),
+                Username = "qa.viewer",
+                UserId = 77,
+                IpAddress = "203.0.113.44",
+                RequestDetails = "{\"action\":\"export\",\"format\":\"csv\"}",
+                Details = "HTTP 403 Forbidden"
+            })
+        };
+
+    protected override string FormatLoadedStatus(int count)
+        => count switch
+        {
+            <= 0 => "No API audit entries match the current filters.",
+            1 => "Loaded 1 API audit entry.",
+            _ => $"Loaded {count} API audit entries."
+        };
+
+    protected override bool MatchesSearch(ModuleRecord record, string searchText)
+        => base.MatchesSearch(record, searchText)
+           || record.InspectorFields.Any(field =>
+               field.Value?.IndexOf(searchText, StringComparison.OrdinalIgnoreCase) >= 0);
+
+    protected virtual Task<IReadOnlyList<ApiAuditEntryDto>> QueryApiAuditsAsync(
+        string apiKey,
+        string user,
+        string action,
+        DateTime from,
+        DateTime to,
+        int limit)
+        => _auditService.GetApiAuditEntriesAsync(apiKey, user, action, from, to, limit);
+
+    private ModuleRecord MapToRecord(ApiAuditEntryDto entry)
+    {
+        var timestamp = entry.EffectiveTimestamp?.ToLocalTime().ToString("g", CultureInfo.CurrentCulture) ?? string.Empty;
+        var userDisplay = entry.UserDisplay;
+        var ownerDisplay = entry.OwnerDisplay;
+        var keyStatus = entry.ApiKeyIsActive.HasValue
+            ? (entry.ApiKeyIsActive.Value ? "Active" : "Disabled")
+            : string.Empty;
+
+        var inspector = new List<InspectorField>
+        {
+            new("Timestamp", timestamp),
+            new("API Key", entry.ApiKeyDisplayLabel),
+            new("User", userDisplay),
+            new("IP Address", entry.IpAddress ?? string.Empty),
+            new("Request Payload", entry.RequestDetails ?? string.Empty),
+            new("Details", entry.Details ?? string.Empty),
+            new("Owner", ownerDisplay),
+            new("Key Status", keyStatus),
+            new("Key Created", FormatDate(entry.ApiKeyCreatedAt)),
+            new("Key Updated", FormatDate(entry.ApiKeyUpdatedAt)),
+            new("Key Last Used", FormatDate(entry.ApiKeyLastUsedAt))
+        };
+
+        var key = entry.Id != 0
+            ? entry.Id.ToString(CultureInfo.InvariantCulture)
+            : $"{entry.EffectiveTimestamp:O}|{entry.ApiKeyId}|{entry.Action}";
+
+        var status = keyStatus.Length > 0 ? keyStatus : null;
+
+        return new ModuleRecord(
+            key,
+            entry.ApiKeyDisplayLabel,
+            entry.Action,
+            status,
+            entry.Details ?? string.Empty,
+            inspector);
+    }
+
+    private void UpdateActionOptions(IReadOnlyList<ApiAuditEntryDto> entries)
+    {
+        var desired = new List<string> { "All" };
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in entries)
+        {
+            var action = entry.Action?.Trim();
+            if (string.IsNullOrWhiteSpace(action) || !seen.Add(action))
+            {
+                continue;
+            }
+
+            desired.Add(action);
+        }
+
+        desired = desired.Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(option => option.Equals("All", StringComparison.OrdinalIgnoreCase) ? 0 : 1)
+            .ThenBy(option => option, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (!_actionOptions.SequenceEqual(desired))
+        {
+            _actionOptions.Clear();
+            foreach (var option in desired)
+            {
+                _actionOptions.Add(option);
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(SelectedAction) || !_actionOptions.Contains(SelectedAction))
+        {
+            SelectedAction = _actionOptions.FirstOrDefault();
+        }
+    }
+
+    private static (DateTime QueryFrom, DateTime QueryTo, DateTime FilterFrom, DateTime FilterTo) NormalizeDateRange(DateTime? from, DateTime? to)
+    {
+        var today = DateTime.Today;
+        var normalizedFrom = from?.Date ?? today.AddDays(-30);
+        var normalizedTo = to?.Date ?? (from.HasValue ? normalizedFrom : today);
+
+        if (normalizedFrom > normalizedTo)
+        {
+            (normalizedFrom, normalizedTo) = (normalizedTo, normalizedFrom);
+        }
+
+        var queryFrom = normalizedFrom;
+        var queryTo = normalizedTo.Date.AddDays(1).AddTicks(-1);
+
+        return (queryFrom, queryTo, normalizedFrom, normalizedTo);
+    }
+
+    private static string FormatDate(DateTime? value)
+    {
+        if (!value.HasValue)
+        {
+            return string.Empty;
+        }
+
+        return value.Value.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
+    }
+}

--- a/YasGMP.Wpf/Views/ApiAuditModuleView.xaml
+++ b/YasGMP.Wpf/Views/ApiAuditModuleView.xaml
@@ -1,0 +1,127 @@
+<UserControl x:Class="YasGMP.Wpf.Views.ApiAuditModuleView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:YasGMP.Wpf.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="400"
+             d:DesignWidth="600">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+    </UserControl.Resources>
+    <DockPanel>
+        <ToolBar DockPanel.Dock="Top">
+            <ItemsControl ItemsSource="{Binding Toolbar}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <ToggleButton Content="{Binding Caption}"
+                                      Command="{Binding Command}"
+                                      IsChecked="{Binding IsChecked}"
+                                      Margin="0,0,4,0" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Separator />
+            <Button Content="CFL" Command="{Binding ShowCflCommand}" />
+            <controls:GoldenArrowButton Command="{Binding GoldenArrowCommand}" Margin="8,0,0,0" />
+        </ToolBar>
+        <Grid Margin="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <StackPanel Grid.Row="0" Margin="0,0,0,8">
+                <WrapPanel Margin="0,0,0,8" ItemHeight="60" ItemWidth="200">
+                    <StackPanel Width="220" Margin="0,0,12,0">
+                        <TextBlock Text="API Key" FontWeight="SemiBold" />
+                        <TextBox Text="{Binding FilterApiKey, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
+                    <StackPanel Width="200" Margin="0,0,12,0">
+                        <TextBlock Text="User" FontWeight="SemiBold" />
+                        <TextBox Text="{Binding FilterUser, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
+                    <StackPanel Width="200" Margin="0,0,12,0">
+                        <TextBlock Text="Action" FontWeight="SemiBold" />
+                        <ComboBox ItemsSource="{Binding ActionOptions}"
+                                  SelectedItem="{Binding SelectedAction, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
+                    <StackPanel Width="180" Margin="0,0,12,0">
+                        <TextBlock Text="From" FontWeight="SemiBold" />
+                        <DatePicker SelectedDate="{Binding FilterFrom, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}, FallbackValue={x:Null}}" />
+                    </StackPanel>
+                    <StackPanel Width="180" Margin="0,0,12,0">
+                        <TextBlock Text="To" FontWeight="SemiBold" />
+                        <DatePicker SelectedDate="{Binding FilterTo, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}, FallbackValue={x:Null}}" />
+                    </StackPanel>
+                </WrapPanel>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="220" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0" />
+                    <TextBox Grid.Column="1" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+                    <Button Grid.Column="2"
+                            Content="Apply Filters"
+                            Command="{Binding RefreshCommand}"
+                            Margin="12,0,0,0"
+                            Padding="12,4" />
+                </Grid>
+            </StackPanel>
+            <Grid Grid.Row="1">
+                <DataGrid ItemsSource="{Binding RecordsView}"
+                          SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
+                          AutoGenerateColumns="False"
+                          IsReadOnly="True"
+                          CanUserAddRows="False"
+                          CanUserDeleteRows="False">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Timestamp" Binding="{Binding InspectorFields[0].Value}" Width="160" />
+                        <DataGridTextColumn Header="API Key" Binding="{Binding Title}" Width="220" />
+                        <DataGridTextColumn Header="Action" Binding="{Binding Code}" Width="200" />
+                        <DataGridTextColumn Header="User" Binding="{Binding InspectorFields[2].Value}" Width="200" />
+                        <DataGridTextColumn Header="IP Address" Binding="{Binding InspectorFields[3].Value}" Width="160" />
+                        <DataGridTextColumn Header="Request" Binding="{Binding InspectorFields[4].Value}" Width="2*" />
+                        <DataGridTextColumn Header="Details" Binding="{Binding Description}" Width="2*" />
+                    </DataGrid.Columns>
+                </DataGrid>
+                <Border Background="#80FFFFFF"
+                        Visibility="{Binding IsBusy, Converter={StaticResource BooleanToVisibilityConverter}}"
+                        IsHitTestVisible="True">
+                    <StackPanel HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Orientation="Vertical"
+                                Margin="24">
+                        <ProgressBar IsIndeterminate="True" Width="200" Height="20" />
+                        <TextBlock Text="Loading..."
+                                   Margin="0,12,0,0"
+                                   HorizontalAlignment="Center"
+                                   Foreground="Gray"
+                                   FontStyle="Italic" />
+                    </StackPanel>
+                </Border>
+            </Grid>
+            <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" FontStyle="Italic" Margin="0,8,0,0">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="Foreground" Value="Gray" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding HasError}" Value="True">
+                                <Setter Property="Foreground" Value="Firebrick" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
+        </Grid>
+    </DockPanel>
+</UserControl>

--- a/YasGMP.Wpf/Views/ApiAuditModuleView.xaml.cs
+++ b/YasGMP.Wpf/Views/ApiAuditModuleView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Views;
+
+public partial class ApiAuditModuleView : UserControl
+{
+    public ApiAuditModuleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -29,7 +29,7 @@
   - Scheduled Jobs — [x] done *(mode-aware editor with execute/acknowledge tooling, attachment workflow, and enforced signature capture; audit surfacing tracked under Batch B2)*
   - Users/Roles — [x] done *(Security module now exposes a CRUD-capable user/role editor with CFL, toolbar modes, role assignment management, and e-signature gating)*
   - Suppliers/External Servicers — [x] done *(Suppliers module enforces electronic signatures on save alongside attachments + CFL; External Servicers cockpit now also blocks persistence on signature capture)*
-  - Audit/API Audit — [~] in-progress *(WPF audit trail now pulls filtered entries via AuditService with expanded inspector grid, filters, and explicit empty/error status flags.)*
+  - Audit/API Audit — [~] in-progress *(WPF audit trail retains export filters and status guards; new API audit module surfaces masked API key activity with inspector payloads, dynamic action filters, and smoke registration.)*
   - Documents/Attachments — [ ] todo
   - Dashboard/Reports — [ ] todo
   - Settings/Admin — [ ] todo
@@ -53,6 +53,7 @@
 - 2025-12-12: TestElectronicSignatureDialogService now records log-only signature payloads without mutating identifiers, and SignaturePersistenceHelper tests assert the log path replays persisted metadata while dotnet CLI access remains blocked for restore/build/test.
 - 2025-12-15: Audit trail WPF view now surfaces Export PDF/Excel toolbar buttons tied to the async commands, shows a busy overlay aligned with IsBusy, and keeps the status text/error styling wired so export failures bubble immediately; dotnet restore/build/smoke remain blocked without the CLI.
 - 2025-12-16: Audit trail unit tests now stub ExportService to exercise PDF export success/failure flows, asserting busy flag lifecycles and status messaging while dotnet restore/build/smoke remain blocked by the missing CLI.
+- 2025-12-17: API audit module added to the WPF shell with masked inspector payloads, dynamic action filters, module registration, smoke coverage updates, and unit tests alongside a new AuditService.GetApiAuditEntriesAsync helper; dotnet restore/build/test still blocked because the CLI is unavailable in the container.
 - 2025-12-14: Audit trail module now caches the latest query payload and formatted filters so export commands can reuse them, added async PDF/Excel exports with busy/error guards, and refreshed DI to supply ExportService; dotnet restore/build/smoke still blocked until the CLI is installed.
 - 2025-12-13: Added a counting DatabaseService double plus module/service tests that simulate adapter-driven signature inserts, asserting a single InsertDigitalSignatureAsync call still yields SIGNATURE_PERSISTED auditing while dotnet CLI access remains unavailable.
 - 2025-12-13: ElectronicSignatureDialogService WPF tests now assert insert skips fire when a signature id already exists, confirm audit logging for both persisted and log-only flows, and reiterate that dotnet restore/build remain blocked because the CLI is unavailable in the container.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -86,15 +86,16 @@
     "Suppliers": "done",
     "ExternalServicers": "done",
     "Audit": "in-progress",
-    "ApiAudit": "pending",
+    "ApiAudit": "in-progress",
     "Attachments": "pending",
     "Dashboard": "pending",
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "test: cover audit export commands",
+  "lastCommitSummary": "feat: add API audit module to WPF shell",
   "notes": [
     "2025-12-16: Audit module unit tests now override ExportService calls to exercise PDF export success and failure paths, verifying busy state transitions and status/error messaging while dotnet restore/build remain blocked by the missing CLI.",
+    "2025-12-17: API audit module added to the WPF shell with masked inspector payloads, new AuditService.GetApiAuditEntriesAsync helper, module registry/smoke updates, and dedicated unit coverage; dotnet restore/build/test still fail because the CLI is unavailable.",
     "2025-12-15: Audit module WPF view adds Export PDF/Excel buttons that respect IsBusy and introduces a progress overlay so busy/export errors mirror the MAUI experience while the dotnet CLI remains unavailable for restore/build/smoke.",
     "2025-12-14: Audit module now retains the most recent audit query payload plus filter summary for export reuse, added guarded AsyncRelayCommand PDF/Excel exports, and registered ExportService so DI resolves the new constructor; dotnet CLI remains unavailable so restore/build/test stay blocked.",
     "2025-12-07: External Servicer CRUD fake now mirrors other module doubles by capturing saved snapshots with contexts, cloning entities for assertions, and clearing deleted entries; CrudSaveResult coverage confirms metadata still flows from the provided context while dotnet CLI access remains blocked for restore/build/smoke.",


### PR DESCRIPTION
## Summary
- add ApiAuditEntryDto and a resilient AuditService.GetApiAuditEntriesAsync query for masked API key activity
- implement the ApiAudit module view-model/view, update DI/module registration, and extend the smoke module sequence
- add ApiAudit WPF unit tests, ServiceRegistration coverage, and refresh codex plan/progress documentation

## Testing
- dotnet restore yasgmp.sln *(fails: `dotnet` command not found in container)*
- dotnet build yasgmp.sln *(fails: `dotnet` command not found in container)*
- dotnet test YasGMP.Wpf.Tests/YasGMP.Wpf.Tests.csproj *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de126c71cc83319085f306ad670b0a