### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf/App.xaml.cs
+++ b/YasGMP.Wpf/App.xaml.cs
@@ -101,7 +101,11 @@ namespace YasGMP.Wpf
                         svc.AddSingleton<DebugSmokeTestService>();
                         svc.AddTransient<DigitalSignatureViewModel>();
                         svc.AddTransient<ElectronicSignatureDialogViewModel>();
-                        svc.AddTransient<AuditLogViewModel>();
+                        svc.AddTransient<AuditLogViewModel>(sp =>
+                        {
+                            var database = sp.GetRequiredService<DatabaseService>();
+                            return new AuditLogViewModel(database);
+                        });
                         svc.AddTransient<DashboardModuleViewModel>();
                         svc.AddTransient<AssetsModuleViewModel>();
                         svc.AddTransient<ComponentsModuleViewModel>();

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -29,7 +29,7 @@
   - Scheduled Jobs — [x] done *(mode-aware editor with execute/acknowledge tooling, attachment workflow, and enforced signature capture; audit surfacing tracked under Batch B2)*
   - Users/Roles — [x] done *(Security module now exposes a CRUD-capable user/role editor with CFL, toolbar modes, role assignment management, and e-signature gating)*
   - Suppliers/External Servicers — [x] done *(Suppliers module enforces electronic signatures on save alongside attachments + CFL; External Servicers cockpit now also blocks persistence on signature capture)*
-  - Audit/API Audit — [~] in-progress *(WPF audit trail retains export filters and status guards; MAUI AuditLogViewModel now drives the shell document with synchronized inspector/search/export parity; new API audit module surfaces masked API key activity with inspector payloads, dynamic action filters, and smoke registration.)*
+  - Audit/API Audit — [~] in-progress *(WPF audit trail retains export filters and status guards; MAUI AuditLogViewModel now drives the shell document with synchronized inspector/search/export parity and resolves through DI with the shared DatabaseService; new API audit module surfaces masked API key activity with inspector payloads, dynamic action filters, and smoke registration.)*
   - Documents/Attachments — [ ] todo
   - Dashboard/Reports — [ ] todo
   - Settings/Admin — [ ] todo
@@ -58,6 +58,7 @@
 - 2025-12-19: API audit module unit tests now assert reversed/null date filters normalize to swapped day bounds and end-of-day query ranges via TestApiAuditModuleViewModel captures; dotnet restore/build remain blocked because the CLI is unavailable in the container.
 - 2025-12-20: Added WPF Audit Dashboard document that reuses the MAUI dashboard filters/exports, wired toolbar commands to the shared AsyncRelayCommand logic, and registered the module so compliance users can open the live feed; dotnet restore/build attempts still fail with "command not found" because the CLI is missing in the container.
 - 2025-12-21: Introduced AuditLogDocumentViewModel to project the MAUI AuditLogViewModel into the WPF shell with synchronized records, inspector payloads, and export commands; module registry now opens the new document while dotnet CLI access remains blocked.
+- 2025-12-22: WPF host now resolves AuditLogViewModel via a DI factory so the shared DatabaseService flows into the MAUI-backed audit adapter when the module opens; ModuleRegistry mapping continues to target the new document while dotnet CLI access remains blocked.
 - 2025-12-14: Audit trail module now caches the latest query payload and formatted filters so export commands can reuse them, added async PDF/Excel exports with busy/error guards, and refreshed DI to supply ExportService; dotnet restore/build/smoke still blocked until the CLI is installed.
 - 2025-12-13: Added a counting DatabaseService double plus module/service tests that simulate adapter-driven signature inserts, asserting a single InsertDigitalSignatureAsync call still yields SIGNATURE_PERSISTED auditing while dotnet CLI access remains unavailable.
 - 2025-12-13: ElectronicSignatureDialogService WPF tests now assert insert skips fire when a signature id already exists, confirm audit logging for both persisted and log-only flows, and reiterate that dotnet restore/build remain blocked because the CLI is unavailable in the container.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -95,8 +95,9 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "feat: bridge WPF audit log to MAUI view-model",
+  "lastCommitSummary": "fix: ensure WPF audit log resolves DatabaseService",
   "notes": [
+    "2025-12-22: AuditLogViewModel now resolves through a DI factory so the shared DatabaseService reaches the WPF audit adapter when modules open; module registry mapping stays on the new document while dotnet restore/build remain blocked by the missing CLI.",
     "2025-12-21: Audit log document now wraps the MAUI AuditLogViewModel with synchronized records, exports, and status propagation while the module registry targets the new adapter; dotnet restore/build remain blocked by the missing CLI.",
     "2025-12-16: Audit module unit tests now override ExportService calls to exercise PDF export success and failure paths, verifying busy state transitions and status/error messaging while dotnet restore/build remain blocked by the missing CLI.",
     "2025-12-20: WPF shell now exposes an Audit Dashboard document that reuses the MAUI dashboard filters/exports, updates inspector records when SignalR pushes arrive, and adds module registry wiring while dotnet restore/build remain blocked by the missing CLI.",


### PR DESCRIPTION
## Summary
- ensure the WPF host resolves `AuditLogViewModel` via DI so the singleton `DatabaseService` reaches the MAUI-backed audit document
- document the DI change in `codex_plan.md` and `codex_progress.json`

## Testing
- `dotnet restore yasgmp.sln` *(fails: command not found in container)*
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj -c Debug` *(fails: command not found in container)*
- `dotnet build yasgmp.csproj -c Debug -f net9.0-windows10.0.19041.0` *(fails: command not found in container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence)
- [ ] MAUI builds/runs unaffected.
- [ ] Shared AppCore extraction complete where required; adapters compiled.
- [ ] ModulesPane lists every module and opens feature-parity editors.
- [ ] B1 FormModes & command enablement wired across editors.
- [ ] CFL pickers + Golden Arrow navigation working.
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end.
- [ ] Warehouse ledger with running balance and alerts.
- [ ] Audit surfacing + e-signature prompts on critical saves.
- [ ] Attachments DB-backed with upload/preview/download.
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented.
- [ ] Smoke tests succeed and log output.
- [ ] `README_WPF_SHELL.md` and `/docs/WPF_MAPPING.md` kept current.


------
https://chatgpt.com/codex/tasks/task_e_68de2cfe3b6c8331b1d6c76db519282f