### PR TITLE
Add Audit dashboard document view

### DIFF
--- a/YasGMP.Wpf/App.xaml
+++ b/YasGMP.Wpf/App.xaml
@@ -54,6 +54,9 @@
         <DataTemplate DataType="{x:Type vm:AuditModuleViewModel}">
             <views:AuditModuleView />
         </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:AuditDashboardDocumentViewModel}">
+            <views:AuditDashboardDocument />
+        </DataTemplate>
         <DataTemplate DataType="{x:Type vm:ApiAuditModuleViewModel}">
             <views:ApiAuditModuleView />
         </DataTemplate>

--- a/YasGMP.Wpf/Views/AuditDashboardDocument.xaml
+++ b/YasGMP.Wpf/Views/AuditDashboardDocument.xaml
@@ -1,0 +1,163 @@
+<UserControl x:Class="YasGMP.Wpf.Views.AuditDashboardDocument"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:YasGMP.Wpf.ViewModels.Modules"
+             xmlns:controls="clr-namespace:YasGMP.Wpf.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="400"
+             d:DesignWidth="600"
+             d:DataContext="{d:DesignInstance Type=vm:AuditDashboardDocumentViewModel}">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <Style x:Key="BusyAwareToolbarButtonStyle" TargetType="Button">
+            <Setter Property="Margin" Value="4,0,0,0" />
+            <Setter Property="Padding" Value="12,4" />
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsBusy}" Value="True">
+                    <Setter Property="IsEnabled" Value="False" />
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+    </UserControl.Resources>
+
+    <DockPanel>
+        <ToolBar DockPanel.Dock="Top">
+            <ItemsControl ItemsSource="{Binding Toolbar}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <ToggleButton Content="{Binding Caption}"
+                                      Command="{Binding Command}"
+                                      IsChecked="{Binding IsChecked}"
+                                      Margin="0,0,4,0" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Separator />
+            <Button Content="CFL"
+                    Command="{Binding ShowCflCommand}" />
+            <controls:GoldenArrowButton Command="{Binding GoldenArrowCommand}" Margin="8,0,0,0" />
+            <Separator />
+            <Button Content="Apply Filters"
+                    Command="{Binding ApplyFilterCommand}"
+                    Style="{StaticResource BusyAwareToolbarButtonStyle}" />
+            <Button Content="Refresh"
+                    Command="{Binding RefreshCommand}"
+                    Style="{StaticResource BusyAwareToolbarButtonStyle}" />
+            <Button Content="Export PDF"
+                    Command="{Binding ExportPdfCommand}"
+                    Style="{StaticResource BusyAwareToolbarButtonStyle}" />
+            <Button Content="Export Excel"
+                    Command="{Binding ExportExcelCommand}"
+                    Style="{StaticResource BusyAwareToolbarButtonStyle}" />
+        </ToolBar>
+
+        <Grid Margin="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <StackPanel Grid.Row="0" Margin="0,0,0,8">
+                <WrapPanel Margin="0,0,0,8">
+                    <StackPanel Width="200" Margin="0,0,12,0">
+                        <TextBlock Text="User" FontWeight="SemiBold" />
+                        <TextBox Text="{Binding Dashboard.FilterUser, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
+                    <StackPanel Width="200" Margin="0,0,12,0">
+                        <TextBlock Text="Entity" FontWeight="SemiBold" />
+                        <TextBox Text="{Binding Dashboard.FilterEntity, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
+                    <StackPanel Width="180" Margin="0,0,12,0">
+                        <TextBlock Text="Action" FontWeight="SemiBold" />
+                        <ComboBox ItemsSource="{Binding Dashboard.ActionTypes}"
+                                  SelectedItem="{Binding Dashboard.SelectedAction, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
+                    <StackPanel Width="180" Margin="0,0,12,0">
+                        <TextBlock Text="From" FontWeight="SemiBold" />
+                        <DatePicker SelectedDate="{Binding Dashboard.FilterFrom, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
+                    <StackPanel Width="180" Margin="0,0,12,0">
+                        <TextBlock Text="To" FontWeight="SemiBold" />
+                        <DatePicker SelectedDate="{Binding Dashboard.FilterTo, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
+                </WrapPanel>
+
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="220" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0" />
+                    <TextBox Grid.Column="1"
+                             Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+                    <Button Grid.Column="2"
+                            Content="Apply Filters"
+                            Command="{Binding ApplyFilterCommand}"
+                            Margin="12,0,0,0"
+                            Padding="12,4"
+                            Style="{StaticResource BusyAwareToolbarButtonStyle}" />
+                </Grid>
+            </StackPanel>
+
+            <Grid Grid.Row="1">
+                <DataGrid ItemsSource="{Binding RecordsView}"
+                          SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
+                          AutoGenerateColumns="False"
+                          IsReadOnly="True"
+                          CanUserAddRows="False"
+                          CanUserDeleteRows="False">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Timestamp" Binding="{Binding InspectorFields[0].Value}" Width="160" />
+                        <DataGridTextColumn Header="User" Binding="{Binding InspectorFields[1].Value}" Width="220" />
+                        <DataGridTextColumn Header="Entity" Binding="{Binding InspectorFields[2].Value}" Width="220" />
+                        <DataGridTextColumn Header="Action" Binding="{Binding InspectorFields[3].Value}" Width="120" />
+                        <DataGridTextColumn Header="Device" Binding="{Binding InspectorFields[4].Value}" Width="200" />
+                        <DataGridTextColumn Header="Description" Binding="{Binding InspectorFields[5].Value}" Width="2*" />
+                    </DataGrid.Columns>
+                </DataGrid>
+
+                <Border Background="#80FFFFFF"
+                        Visibility="{Binding IsBusy, Converter={StaticResource BooleanToVisibilityConverter}}"
+                        IsHitTestVisible="True">
+                    <StackPanel HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Orientation="Vertical"
+                                Margin="24">
+                        <ProgressBar IsIndeterminate="True" Width="200" Height="20" />
+                        <TextBlock Text="Loading..."
+                                   Margin="0,12,0,0"
+                                   HorizontalAlignment="Center"
+                                   Foreground="Gray"
+                                   FontStyle="Italic" />
+                    </StackPanel>
+                </Border>
+            </Grid>
+
+            <TextBlock Grid.Row="2"
+                       Text="{Binding StatusMessage}"
+                       FontStyle="Italic"
+                       Margin="0,8,0,0">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="Foreground" Value="Gray" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding HasError}" Value="True">
+                                <Setter Property="Foreground" Value="Firebrick" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
+        </Grid>
+    </DockPanel>
+</UserControl>

