### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf/Views/AttachmentsModuleView.xaml
+++ b/YasGMP.Wpf/Views/AttachmentsModuleView.xaml
@@ -29,16 +29,21 @@
             <controls:GoldenArrowButton Command="{Binding GoldenArrowCommand}" Margin="8,0,0,0" />
         </ToolBar>
         <Grid Margin="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*" />
+                <ColumnDefinition Width="3*" />
+            </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
-            <DockPanel Grid.Row="0" Margin="0,0,0,8">
+            <DockPanel Grid.Row="0" Grid.ColumnSpan="2" Margin="0,0,0,8">
                 <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,8,0" />
                 <TextBox Width="220" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
             </DockPanel>
             <DataGrid Grid.Row="1"
+                      Grid.Column="0"
                       ItemsSource="{Binding RecordsView}"
                       SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
                       AutoGenerateColumns="False"
@@ -52,7 +57,212 @@
                     <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" />
                 </DataGrid.Columns>
             </DataGrid>
-            <TextBlock Grid.Row="2" Text="{Binding StatusMessage}" FontStyle="Italic" Foreground="Gray" Margin="0,8,0,0" />
+            <Border Grid.Row="1"
+                    Grid.Column="1"
+                    Margin="8,0,0,0"
+                    Padding="12"
+                    BorderBrush="LightGray"
+                    BorderThickness="1"
+                    Background="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}">
+                <Border.DataContext>
+                    <Binding Path="SelectedAttachment" />
+                </Border.DataContext>
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel>
+                        <TextBlock Text="Select an attachment to view details." FontStyle="Italic" Foreground="Gray">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding}" Value="{x:Null}">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                        <StackPanel Margin="0,0,0,16">
+                            <StackPanel.Style>
+                                <Style TargetType="StackPanel">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding}" Value="{x:Null}">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </StackPanel.Style>
+                            <TextBlock Text="Attachment Details" FontWeight="Bold" FontSize="16" Margin="0,0,0,12" />
+                            <Grid Margin="0,0,0,12">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="Display Name:" Margin="0,0,8,4" />
+                                <TextBox Grid.Row="0"
+                                         Grid.Column="1"
+                                         Text="{Binding DisplayName}"
+                                         IsReadOnly="True"
+                                         Margin="0,0,0,4" />
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="File Name:" Margin="0,0,8,4" />
+                                <TextBox Grid.Row="1"
+                                         Grid.Column="1"
+                                         Text="{Binding FileName}"
+                                         IsReadOnly="True"
+                                         Margin="0,0,0,4" />
+                                <TextBlock Grid.Row="2" Grid.Column="0" Text="Status:" Margin="0,0,8,4" />
+                                <TextBox Grid.Row="2"
+                                         Grid.Column="1"
+                                         Text="{Binding Status}"
+                                         IsReadOnly="True"
+                                         Margin="0,0,0,4" />
+                                <TextBlock Grid.Row="3" Grid.Column="0" Text="Entity:" Margin="0,0,8,4" />
+                                <TextBox Grid.Row="3"
+                                         Grid.Column="1"
+                                         Text="{Binding EntityDisplayName}"
+                                         IsReadOnly="True"
+                                         Margin="0,0,0,4" />
+                                <TextBlock Grid.Row="4" Grid.Column="0" Text="File Type:" Margin="0,0,8,4" />
+                                <TextBox Grid.Row="4"
+                                         Grid.Column="1"
+                                         Text="{Binding FileType}"
+                                         IsReadOnly="True"
+                                         Margin="0,0,0,4" />
+                                <TextBlock Grid.Row="5" Grid.Column="0" Text="File Size:" Margin="0,0,8,4" />
+                                <TextBox Grid.Row="5"
+                                         Grid.Column="1"
+                                         Text="{Binding FileSizeDisplay}"
+                                         IsReadOnly="True"
+                                         Margin="0,0,0,4" />
+                                <TextBlock Grid.Row="6" Grid.Column="0" Text="SHA-256:" Margin="0,0,8,4" />
+                                <TextBox Grid.Row="6"
+                                         Grid.Column="1"
+                                         Text="{Binding Sha256}"
+                                         IsReadOnly="True"
+                                         Margin="0,0,0,4" />
+                                <TextBlock Grid.Row="7" Grid.Column="0" Text="Notes:" Margin="0,0,8,4" />
+                                <TextBox Grid.Row="7"
+                                         Grid.Column="1"
+                                         Text="{Binding Notes}"
+                                         IsReadOnly="True"
+                                         AcceptsReturn="True"
+                                         TextWrapping="Wrap"
+                                         MinHeight="60"
+                                         Margin="0,0,0,4" />
+                                <TextBlock Grid.Row="8" Grid.Column="0" Text="Retention Policy:" Margin="0,0,8,4" />
+                                <TextBox Grid.Row="8"
+                                         Grid.Column="1"
+                                         Text="{Binding RetentionPolicyName}"
+                                         IsReadOnly="True"
+                                         Margin="0,0,0,4" />
+                                <TextBlock Grid.Row="9" Grid.Column="0" Text="Retain Until:" Margin="0,0,8,4" />
+                                <TextBox Grid.Row="9"
+                                         Grid.Column="1"
+                                         Text="{Binding RetainUntil}"
+                                         IsReadOnly="True"
+                                         Margin="0,0,0,4" />
+                                <TextBlock Grid.Row="10" Grid.Column="0" Text="Retention Flags:" Margin="0,0,8,4" />
+                                <StackPanel Grid.Row="10" Grid.Column="1" Orientation="Vertical" Margin="0,0,0,4">
+                                    <CheckBox Content="Legal Hold"
+                                              IsChecked="{Binding RetentionLegalHold}"
+                                              IsEnabled="False"
+                                              Margin="0,0,0,4" />
+                                    <CheckBox Content="Review Required"
+                                              IsChecked="{Binding RetentionReviewRequired}"
+                                              IsEnabled="False"
+                                              Margin="0,0,0,4" />
+                                    <TextBlock Text="Retention Notes" FontWeight="SemiBold" Margin="0,8,0,4" />
+                                    <TextBox Text="{Binding RetentionNotes}"
+                                             IsReadOnly="True"
+                                             AcceptsReturn="True"
+                                             TextWrapping="Wrap"
+                                             MinHeight="40" />
+                                </StackPanel>
+                            </Grid>
+                        </StackPanel>
+                        <Separator />
+                        <TextBlock Text="Staged Uploads" FontWeight="Bold" FontSize="16" Margin="0,12,0,8" />
+                        <ItemsControl ItemsSource="{Binding DataContext.StagedUploads, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border BorderBrush="Gainsboro" BorderThickness="1" Padding="8" Margin="0,0,0,8" CornerRadius="4">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="*" />
+                                            </Grid.ColumnDefinitions>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                            </Grid.RowDefinitions>
+                                            <TextBlock Grid.Row="0" Grid.Column="0" Text="File Name:" Margin="0,0,8,4" VerticalAlignment="Center" />
+                                            <TextBox Grid.Row="0"
+                                                     Grid.Column="1"
+                                                     Text="{Binding FileName, UpdateSourceTrigger=PropertyChanged}" />
+                                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Content Type:" Margin="0,0,8,4" VerticalAlignment="Center" />
+                                            <TextBox Grid.Row="1"
+                                                     Grid.Column="1"
+                                                     Text="{Binding ContentType, UpdateSourceTrigger=PropertyChanged}" />
+                                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Entity Type:" Margin="0,0,8,4" VerticalAlignment="Center" />
+                                            <TextBox Grid.Row="2"
+                                                     Grid.Column="1"
+                                                     Text="{Binding EntityType, UpdateSourceTrigger=PropertyChanged}" />
+                                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Entity ID:" Margin="0,0,8,4" VerticalAlignment="Center" />
+                                            <TextBox Grid.Row="3"
+                                                     Grid.Column="1"
+                                                     Text="{Binding EntityId, UpdateSourceTrigger=PropertyChanged}" />
+                                            <TextBlock Grid.Row="4" Grid.Column="0" Text="Notes:" Margin="0,0,8,0" VerticalAlignment="Top" />
+                                            <TextBox Grid.Row="4"
+                                                     Grid.Column="1"
+                                                     Text="{Binding Notes, UpdateSourceTrigger=PropertyChanged}"
+                                                     AcceptsReturn="True"
+                                                     TextWrapping="Wrap"
+                                                     MinHeight="40" />
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                        <TextBlock Text="No files staged for upload. Use Upload to add files before saving."
+                                   FontStyle="Italic"
+                                   Foreground="Gray"
+                                   Margin="0,8,0,0">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding DataContext.HasStagedUploads, RelativeSource={RelativeSource AncestorType=UserControl}}" Value="True">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </StackPanel>
+                </ScrollViewer>
+            </Border>
+            <TextBlock Grid.Row="2"
+                       Grid.ColumnSpan="2"
+                       Text="{Binding StatusMessage}"
+                       FontStyle="Italic"
+                       Foreground="Gray"
+                       Margin="0,8,0,0" />
         </Grid>
     </DockPanel>
 </UserControl>

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -31,6 +31,7 @@
   - Suppliers/External Servicers — [x] done *(Suppliers module enforces electronic signatures on save alongside attachments + CFL; External Servicers cockpit now also blocks persistence on signature capture)*
   - Audit/API Audit — [~] in-progress *(WPF audit trail retains export filters and status guards; MAUI AuditLogViewModel now drives the shell document with synchronized inspector/search/export parity and resolves through DI with the shared DatabaseService; WPF Audit Log document view mirrors the dashboard patterns with toolbar buttons, filters, busy overlay, and status styling; new API audit module surfaces masked API key activity with inspector payloads, dynamic action filters, and smoke registration. These audit-focused modules are now grouped under the "Quality & Compliance" category in the ModuleRegistry.)*
   - Documents/Attachments — [~] in-progress *(Attachments module now inherits ModuleDocumentViewModel, wires shared shell services, seeds design-time records, tracks AttachmentRows/StagedUploads/SelectedAttachment observables to drive the inspector payload, and now surfaces upload/download/delete toolbar commands with SHA-256 deduplication, streaming downloads, and status updates.)*
