### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf/Services/IShellInteractionService.cs
+++ b/YasGMP.Wpf/Services/IShellInteractionService.cs
@@ -2,18 +2,70 @@ using YasGMP.Wpf.ViewModels.Modules;
 
 namespace YasGMP.Wpf.Services;
 
-/// <summary>Exposes status/inspector updates for docked module documents.</summary>
+/// <summary>
+/// Coordinates shell-level status bar and inspector broadcasts raised by module documents and ribbon commands.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Ribbon controls and Golden Arrow components should forward user-facing status changes through this contract
+/// on the UI dispatcher so the shell can refresh the docked status bar without racing background tasks.
+/// </para>
+/// <para>
+/// Inspector updates are expected to originate from the active <see cref="ModuleDocumentViewModel"/> whenever the
+/// selection changes, attachments mutate, or audit context needs to surface. Consumers should ensure the supplied
+/// <see cref="InspectorContext"/> matches the module metadata registered in <see cref="IModuleRegistry"/> so the
+/// inspector renders localization and audit traces that align with the currently activated module pane.
+/// </para>
+/// </remarks>
 public interface IShellInteractionService
 {
+    /// <summary>
+    /// Pushes a localized status message into the docked status bar, typically in response to ribbon command execution.
+    /// </summary>
+    /// <param name="message">Localized status string composed from <c>ShellStrings</c> resources.</param>
     void UpdateStatus(string message);
 
+    /// <summary>
+    /// Updates the inspector panel with module-specific metadata, audit trails, or Golden Arrow primers.
+    /// </summary>
+    /// <param name="context">
+    /// Context payload produced by the active module document; should be captured on the UI dispatcher before invoking
+    /// the shell service so bound dependency properties remain thread-affine.
+    /// </param>
     void UpdateInspector(InspectorContext context);
 }
 
-/// <summary>Navigation contract used by golden-arrow buttons to activate related modules.</summary>
+/// <summary>
+/// Navigation contract used by Golden Arrow buttons, ribbon launchers, and Modules pane selection handlers to activate
+/// related documents.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementers should route navigation requests through the metadata registered in <see cref="IModuleRegistry"/> to keep
+/// module instantiation, localization, and audit routing consistent with shell expectations.
+/// </para>
+/// <para>
+/// Calls must occur on the WPF dispatcher thread; Golden Arrow callbacks often originate from background data observers and
+/// need to marshal to the dispatcher before invoking <see cref="OpenModule"/> or <see cref="Activate"/> to avoid cross-thread
+/// access violations.
+/// </para>
+/// </remarks>
 public interface IModuleNavigationService
 {
+    /// <summary>
+    /// Opens (or resolves) the module document associated with the supplied key, using <see cref="IModuleRegistry"/> metadata
+    /// to instantiate the document when necessary.
+    /// </summary>
+    /// <param name="moduleKey">Registry key defined in <see cref="IModuleRegistry"/> that maps Golden Arrow sources to modules.</param>
+    /// <param name="parameter">
+    /// Optional navigation payload (e.g., selected record identifiers) that Golden Arrow buttons pass to prime the target module.
+    /// </param>
+    /// <returns>The module document instance representing the opened/activated pane.</returns>
     ModuleDocumentViewModel OpenModule(string moduleKey, object? parameter = null);
 
+    /// <summary>
+    /// Brings an existing module document to the foreground within the docking manager and synchronizes inspector/status state.
+    /// </summary>
+    /// <param name="document">Document previously resolved from <see cref="OpenModule"/>.</param>
     void Activate(ModuleDocumentViewModel document);
 }

--- a/YasGMP.Wpf/Services/ShellInteractionService.cs
+++ b/YasGMP.Wpf/Services/ShellInteractionService.cs
@@ -3,7 +3,31 @@ using YasGMP.Wpf.ViewModels.Modules;
 
 namespace YasGMP.Wpf.Services;
 