--- a/YasGMP.Wpf/Views/AuditDashboardDocument.xaml.cs
+++ b/YasGMP.Wpf/Views/AuditDashboardDocument.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace YasGMP.Wpf.Views;
+
+public partial class AuditDashboardDocument : UserControl
+{
+    public AuditDashboardDocument()
+    {
+        InitializeComponent();
+    }
+}

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -42,6 +42,7 @@
   - 2025-09-24: Batch 0 rerun inside container confirmed `.NET 9` CLI is still missing; all `dotnet` commands fail immediately. Remains a prerequisite before module CRUD refactors can progress.
 
 ## Notes
+- 2025-10-02: Added the AuditDashboardDocument WPF view with toolbar/filter parity, busy overlay, and shell DataTemplate wiring while dotnet restore/build remain blocked by the missing CLI.
 - 2025-12-05: Added WPF unit coverage exercising ValidationCrudServiceAdapter context propagation, updated the validation CRUD
   fake to retain signature/IP/session metadata, and asserted CrudSaveResult mirrors the persisted entity so regressions surface
   quickly while dotnet CLI access remains blocked.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -96,8 +96,9 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "fix: wire audit log document factory",
+  "lastCommitSummary": "feat: add audit dashboard document view",
   "notes": [
+    "2025-10-02: WPF AuditDashboardDocument view mirrors the MAUI filters/exports with busy overlay + App.xaml DataTemplate wiring while dotnet restore/build remain blocked by the missing CLI.",
     "2025-12-23: WPF host now constructs AuditLogDocumentViewModel via DI so AuditService, ExportService, and the DatabaseService-backed AuditLogViewModel flow into the shell toolbar; dotnet restore/build remain blocked by the missing CLI.",
     "2025-12-22: AuditLogViewModel now resolves through a DI factory so the shared DatabaseService reaches the WPF audit adapter when modules open; module registry mapping stays on the new document while dotnet restore/build remain blocked by the missing CLI.",
     "2025-12-21: Audit log document now wraps the MAUI AuditLogViewModel with synchronized records, exports, and status propagation while the module registry targets the new adapter; dotnet restore/build remain blocked by the missing CLI.",


### PR DESCRIPTION
## Summary
- add an AuditDashboardDocument WPF view with toolbar commands, filter panel, busy overlay, and status styling bound to AuditDashboardDocumentViewModel
- register the document view for AuditDashboardDocumentViewModel and provide a user control code-behind
- update codex planning/progress notes to capture the new dashboard view work

## Testing
- dotnet restore yasgmp.sln *(fails: command not found)*
- dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj *(fails: command not found)*
- dotnet build yasgmp.csproj *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68de399aa6388331a6ee1bc62431b34a