+    - 2026-01-05: Attachments view now splits the layout into a records grid and inspector/editor pane that surfaces SelectedAttachment metadata alongside staged upload previews.
   - Dashboard/Reports — [ ] todo
   - Settings/Admin — [ ] todo
 

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -104,6 +104,7 @@
   "notes": [
     "2025-10-02: WPF AuditDashboardDocument view mirrors the MAUI filters/exports with busy overlay + App.xaml DataTemplate wiring while dotnet restore/build remain blocked by the missing CLI.",
     "2026-01-04: WPF host now resolves AttachmentsModuleViewModel via an explicit service provider factory so DatabaseService, attachment workflow, file picker, signature dialog, audit, CFL, shell interaction, and navigation services align with the current constructor order; dotnet restore/build remain blocked by the missing CLI.",
+    "2026-01-05: Attachments module view now introduces a two-column layout with a SelectedAttachment inspector and staged upload editor so metadata and pending files are visible before persistence; dotnet restore/build remain blocked by the missing CLI.",
     "2025-12-23: WPF host now constructs AuditLogDocumentViewModel via DI so AuditService, ExportService, and the DatabaseService-backed AuditLogViewModel flow into the shell toolbar; dotnet restore/build remain blocked by the missing CLI.",
     "2025-12-25: Added DI registration for AuditDashboardViewModel so the WPF audit dashboard/log documents resolve consistently alongside ModuleRegistry/DataTemplate wiring; dotnet restore/build remain blocked by the missing CLI.",
     "2025-12-22: AuditLogViewModel now resolves through a DI factory so the shared DatabaseService reaches the WPF audit adapter when modules open; module registry mapping stays on the new document while dotnet restore/build remain blocked by the missing CLI.",


### PR DESCRIPTION
## Summary
- split the attachments module view into list and inspector columns so records stay visible alongside editor content
- surface SelectedAttachment metadata, retention flags, and staged upload controls in the new right-hand pane
- log the layout work in codex_plan.md and codex_progress.json for persistent tracking

## Testing
- `dotnet restore yasgmp.sln` *(fails: `dotnet` CLI is unavailable in the container)*
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj` *(fails: `dotnet` CLI is unavailable in the container)*
- `dotnet build yasgmp.csproj` *(fails: `dotnet` CLI is unavailable in the container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence).
- [ ] MAUI builds/runs unaffected.
- [ ] Shared AppCore extraction complete where required; adapters compiled.
- [ ] ModulesPane lists every module and opens feature-parity editors.
- [ ] B1 FormModes & command enablement wired across editors.
- [ ] CFL pickers + Golden Arrow navigation working.
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end.
- [ ] Warehouse ledger with running balance and alerts.
- [ ] Audit surfacing + e-signature prompts on critical saves.
- [ ] Attachments DB-backed with upload/preview/download.
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented.
- [ ] Smoke tests succeed and log output.
- [ ] `README_WPF_SHELL.md` and `/docs/WPF_MAPPING.md` kept current.

------
https://chatgpt.com/codex/tasks/task_e_68df6affa1188331b26e2bb57e4720ae