-/// <summary>Bridges module documents with the shell window.</summary>
+/// <summary>
+/// Default shell interaction service that wires module documents, status updates, and Golden Arrow navigation into the WPF host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The shell bootstrapping sequence must call <see cref="Configure"/> once after constructing the docking manager, ribbon,
+/// and Modules pane. The supplied delegates typically originate from <see cref="IModuleRegistry"/> metadata so navigation and
+/// inspector payloads mirror the registered module keys, localization resources, and audit routing expectations.
+/// </para>
+/// <para>
+/// All callbacks are expected to execute on the WPF dispatcher thread. Ribbon and Golden Arrow handlers should marshal to the
+/// dispatcher before invoking navigation methods to avoid cross-thread access when docking documents or updating dependency
+/// properties.
+/// </para>
+/// <para>
+/// Inspector updates carry localization and audit metadata, allowing downstream consumers to propagate language changes and
+/// audit traces through the inspector pane without rehydrating module state. Status updates follow the same pattern so localized
+/// audit/a11y messages appear immediately after module operations complete.
+/// </para>
+/// <para>
+/// Consumers should always retrieve modules through <see cref="OpenModule"/> and activate them with <see cref="Activate"/>
+/// rather than caching view-model references. This ensures each navigation request respects current registry metadata, safely
+/// reuses existing documents, and keeps audit/inspector synchronization consistent with the shell lifecycle.
+/// </para>
+/// </remarks>
 public sealed class ShellInteractionService : IShellInteractionService, IModuleNavigationService
 {
     private Func<string, object?, ModuleDocumentViewModel>? _openModule;
@@ -11,6 +35,15 @@ public sealed class ShellInteractionService : IShellInteractionService, IModuleN
     private Action<string>? _statusUpdater;
     private Action<InspectorContext>? _inspectorUpdater;
 
+    /// <summary>
+    /// Captures shell delegates for module creation/activation and status/inspector broadcasting; must be invoked during shell startup.
+    /// </summary>
+    /// <param name="openModule">
+    /// Delegate that resolves module documents by key, usually derived from <see cref="IModuleRegistry"/> entries.
+    /// </param>
+    /// <param name="activate">Callback that brings a module document to the foreground within the docking host.</param>
+    /// <param name="statusUpdater">Dispatcher-affine status bar update handler.</param>
+    /// <param name="inspectorUpdater">Dispatcher-affine inspector update handler.</param>
     public void Configure(
         Func<string, object?, ModuleDocumentViewModel> openModule,
         Action<ModuleDocumentViewModel> activate,
@@ -23,6 +56,7 @@ public sealed class ShellInteractionService : IShellInteractionService, IModuleN
         _inspectorUpdater = inspectorUpdater ?? throw new ArgumentNullException(nameof(inspectorUpdater));
     }
 
+    /// <inheritdoc />
     public ModuleDocumentViewModel OpenModule(string moduleKey, object? parameter = null)
     {
         if (_openModule == null)
@@ -34,6 +68,7 @@ public sealed class ShellInteractionService : IShellInteractionService, IModuleN
         return document;
     }
 
+    /// <inheritdoc />
     public void Activate(ModuleDocumentViewModel document)
     {
         if (_activate == null)
@@ -44,6 +79,7 @@ public sealed class ShellInteractionService : IShellInteractionService, IModuleN
         _activate(document);
     }
 
+    /// <inheritdoc />
     public void UpdateStatus(string message)
     {
         if (_statusUpdater == null)
@@ -54,6 +90,7 @@ public sealed class ShellInteractionService : IShellInteractionService, IModuleN
         _statusUpdater(message);
     }
 
+    /// <inheritdoc />
     public void UpdateInspector(InspectorContext context)
     {
         if (_inspectorUpdater == null)

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -53,6 +53,7 @@
 
 ## Notes
 - 2026-01-28: Expanded CFL dialog service XML documentation so Golden Arrow callers understand dispatcher invocation, owner wiring, localization sourcing, and how to feed selections into the audit appenders while dotnet restore/build/smoke remain blocked by the missing CLI.
+- 2026-01-29: Expanded shell interaction/navigation service XML docs covering ribbon & Golden Arrow usage patterns, dispatcher marshalling, and how <code>IModuleRegistry</code> metadata drives inspector/audit wiring while dotnet restore/build/smoke remain blocked by the missing CLI.
 - 2026-01-16: Added shared localization dictionaries for ribbon, backstage, and dock pane metadata with dynamic resources and automation identifiers so EN↔HR switches update headers, tooltips, and accessibility names; dotnet restore/build/smoke remain blocked by the missing CLI in the container.
 - 2026-01-17: Localized dashboard toolbar toggles/buttons, search, and data grid columns plus module tree categories/nodes via the shared localization service, adding automation ids/names for Accessibility Insights/FlaUI; dotnet restore/build/smoke remain blocked pending CLI availability.
 - 2026-01-18: Extended module tree templates so each node's header now binds tooltip and automation metadata directly from localization-aware view-model properties, keeping screen reader output aligned after language switches; `dotnet restore`/`dotnet build`/smoke remain blocked by the missing CLI.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -76,7 +76,8 @@
         "ValidationService now keeps adapter-supplied validation signature hashes intact on create/update and only regenerates when explicitly forced (e.g., MarkExecuted), with new unit coverage confirming the stored hash matches the adapter payload.",
         "WPF ValidationCrudServiceAdapter test now asserts signature hash/IP/session context persist alongside CrudSaveResult metadata, and validation CRUD fakes retain those fields for downstream assertions while CLI validation stays blocked.",
         "Test signature dialog now records capture results and persist calls, CRUD fakes expose configurable signature id providers, and module regression tests assert adapter-assigned ids skip redundant persistence while CLI validation remains blocked.",
-        "2026-01-28: CFL dialog service XML docs now instruct modules on dispatcher usage, localization sourcing, and audit appenders so Golden Arrow flows capture selections even while CLI access is blocked."
+        "2026-01-28: CFL dialog service XML docs now instruct modules on dispatcher usage, localization sourcing, and audit appenders so Golden Arrow flows capture selections even while CLI access is blocked.",
+        "2026-01-29: Shell interaction/navigation service XML documentation now outlines ribbon/Golden Arrow usage, dispatcher marshalling expectations, and cross-references IModuleRegistry metadata so audit and inspector updates stay aligned while CLI access remains blocked."
       ]
     },
     {


### PR DESCRIPTION
## Summary
- expand the shell interaction/navigation service XML documentation with dispatcher guidance, ribbon and Golden Arrow usage notes, and module registry cross-references
- update ShellInteractionService remarks to capture configuration lifecycle, thread affinity expectations, and safe activation guidance for module consumers
- record the documentation refresh in codex plan/progress artifacts for traceability

## Testing
- dotnet restore *(fails: `dotnet` not found in container PATH)*
- dotnet build yasgmp.sln *(fails: `dotnet` not found in container PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68e4da354bc08331bcf5a13ec7130ed4