### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf/Services/CflDialogService.cs
+++ b/YasGMP.Wpf/Services/CflDialogService.cs
@@ -4,6 +4,27 @@ using YasGMP.Wpf.Dialogs;
 
 namespace YasGMP.Wpf.Services;
 
+/// <summary>
+/// Default CFL dialog implementation that marshals requests onto the WPF dispatcher and presents the
+/// modal picker with the shell's primary window as owner.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Instances assume requests may arrive from background threads and therefore wrap dialog creation
+/// in <see cref="Application.Current"/>'s dispatcher. The first available shell window is used as the
+/// dialog owner so focus and modality align with Golden Arrow navigation expectations.
+/// </para>
+/// <para>
+/// The service forwards the localized title and rows supplied via <see cref="CflRequest"/>; callers
+/// are responsible for sourcing those values from the shared resource dictionaries to satisfy the
+/// shell's localization requirements.
+/// </para>
+/// <para>
+/// Confirmed and cancelled outcomes are pushed back through the returned <see cref="Task"/> so audit
+/// aware consumers can write the resulting <see cref="CflResult"/> (or a null cancellation marker)
+/// into their audit appenders alongside form mode transitions.
+/// </para>
+/// </remarks>
 public sealed class CflDialogService : ICflDialogService
 {
     public Task<CflResult?> ShowAsync(CflRequest request)

--- a/YasGMP.Wpf/Services/ICflDialogService.cs
+++ b/YasGMP.Wpf/Services/ICflDialogService.cs
@@ -4,13 +4,43 @@ using YasGMP.Wpf.ViewModels.Modules;
 
 namespace YasGMP.Wpf.Services;
 
-/// <summary>Service used to display SAP Business One style choose-from-list dialogs.</summary>
+/// <summary>
+/// Defines the shell service responsible for surfacing SAP Business One style choose-from-list (CFL)
+/// dialogs when a Golden Arrow navigation, field trigger, or form mode transition requires a user
+/// selection.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Shell components should invoke the service whenever a module needs a user-driven lookup to
+/// continue a Find/Add/Update cycle, particularly when Golden Arrow relationships or dependent
+/// master data must be resolved. Invocations are expected to originate on background threads but are
+/// marshalled to the UI dispatcher by implementations.
+/// </para>
+/// <para>
+/// Requests must provide localization-ready data; <see cref="CflRequest.Title"/> and
+/// <see cref="CflItem.Label"/> values should be sourced from the shell's resource dictionaries so
+/// downstream consumers receive fully translated text. Implementations are expected to return the
+/// user's selection so form modes can update state and so audit logging pipelines (see
+/// <see cref="CflResult"/>) can record the pick as part of the Golden Arrow and immutable audit
+/// flows.
+/// </para>
+/// </remarks>
 public interface ICflDialogService
 {
     Task<CflResult?> ShowAsync(CflRequest request);
 }
 
-/// <summary>Descriptor for CFL invocations.</summary>
+/// <summary>
+/// Describes a CFL invocation including localized title text and selectable rows supplied by the
+/// caller.
+/// </summary>
+/// <remarks>
+/// The <see cref="Title"/> property should already be localized using the same resource providers
+/// consumed by ribbon, form mode, and audit surfaces so that modal dialogs are consistent across the
+/// shell. Items provided in <see cref="Items"/> must respect Golden Arrow conventions, meaning they
+/// include all information needed for downstream audit logging to correlate the selection with the
+/// initiating document.
+/// </remarks>
 public sealed class CflRequest
 {
     public CflRequest(string title, IReadOnlyList<CflItem> items)
@@ -24,7 +54,16 @@ public sealed class CflRequest
     public IReadOnlyList<CflItem> Items { get; }
 }
 
-/// <summary>Single CFL row.</summary>
+/// <summary>
+/// Represents a single row displayed in a CFL dialog including the record key, localized label, and
+/// optional descriptive text.
+/// </summary>
+/// <remarks>
+/// <see cref="Label"/> and <see cref="Description"/> should originate from localized catalogs and
+/// include sufficient context (e.g., document numbers, revision codes) so that when a selection is
+/// emitted it can be written verbatim into audit trails and Golden Arrow navigation logs without
+/// additional lookups.
+/// </remarks>
 public sealed class CflItem
 {
     public CflItem(string key, string label, string? description = null)
@@ -41,7 +80,15 @@ public sealed class CflItem
     public string Description { get; }
 }
 
-/// <summary>Result returned from a CFL dialog.</summary>
+/// <summary>
+/// Captures the outcome of a CFL dialog, supplying the selected item for form mode transitions and
+/// audit logging.
+/// </summary>
+/// <remarks>
+/// Consumers should forward the <see cref="Selected"/> payload into the shell's audit logging
+/// pipeline (e.g., the audit appenders used by save/confirm flows) alongside the form mode state so
+/// that Golden Arrow history and immutable audit ledgers reflect the user's pick.
+/// </remarks>
 public sealed class CflResult
 {
     public CflResult(CflItem selected)

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -52,6 +52,7 @@
   - 2025-09-24: Batch 0 rerun inside container confirmed `.NET 9` CLI is still missing; all `dotnet` commands fail immediately. Remains a prerequisite before module CRUD refactors can progress.
 
 ## Notes
+- 2026-01-28: Expanded CFL dialog service XML documentation so Golden Arrow callers understand dispatcher invocation, owner wiring, localization sourcing, and how to feed selections into the audit appenders while dotnet restore/build/smoke remain blocked by the missing CLI.
 - 2026-01-16: Added shared localization dictionaries for ribbon, backstage, and dock pane metadata with dynamic resources and automation identifiers so EN↔HR switches update headers, tooltips, and accessibility names; dotnet restore/build/smoke remain blocked by the missing CLI in the container.
 - 2026-01-17: Localized dashboard toolbar toggles/buttons, search, and data grid columns plus module tree categories/nodes via the shared localization service, adding automation ids/names for Accessibility Insights/FlaUI; dotnet restore/build/smoke remain blocked pending CLI availability.
 - 2026-01-18: Extended module tree templates so each node's header now binds tooltip and automation metadata directly from localization-aware view-model properties, keeping screen reader output aligned after language switches; `dotnet restore`/`dotnet build`/smoke remain blocked by the missing CLI.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -43,7 +43,8 @@
       "2026-01-08: dotnet restore/build retried for yasgmp.sln; CLI remains unavailable so each command exits with 'command not found'.",
       "2026-01-11: dotnet restore/build retried for yasgmp.sln and platform-specific targets; CLI remains unavailable in the container so each command fails with \"command not found\".",
       "2026-01-12: dotnet restore/build/test attempted for yasgmp.sln, YasGMP.Wpf, and MAUI net9.0-windows targets; CLI still missing so every command exits with 'command not found'.",
-      "2026-01-13: dotnet restore retried for yasgmp.sln after API audit filter refresh updates; CLI remains unavailable so the command exits with 'command not found'."
+      "2026-01-13: dotnet restore retried for yasgmp.sln after API audit filter refresh updates; CLI remains unavailable so the command exits with 'command not found'.",
+      "2026-01-28: dotnet restore yasgmp.sln retried; CLI remains unavailable in the container so the command exits with 'command not found'."
     ]
   },
   "batches": [
@@ -74,7 +75,8 @@
         "Module save flows now rehydrate adapter-provided signature ids/hashes before optional persistence, skipping redundant dialog writes when a signature already exists while preserving current UX messaging.",
         "ValidationService now keeps adapter-supplied validation signature hashes intact on create/update and only regenerates when explicitly forced (e.g., MarkExecuted), with new unit coverage confirming the stored hash matches the adapter payload.",
         "WPF ValidationCrudServiceAdapter test now asserts signature hash/IP/session context persist alongside CrudSaveResult metadata, and validation CRUD fakes retain those fields for downstream assertions while CLI validation stays blocked.",
-        "Test signature dialog now records capture results and persist calls, CRUD fakes expose configurable signature id providers, and module regression tests assert adapter-assigned ids skip redundant persistence while CLI validation remains blocked."
+        "Test signature dialog now records capture results and persist calls, CRUD fakes expose configurable signature id providers, and module regression tests assert adapter-assigned ids skip redundant persistence while CLI validation remains blocked.",
+        "2026-01-28: CFL dialog service XML docs now instruct modules on dispatcher usage, localization sourcing, and audit appenders so Golden Arrow flows capture selections even while CLI access is blocked."
       ]
     },
     {
@@ -243,7 +245,7 @@
     "2026-01-20: Accessibility Insights for Windows tooling could not be executed inside the Linux container; scheduled a Windows-hosted rerun to capture locale-sensitive tooltip/name coverage for ribbon tabs, dock panes, and module document views.",
     "2026-01-22: Localized MainWindow title, CFL/ElectronicSignature dialogs, and every module view grid/toolbar label via ShellStrings resx keys while wiring shared ToolTip/Automation metadata; dotnet restore/build remain blocked by the missing CLI.",
     "2026-01-23: Centralized module titles, status phrases, and combo-box option lists in ShellStrings with formatting helpers, updated B1FormDocumentViewModel plus derived modules to consume ILocalizationService, and refreshed unit tests with a deterministic localization stub while the dotnet CLI gap persists.",
-    "2026-01-24: Added LocalizationService regression tests that drive EN↔HR switches across ribbon/toolbars and module tree view-models, plus documented the operator language toggle workflow while dotnet restore/build/smoke remain blocked by the missing CLI.",
+    "2026-01-24: Added LocalizationService regression tests that drive EN\u2194HR switches across ribbon/toolbars and module tree view-models, plus documented the operator language toggle workflow while dotnet restore/build/smoke remain blocked by the missing CLI.",
     "2026-01-25: Added XML documentation to B1FormDocumentViewModel toolbar commands so audit/status semantics stay clear for downstream modules while dotnet CLI availability continues to block restore/build/smoke validation.",
     "2026-01-26: Documented ModuleRecord key/status/inspector metadata so Golden Arrow navigation and SAP B1 form-mode visuals stay aligned while dotnet restore/build/smoke remain blocked by the missing CLI.",
     "2026-01-27: ModuleRegistry XML documentation now maps module keys/titles/categories to Modules pane population, localization resource lookups, Golden Arrow automation ids, and SAP B1 toolbar/form-mode consumption while dotnet restore/build/smoke remain blocked by the missing CLI."


### PR DESCRIPTION
## Summary
- expand the ICflDialogService contract documentation to describe Golden Arrow triggers, localization requirements, audit logging, and dispatcher expectations
- add class-level XML documentation to CflDialogService covering dispatcher usage, owner wiring, localization sourcing, and audit-forwarding guidance
- refresh codex plan/progress artifacts to capture the new CFL documentation work and the latest dotnet CLI blocking attempts

## Testing
- dotnet restore yasgmp.sln *(fails: `dotnet` CLI unavailable in container)*
- dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj -f net9.0-windows10.0.19041.0 *(fails: `dotnet` CLI unavailable in container)*
- dotnet build yasgmp.csproj -f net9.0-windows10.0.19041.0 *(fails: `dotnet` CLI unavailable in container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence) *(blocked: `dotnet` CLI unavailable inside container)*
- [ ] MAUI builds/runs unaffected *(blocked: `dotnet` CLI unavailable inside container)*
- [ ] Shared AppCore extraction complete where required; adapters compiled *(pending broader integration work)*
- [ ] ModulesPane lists every module and opens feature-parity editors *(tracked in ongoing batches)*
- [ ] B1 FormModes & command enablement wired across editors *(tracked in ongoing batches)*
- [ ] CFL pickers + Golden Arrow navigation working *(documentation expanded; runtime validation blocked on CLI)*
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end *(tracked in ongoing batches)*
- [ ] Warehouse ledger with running balance and alerts *(tracked in ongoing batches)*
- [ ] Audit surfacing + e-signature prompts on critical saves *(audit documentation expanded; runtime validation blocked on CLI)*
- [ ] Attachments DB-backed with upload/preview/download *(tracked in ongoing batches)*
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented *(tracked in ongoing batches)*
- [ ] Smoke tests succeed and log output *(blocked: `dotnet` CLI & Windows tooling unavailable)*
- [ ] README_WPF_SHELL.md and /docs/WPF_MAPPING.md kept current *(tracked via documentation updates)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d7ce8d4c83319b687a8cd56a525f