### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf/Views/AttachmentsModuleView.xaml
+++ b/YasGMP.Wpf/Views/AttachmentsModuleView.xaml
@@ -7,6 +7,9 @@
              mc:Ignorable="d"
              d:DesignHeight="400"
              d:DesignWidth="600">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+    </UserControl.Resources>
     <DockPanel>
         <ToolBar DockPanel.Dock="Top">
             <ItemsControl ItemsSource="{Binding Toolbar}">
@@ -292,12 +295,55 @@
                     </StackPanel>
                 </ScrollViewer>
             </Border>
-            <TextBlock Grid.Row="2"
-                       Grid.ColumnSpan="2"
-                       Text="{Binding StatusMessage}"
-                       FontStyle="Italic"
-                       Foreground="Gray"
-                       Margin="0,8,0,0" />
+            <StackPanel Grid.Row="2"
+                        Grid.ColumnSpan="2"
+                        Margin="0,8,0,0">
+                <ItemsControl ItemsSource="{Binding ValidationMessages}"
+                              Visibility="{Binding HasValidationErrors, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,2">
+                                <TextBlock Text="•" Foreground="DarkRed" Margin="0,0,4,0" />
+                                <TextBlock Text="{Binding}" Foreground="DarkRed" TextWrapping="Wrap" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+                <TextBlock Text="{Binding StatusMessage}"
+                           FontStyle="Italic"
+                           Margin="0,4,0,0">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Foreground" Value="Gray" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding HasValidationErrors}" Value="True">
+                                    <Setter Property="Foreground" Value="Firebrick" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+            </StackPanel>
+            <Border Grid.Row="0"
+                    Grid.Column="0"
+                    Grid.RowSpan="3"
+                    Grid.ColumnSpan="2"
+                    Background="#80FFFFFF"
+                    Visibility="{Binding IsBusy, Converter={StaticResource BooleanToVisibilityConverter}}"
+                    IsHitTestVisible="True"
+                    Panel.ZIndex="100">
+                <StackPanel HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Orientation="Vertical"
+                            Margin="24">
+                    <ProgressBar IsIndeterminate="True" Width="200" Height="20" />
+                    <TextBlock Text="Processing..."
+                               Margin="0,12,0,0"
+                               HorizontalAlignment="Center"
+                               Foreground="Gray"
+                               FontStyle="Italic" />
+                </StackPanel>
+            </Border>
         </Grid>
     </DockPanel>
 </UserControl>

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -33,6 +33,7 @@
   - Documents/Attachments — [~] in-progress *(Attachments module now inherits ModuleDocumentViewModel, wires shared shell services, seeds design-time records, tracks AttachmentRows/StagedUploads/SelectedAttachment observables to drive the inspector payload, and now surfaces upload/download/delete toolbar commands with SHA-256 deduplication, streaming downloads, and status updates.)*
     - 2026-01-05: Attachments view now splits the layout into a records grid and inspector/editor pane that surfaces SelectedAttachment metadata alongside staged upload previews.
     - 2026-01-06: Editor pane now exposes HasAttachmentWorkflow-gated upload, download, and delete buttons bound to SelectedAttachment so commands hide when the attachment service is unavailable.
+    - 2026-01-07: Attachments editor now shows a busy overlay tied to IsBusy, lists validation messages inline, and styles the status text to highlight validation errors while dotnet restore/build remain blocked by the missing CLI.
   - Dashboard/Reports — [ ] todo
   - Settings/Admin — [ ] todo
 

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -37,7 +37,8 @@
       "2025-12-24: dotnet restore yasgmp.sln and dotnet build (YasGMP.Wpf.csproj, yasgmp.csproj net9.0-windows10.0.19041.0) retried; CLI still missing so each command exits with 'command not found'.",
       "2025-12-26: dotnet --info/restore/build retried; CLI remains unavailable in the container so commands exit with 'command not found'.",
       "2025-12-28: dotnet restore/build/run for WPF + MAUI targets retried after wiring new Quality & Compliance ribbon/backstage buttons; CLI is still missing so each command exits with 'command not found'.",
