### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
+++ b/YasGMP.Wpf/ViewModels/Modules/AuditModuleViewModel.cs
@@ -152,12 +152,35 @@ public sealed partial class AuditModuleViewModel : DataDrivenModuleDocumentViewM
     [ObservableProperty]
     private bool _hasError;
 
+    partial void OnFilterUserChanged(string? value) => TriggerRefreshForFilterChange();
+
+    partial void OnFilterEntityChanged(string? value) => TriggerRefreshForFilterChange();
+
+    partial void OnSelectedActionChanged(string? value) => TriggerRefreshForFilterChange();
+
+    partial void OnFilterFromChanged(DateTime? value) => TriggerRefreshForFilterChange();
+
+    partial void OnFilterToChanged(DateTime? value) => TriggerRefreshForFilterChange();
+
     private readonly AuditService _auditService;
     private readonly ExportService _exportService;
     private readonly AsyncRelayCommand _exportToPdfCommand;
     private readonly AsyncRelayCommand _exportToExcelCommand;
     private IReadOnlyList<AuditEntryDto>? _lastAuditEntries;
     private string? _lastFilterDescription;
+
+    private void TriggerRefreshForFilterChange()
+    {
+        if (!IsInitialized || IsBusy)
+        {
+            return;
+        }
+
+        HasError = false;
+        HasResults = false;
+        StatusMessage = $"Loading {Title} records...";
+        _ = RefreshCommand.ExecuteAsync(null);
+    }
 
     protected virtual async Task<IReadOnlyList<AuditEntryDto>> QueryAuditsAsync(
         string user,

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -45,6 +45,7 @@
   - 2025-09-24: Batch 0 rerun inside container confirmed `.NET 9` CLI is still missing; all `dotnet` commands fail immediately. Remains a prerequisite before module CRUD refactors can progress.
 
 ## Notes
+- 2026-01-11: Audit trail filters now trigger an automatic refresh so results stay aligned with user selections; another `dotnet restore` attempt (and implied builds/smoke) failed with **command not found** because the CLI remains unavailable in the container.
 - 2026-01-10: Debug smoke harness now navigates to the Attachments module, stages a temp upload, completes the signature-gated save, downloads via AttachmentService, and deletes the record with temp-file cleanup so attachments are covered in the automation log; dotnet restore/build remain blocked because the CLI is unavailable in the container.
 - 2026-01-04: WPF host now resolves AttachmentsModuleViewModel via an explicit factory so DatabaseService, AttachmentService, FilePicker, signature dialog, audit, CFL, shell interaction, and navigation services are injected consistently even if constructor ordering shifts; dotnet restore/build remain blocked by the missing CLI.
 - 2026-01-03: Attachments document now clears staged uploads on mode transitions, restricts upload/download/delete tooling to the appropriate form modes, requires an electronic signature before committing staged files on Save (logging attachment audits and refreshing the inspector afterwards), and Cancel now discards temporary uploads before refreshing; dotnet restore/build remain blocked by the missing CLI.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -39,7 +39,8 @@
       "2025-12-28: dotnet restore/build/run for WPF + MAUI targets retried after wiring new Quality & Compliance ribbon/backstage buttons; CLI is still missing so each command exits with 'command not found'.",
       "2025-12-31: dotnet restore/build retried for yasgmp.sln, YasGMP.Wpf, and yasgmp.csproj; CLI remains unavailable so every command exits with 'command not found'.",
       "2026-01-07: dotnet --info/restore/build retried for yasgmp.sln and YasGMP.Wpf; CLI remains unavailable in the container so each command exits with 'command not found'.",
-      "2026-01-08: dotnet restore/build retried for yasgmp.sln; CLI remains unavailable so each command exits with 'command not found'."
+      "2026-01-08: dotnet restore/build retried for yasgmp.sln; CLI remains unavailable so each command exits with 'command not found'.",
+      "2026-01-11: dotnet restore/build retried for yasgmp.sln and platform-specific targets; CLI remains unavailable in the container so each command fails with \"command not found\"."
     ]
   },
   "batches": [
@@ -102,7 +103,7 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "fix: wire attachments busy overlay and validation display",
+  "lastCommitSummary": "fix: trigger audit refresh on filter changes",
   "notes": [
     "2025-10-02: WPF AuditDashboardDocument view mirrors the MAUI filters/exports with busy overlay + App.xaml DataTemplate wiring while dotnet restore/build remain blocked by the missing CLI.",
     "2026-01-04: WPF host now resolves AttachmentsModuleViewModel via an explicit service provider factory so DatabaseService, attachment workflow, file picker, signature dialog, audit, CFL, shell interaction, and navigation services align with the current constructor order; dotnet restore/build remain blocked by the missing CLI.",
@@ -224,6 +225,7 @@
     "2025-12-27: Updated codex artifacts to explicitly note that Audit Log, Audit Dashboard, and API Audit modules now live under the \"Quality & Compliance\" category so documentation and ModuleRegistry stay synchronized; dotnet CLI availability still required for restore/build/smoke.",
     "2026-01-03: Attachments module now clears staged uploads on form mode changes, gates upload/download/delete commands by B1 semantics, enforces electronic signature capture before committing staged files with attachment audits, and Cancel discards temp uploads before refreshing the inspector/status.",
     "2026-01-09: Attachments module unit coverage now exercises mode transitions, staged upload dedupe, save/cancel behavior, and download/delete command enablement; dotnet CLI remains unavailable so restore/build/smoke are still blocked.",
-    "2026-01-10: Debug smoke harness now stages an attachment upload, completes the signature-gated save, streams the file back via AttachmentService, and deletes the record while cleaning temp artifacts so attachments are included in the automation log; dotnet CLI remains unavailable so restore/build/smoke continue to be blocked."
+    "2026-01-10: Debug smoke harness now stages an attachment upload, completes the signature-gated save, streams the file back via AttachmentService, and deletes the record while cleaning temp artifacts so attachments are included in the automation log; dotnet CLI remains unavailable so restore/build/smoke continue to be blocked.",
+    "2026-01-11: Audit trail filters now trigger an auto-refresh when modified so the grid reloads immediately; dotnet CLI remains unavailable so restore/build/smoke stay blocked pending installation."
   ]
 }


### PR DESCRIPTION
## Summary
- add a guardable refresh helper so audit filter changes requeue the module load when the view is ready
- reset audit status/results prior to each filter-driven refresh to keep export enablement and status text consistent with B1 refresh semantics
- document the auto-refresh change and the continued lack of dotnet CLI access in the codex plan/progress artifacts

## Testing
- dotnet restore *(fails: `command not found` in container)*
- dotnet build yasgmp.sln *(fails: `command not found` in container)*
- dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj -f net9.0-windows10.0.19041.0 *(fails: `command not found` in container)*
- dotnet build yasgmp.csproj -f net9.0-windows10.0.19041.0 *(fails: `command not found` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df8477341083318db9116d89831a60