### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -16,6 +16,7 @@
 ## Batches
 - **B0 — Environment stabilization** (SDKs, NuGets, XAML namespaces) — **blocked** *(no `dotnet` CLI)*
 - **B1 — Shell foundation** (Ribbon, Docking, StatusBar, FormMode state machine) — [ ] todo
+  - 2026-01-25: Documented B1FormDocumentViewModel command/state surface so derived modules inherit SAP B1 toolbar, audit, and busy-state guidance.
 - **B2 — Cross-cutting** (Attachments DB, E-Signature, Audit) — [~] in-progress *(e-sign capture now spans Assets, Components, Warehouses, Incidents, CAPA, Change Control, Validations, Scheduled Jobs, Suppliers, External Servicers, Users, and Work Orders; WPF adapters and AppCore services propagate optional signature metadata through to the database, falling back to the legacy hash generator only when metadata is missing; the WPF dialog service now emits audit events on capture/persist while broader audit surfacing remains gated on SDK access)*
 - **B3 — Editor framework** (templates, host, unsaved-guard) — [ ] todo
 - **B4+ — Module rollout:**

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -242,6 +242,7 @@
     "2026-01-20: Accessibility Insights for Windows tooling could not be executed inside the Linux container; scheduled a Windows-hosted rerun to capture locale-sensitive tooltip/name coverage for ribbon tabs, dock panes, and module document views.",
     "2026-01-22: Localized MainWindow title, CFL/ElectronicSignature dialogs, and every module view grid/toolbar label via ShellStrings resx keys while wiring shared ToolTip/Automation metadata; dotnet restore/build remain blocked by the missing CLI.",
     "2026-01-23: Centralized module titles, status phrases, and combo-box option lists in ShellStrings with formatting helpers, updated B1FormDocumentViewModel plus derived modules to consume ILocalizationService, and refreshed unit tests with a deterministic localization stub while the dotnet CLI gap persists.",
-    "2026-01-24: Added LocalizationService regression tests that drive EN↔HR switches across ribbon/toolbars and module tree view-models, plus documented the operator language toggle workflow while dotnet restore/build/smoke remain blocked by the missing CLI."
+    "2026-01-24: Added LocalizationService regression tests that drive EN↔HR switches across ribbon/toolbars and module tree view-models, plus documented the operator language toggle workflow while dotnet restore/build/smoke remain blocked by the missing CLI.",
+    "2026-01-25: Added XML documentation to B1FormDocumentViewModel toolbar commands so audit/status semantics stay clear for downstream modules while dotnet CLI availability continues to block restore/build/smoke validation."
   ]
 }


### PR DESCRIPTION
## Summary
- Documented the B1FormDocumentViewModel command/state surface so derived modules understand SAP B1 toolbar, audit, and busy-state semantics.
- Recorded the documentation work in codex_plan and codex_progress so ongoing tracking reflects the clarified guidance.

## Testing
- ❌ `dotnet --version` *(fails: command not found in container environment)*
- ❌ `dotnet restore yasgmp.sln` *(fails: command not found in container environment)*
- ❌ `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj` *(fails: command not found in container environment)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence).
- [ ] MAUI builds/runs unaffected.
- [ ] Shared AppCore extraction complete where required; adapters compiled.
- [ ] ModulesPane lists every module and opens feature-parity editors.
- [ ] B1 FormModes & command enablement wired across editors.
- [ ] CFL pickers + Golden Arrow navigation working.
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end.
- [ ] Warehouse ledger with running balance and alerts.
- [ ] Audit surfacing + e-signature prompts on critical saves.
- [ ] Attachments DB-backed with upload/preview/download.
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented.
- [ ] Smoke tests succeed and log output.
- [ ] `README_WPF_SHELL.md` and `/docs/WPF_MAPPING.md` kept current.


------
https://chatgpt.com/codex/tasks/task_e_68e3bc0d40e8833192a2c208a090d0bc