-      "2025-12-31: dotnet restore/build retried for yasgmp.sln, YasGMP.Wpf, and yasgmp.csproj; CLI remains unavailable so every command exits with 'command not found'."
+      "2025-12-31: dotnet restore/build retried for yasgmp.sln, YasGMP.Wpf, and yasgmp.csproj; CLI remains unavailable so every command exits with 'command not found'.",
+      "2026-01-07: dotnet --info/restore/build retried for yasgmp.sln and YasGMP.Wpf; CLI remains unavailable in the container so each command exits with 'command not found'."
     ]
   },
   "batches": [
@@ -100,12 +101,13 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "fix: register attachments module factory",
+  "lastCommitSummary": "fix: wire attachments busy overlay and validation display",
   "notes": [
     "2025-10-02: WPF AuditDashboardDocument view mirrors the MAUI filters/exports with busy overlay + App.xaml DataTemplate wiring while dotnet restore/build remain blocked by the missing CLI.",
     "2026-01-04: WPF host now resolves AttachmentsModuleViewModel via an explicit service provider factory so DatabaseService, attachment workflow, file picker, signature dialog, audit, CFL, shell interaction, and navigation services align with the current constructor order; dotnet restore/build remain blocked by the missing CLI.",
     "2026-01-05: Attachments module view now introduces a two-column layout with a SelectedAttachment inspector and staged upload editor so metadata and pending files are visible before persistence; dotnet restore/build remain blocked by the missing CLI.",
     "2026-01-06: Attachments editor pane now surfaces HasAttachmentWorkflow-gated upload/download/delete buttons with SelectedAttachment command parameters so tooling hides when the service stack is offline; dotnet restore/build remain blocked by the missing CLI.",
+    "2026-01-07: Attachments editor now shows a busy overlay tied to IsBusy, lists validation messages inline, and styles the status text to highlight validation errors while dotnet restore/build remain blocked by the missing CLI.",
     "2025-12-23: WPF host now constructs AuditLogDocumentViewModel via DI so AuditService, ExportService, and the DatabaseService-backed AuditLogViewModel flow into the shell toolbar; dotnet restore/build remain blocked by the missing CLI.",
     "2025-12-25: Added DI registration for AuditDashboardViewModel so the WPF audit dashboard/log documents resolve consistently alongside ModuleRegistry/DataTemplate wiring; dotnet restore/build remain blocked by the missing CLI.",
     "2025-12-22: AuditLogViewModel now resolves through a DI factory so the shared DatabaseService reaches the WPF audit adapter when modules open; module registry mapping stays on the new document while dotnet restore/build remain blocked by the missing CLI.",


### PR DESCRIPTION
## Summary
- surface a BooleanToVisibilityConverter resource in AttachmentsModuleView and bind a busy overlay to IsBusy so long-running work blocks the editor
- list validation messages inline with the attachments editor, toggle visibility from HasValidationErrors, and restyle the status text to highlight issues
- update codex plan/progress artifacts with the attachments view improvements and log the continued dotnet CLI blockage

## Testing
- `dotnet restore yasgmp.sln` *(fails: command not found — dotnet CLI unavailable in container)*
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj` *(fails: command not found — dotnet CLI unavailable in container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence).
- [ ] MAUI builds/runs unaffected.
- [ ] Shared AppCore extraction complete where required; adapters compiled.
- [ ] ModulesPane lists every module and opens feature-parity editors.
- [ ] B1 FormModes & command enablement wired across editors.
- [ ] CFL pickers + Golden Arrow navigation working.
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end.
- [ ] Warehouse ledger with running balance and alerts.
- [ ] Audit surfacing + e-signature prompts on critical saves.
- [ ] Attachments DB-backed with upload/preview/download.
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented.
- [ ] Smoke tests succeed and log output.
- [ ] README_WPF_SHELL.md and /docs/WPF_MAPPING.md kept current.

------
https://chatgpt.com/codex/tasks/task_e_68df6fa9dd4c83318519b2d830a287d4