### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf/Services/CalibrationCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/CalibrationCrudServiceAdapter.cs
@@ -8,9 +8,17 @@ using YasGMP.Services;
 namespace YasGMP.Wpf.Services;
 
 /// <summary>
-/// Default <see cref="ICalibrationCrudService"/> implementation backed by the shared
-/// <see cref="CalibrationService"/>.
+/// Connects the WPF calibration module view models to the shared MAUI
+/// <see cref="YasGMP.Services.CalibrationService"/> pipeline.
 /// </summary>
+/// <remarks>
+/// The docked calibration editors call into this adapter, which forwards work to
+/// <see cref="YasGMP.Services.CalibrationService"/> and the cross-shell <see cref="YasGMP.Services.AuditService"/>
+/// so MAUI and WPF share identical persistence and auditing. Operations should be awaited off the UI thread,
+/// then marshalled back with <see cref="WpfUiDispatcher"/>. The <see cref="CrudSaveResult"/> payload provides identifiers,
+/// signature context, and status/note values that callers localize via <see cref="LocalizationServiceExtensions"/>
+/// or <see cref="ILocalizationService"/> before surfacing them to the operator.
+/// </remarks>
 public sealed class CalibrationCrudServiceAdapter : ICalibrationCrudService
 {
     private readonly CalibrationService _inner;

--- a/YasGMP.Wpf/Services/CapaCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/CapaCrudServiceAdapter.cs
@@ -8,8 +8,16 @@ using YasGMP.Services;
 namespace YasGMP.Wpf.Services;
 
 /// <summary>
-/// Adapter that exposes <see cref="CAPAService"/> CRUD workflows to the WPF shell.
+/// Exposes CAPA module workflows in the WPF shell by forwarding them to the shared MAUI
+/// <see cref="YasGMP.Services.CAPAService"/> implementation.
 /// </summary>
+/// <remarks>
+/// CAPA view models invoke this adapter, which uses <see cref="YasGMP.Services.CAPAService"/> and
+/// the cross-platform <see cref="YasGMP.Services.AuditService"/> to keep persistence and logging in sync with the MAUI app.
+/// Await operations off the UI thread and dispatch UI updates through <see cref="WpfUiDispatcher"/>. The
+/// <see cref="CrudSaveResult"/> returned by create/update calls conveys identifiers, signature metadata, and status text that
+/// callers localize with <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/> prior to presentation.
+/// </remarks>
 public sealed class CapaCrudServiceAdapter : ICapaCrudService
 {
     private readonly CAPAService _service;

--- a/YasGMP.Wpf/Services/ChangeControlCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/ChangeControlCrudServiceAdapter.cs
@@ -7,6 +7,18 @@ using YasGMP.Services;
 
 namespace YasGMP.Wpf.Services;
 
+/// <summary>
+/// Coordinates Change Control module requests from the WPF shell with the shared MAUI
+/// <see cref="YasGMP.Services.ChangeControlService"/> and associated services.
+/// </summary>
+/// <remarks>
+/// Change Control view models call into this adapter, which forwards operations to
+/// <see cref="YasGMP.Services.ChangeControlService"/> and leverages the shared <see cref="YasGMP.Services.AuditService"/>
+/// so audit logs stay unified between WPF and MAUI. Because calls are awaited off the dispatcher thread, callers should marshal
+/// UI updates with <see cref="WpfUiDispatcher"/>. The resulting <see cref="CrudSaveResult"/> carries identifiers and signature
+/// metadata; status or note strings should be localized using <see cref="LocalizationServiceExtensions"/> or
+/// <see cref="ILocalizationService"/> before being shown in the shell.
+/// </remarks>
 public sealed class ChangeControlCrudServiceAdapter : IChangeControlCrudService
 {
     private readonly ChangeControlService _service;

--- a/YasGMP.Wpf/Services/ComponentCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/ComponentCrudServiceAdapter.cs
@@ -8,9 +8,19 @@ using YasGMP.Services;
 namespace YasGMP.Wpf.Services;
 
 /// <summary>
-/// Default <see cref="IComponentCrudService"/> implementation backed by the
-/// shared <see cref="ComponentService"/> from <c>YasGMP.AppCore</c>.
+/// Routes Component module interactions from the WPF shell into the shared MAUI
+/// <see cref="YasGMP.Services.ComponentService"/> implementation.
 /// </summary>
+/// <remarks>
+/// View models issue commands to this adapter, which forwards them to
+/// <see cref="YasGMP.Services.ComponentService"/> (and the associated <see cref="YasGMP.Services.AuditService"/>)
+/// so the same AppCore logic is exercised regardless of shell. Methods are awaited off the UI thread;
+/// callers are expected to marshal updates via <see cref="WpfUiDispatcher"/>. The <see cref="CrudSaveResult"/>
+/// payload contains identifiers, signature metadata, and status text that should be localized with
+/// <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/> before being shown in the ribbon.
+/// Audit entries emitted here surface within the MAUI experiences because the shared <see cref="YasGMP.Services.AuditService"/>
+/// is used to capture them.
+/// </remarks>
 public sealed class ComponentCrudServiceAdapter : IComponentCrudService
 {
     private readonly ComponentService _inner;

--- a/YasGMP.Wpf/Services/ExternalServicerCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/ExternalServicerCrudServiceAdapter.cs
@@ -10,9 +10,18 @@ using YasGMP.Services;
 namespace YasGMP.Wpf.Services;
 
 /// <summary>
-/// Adapter that allows the WPF shell to reuse the shared external servicer services while capturing
-/// the extra audit metadata required by desktop saves.
+/// Bridges the External Servicer module in the WPF shell with the shared MAUI
+/// <see cref="YasGMP.Services.ExternalServicerService"/> and persistence stack.
 /// </summary>
+/// <remarks>
+/// Module view models call into this adapter before delegating to <see cref="YasGMP.Services.ExternalServicerService"/> and
+/// <see cref="YasGMP.Services.DatabaseService"/>, mirroring the MAUI call flow while allowing the WPF shell to stamp
+/// additional metadata. Methods are awaited away from the UI thread; callers should marshal UI updates using
+/// <see cref="WpfUiDispatcher"/>. The <see cref="CrudSaveResult"/> conveys identifiers, status text, and signature context that
+/// must be localized with <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/> before display.
+/// Audit details are persisted via <see cref="YasGMP.Services.DatabaseServiceSuppliersExtensions.LogSupplierAuditAsync(YasGMP.Services.DatabaseService,int,string,int,string?,string,string,string?,System.Threading.CancellationToken)"/>,
+/// ensuring the shared <see cref="YasGMP.Services.AuditService"/> surfaces the same events inside the MAUI experience.
+/// </remarks>
 public sealed class ExternalServicerCrudServiceAdapter : IExternalServicerCrudService
 {
     private readonly ExternalServicerService _externalServicerService;

--- a/YasGMP.Wpf/Services/ICalibrationCrudService.cs
+++ b/YasGMP.Wpf/Services/ICalibrationCrudService.cs
@@ -7,9 +7,16 @@ using YasGMP.Wpf.ViewModels.Dialogs;
 namespace YasGMP.Wpf.Services;
 
 /// <summary>
-/// Adapter-friendly abstraction over <see cref="YasGMP.Services.CalibrationService"/> so the
-/// WPF shell can execute CRUD operations without pulling in the full database runtime during tests.
+/// Shared CRUD contract used by both shells to persist calibrations through
+/// <see cref="YasGMP.Services.CalibrationService"/> and the MAUI audit infrastructure.
 /// </summary>
+/// <remarks>
+/// Module view models invoke this interface on the dispatcher thread, implementations relay work to the shared
+/// <see cref="YasGMP.Services.CalibrationService"/> and <see cref="YasGMP.Services.AuditService"/>, and UI consumers must marshal
+/// updates with <see cref="WpfUiDispatcher"/> once operations complete. The returned <see cref="CrudSaveResult"/> is expected to
+/// include identifiers, signature data, and localization-ready status/notes so MAUI and WPF present consistent audit history and
+/// can translate the text using <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/>.
+/// </remarks>
 public interface ICalibrationCrudService
 {
     Task<IReadOnlyList<Calibration>> GetAllAsync();

--- a/YasGMP.Wpf/Services/ICapaCrudService.cs
+++ b/YasGMP.Wpf/Services/ICapaCrudService.cs
@@ -7,9 +7,16 @@ using YasGMP.Wpf.ViewModels.Dialogs;
 namespace YasGMP.Wpf.Services;
 
 /// <summary>
-/// Adapter abstraction over <see cref="YasGMP.Services.CAPAService"/> so the WPF shell
-/// can execute CAPA CRUD operations without binding directly to infrastructure types.
+/// Shared contract that lets the WPF shell and MAUI client drive CAPA workflows through
+/// <see cref="YasGMP.Services.CAPAService"/> while reusing the same audit pipeline.
 /// </summary>
+/// <remarks>
+/// Module view models call these members from the UI thread, adapters forward the work to the shared
+/// <see cref="YasGMP.Services.CAPAService"/> and <see cref="YasGMP.Services.AuditService"/> so persistence and auditing stay unified.
+/// Awaited results should be marshalled back via <see cref="WpfUiDispatcher"/>, and the <see cref="CrudSaveResult"/> must include
+/// identifiers, signature context, and localization-ready status/priority text so MAUI/WPF surfaces can translate them using
+/// <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/> before displaying to users.
+/// </remarks>
 public interface ICapaCrudService
 {
     Task<IReadOnlyList<CapaCase>> GetAllAsync();

--- a/YasGMP.Wpf/Services/IChangeControlCrudService.cs
+++ b/YasGMP.Wpf/Services/IChangeControlCrudService.cs
@@ -6,6 +6,18 @@ using YasGMP.Wpf.ViewModels.Dialogs;
 
 namespace YasGMP.Wpf.Services;
 
+/// <summary>
+/// Shared contract used by the WPF shell and MAUI host to manage Change Control records through
+/// <see cref="YasGMP.Services.ChangeControlService"/> while sharing audit plumbing.
+/// </summary>
+/// <remarks>
+/// Module view models call these members synchronously on the dispatcher thread. Implementations relay the request to the
+/// shared <see cref="YasGMP.Services.ChangeControlService"/> and <see cref="YasGMP.Services.AuditService"/> so both shells
+/// persist and log identical metadata. Callers should dispatch UI updates via <see cref="WpfUiDispatcher"/> after awaiting the
+/// asynchronous operations. Returned <see cref="CrudSaveResult"/> values must include identifiers, signature data, and
+/// localization-ready status text for consumption with <see cref="LocalizationServiceExtensions"/> or
+/// <see cref="ILocalizationService"/>.
+/// </remarks>
 public interface IChangeControlCrudService
 {
     Task<IReadOnlyList<ChangeControl>> GetAllAsync();

--- a/YasGMP.Wpf/Services/IComponentCrudService.cs
+++ b/YasGMP.Wpf/Services/IComponentCrudService.cs
@@ -7,10 +7,17 @@ using YasGMP.Wpf.ViewModels.Dialogs;
 namespace YasGMP.Wpf.Services;
 
 /// <summary>
-/// Abstraction over <see cref="YasGMP.Services.ComponentService"/> so the WPF
-/// shell can execute CRUD operations without pulling in the full database runtime
-/// during unit tests.
+/// Shared contract that allows the WPF shell and MAUI client to orchestrate Component
+/// persistence through <see cref="YasGMP.Services.ComponentService"/>.
 /// </summary>
+/// <remarks>
+/// Module view models call into this interface, the adapter forwards requests to the shared
+/// MAUI services (<see cref="YasGMP.Services.ComponentService"/> and <see cref="YasGMP.Services.AuditService"/>),
+/// and UI updates should be dispatched via <see cref="WpfUiDispatcher"/> after awaiting the returned tasks.
+/// Implementations must return a <see cref="CrudSaveResult"/> populated with identifiers, status text, and
+/// signature metadata so audit records remain in sync and localization can be applied via
+/// <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/> prior to presentation.
+/// </remarks>
 public interface IComponentCrudService
 {
     Task<IReadOnlyList<Component>> GetAllAsync();

--- a/YasGMP.Wpf/Services/IExternalServicerCrudService.cs
+++ b/YasGMP.Wpf/Services/IExternalServicerCrudService.cs
@@ -8,8 +8,17 @@ using YasGMP.Wpf.ViewModels.Dialogs;
 namespace YasGMP.Wpf.Services;
 
 /// <summary>
-/// Adapter-friendly abstraction exposing external servicer CRUD operations to the WPF shell.
+/// Shared CRUD contract that both WPF and MAUI use to reach <see cref="YasGMP.Services.ExternalServicerService"/>
+/// and its audit/persistence pipeline.
 /// </summary>
+/// <remarks>
+/// WPF module view models invoke these members on the dispatcher thread, adapters forward calls to the shared
+/// <see cref="YasGMP.Services.ExternalServicerService"/> and <see cref="YasGMP.Services.DatabaseService"/> (which in turn feed
+/// <see cref="YasGMP.Services.AuditService"/>). Awaited operations should marshal UI updates with <see cref="WpfUiDispatcher"/>.
+/// Implementations must populate <see cref="CrudSaveResult"/> with identifiers, signature metadata, and localization-ready
+/// status/note text so either shell can translate them using <see cref="LocalizationServiceExtensions"/> or
+/// <see cref="ILocalizationService"/> before presentation.
+/// </remarks>
 public interface IExternalServicerCrudService
 {
     Task<IReadOnlyList<ExternalServicer>> GetAllAsync();

--- a/YasGMP.Wpf/Services/IIncidentCrudService.cs
+++ b/YasGMP.Wpf/Services/IIncidentCrudService.cs
@@ -6,9 +6,15 @@ using YasGMP.Wpf.ViewModels.Dialogs;
 namespace YasGMP.Wpf.Services;
 
 /// <summary>
-/// Abstraction over <see cref="YasGMP.Services.IncidentService"/> so the WPF shell can
-/// run CRUD logic without binding directly to the infrastructure layer.
+/// Shared contract that routes incident CRUD operations through <see cref="YasGMP.Services.IncidentService"/> and the shared MAUI audit stack.
 /// </summary>
+/// <remarks>
+/// Module view models call these members on the dispatcher thread, adapters forward the work to the shared
+/// <see cref="YasGMP.Services.IncidentService"/> and <see cref="YasGMP.Services.AuditService"/>, and callers marshal UI updates with
+/// <see cref="WpfUiDispatcher"/> after awaiting the asynchronous work. Implementations must return <see cref="CrudSaveResult"/> values populated with identifiers,
+/// signature context, and localization-ready status text so <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/> can translate
+/// them consistently with the MAUI shell.
+/// </remarks>
 public interface IIncidentCrudService
 {
     Task<Incident?> TryGetByIdAsync(int id);

--- a/YasGMP.Wpf/Services/IMachineCrudService.cs
+++ b/YasGMP.Wpf/Services/IMachineCrudService.cs
@@ -7,9 +7,17 @@ using YasGMP.Wpf.ViewModels.Dialogs;
 namespace YasGMP.Wpf.Services
 {
     /// <summary>
-    /// Adapter-friendly abstraction around <see cref="YasGMP.Services.MachineService"/>
-    /// so the WPF shell can be unit-tested without the full database infrastructure.
+    /// Shared CRUD contract that lets both shells execute Machine workflows through
+    /// <see cref="YasGMP.Services.MachineService"/> with consistent auditing.
     /// </summary>
+    /// <remarks>
+    /// WPF module view models call these members on the UI thread; adapters pass the work to
+    /// <see cref="YasGMP.Services.MachineService"/> and <see cref="YasGMP.Services.AuditService"/>, then callers dispatch UI
+    /// updates via <see cref="WpfUiDispatcher"/> after awaiting the tasks. Implementations must populate
+    /// <see cref="CrudSaveResult"/> with identifiers, signature context, and localization-ready status text so both MAUI and WPF
+    /// can translate them using <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/> and maintain a
+    /// unified audit history.
+    /// </remarks>
     public interface IMachineCrudService
     {
         Task<IReadOnlyList<Machine>> GetAllAsync();

--- a/YasGMP.Wpf/Services/IPartCrudService.cs
+++ b/YasGMP.Wpf/Services/IPartCrudService.cs
@@ -7,9 +7,17 @@ using YasGMP.Wpf.ViewModels.Dialogs;
 namespace YasGMP.Wpf.Services
 {
     /// <summary>
-    /// Adapter abstraction that surfaces Parts CRUD operations to the WPF shell
-    /// without binding the UI to the concrete infrastructure implementation.
+    /// Shared contract that lets both the WPF shell and the MAUI host drive Parts
+    /// persistence through the <see cref="YasGMP.Services.PartService"/> pipeline.
     /// </summary>
+    /// <remarks>
+    /// Module view models invoke this interface on the UI thread, the adapter forwards the call to the
+    /// shared MAUI services (<see cref="YasGMP.Services.PartService"/> and <see cref="YasGMP.Services.AuditService"/>)
+    /// and callers must dispatch UI updates via <see cref="WpfUiDispatcher"/> once the awaited operation completes.
+    /// The resulting <see cref="CrudSaveResult"/> must carry the identifier, session, and signature metadata so
+    /// audit logs stay aligned across shells and any status or note text can be localized with
+    /// <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/> before presentation.
+    /// </remarks>
     public interface IPartCrudService
     {
         Task<IReadOnlyList<Part>> GetAllAsync();

--- a/YasGMP.Wpf/Services/IScheduledJobCrudService.cs
+++ b/YasGMP.Wpf/Services/IScheduledJobCrudService.cs
@@ -6,9 +6,17 @@ using YasGMP.Wpf.ViewModels.Dialogs;
 namespace YasGMP.Wpf.Services;
 
 /// <summary>
-/// Adapter-friendly abstraction for scheduled job persistence so the WPF shell can
-/// operate without binding directly to database-specific infrastructure.
+/// Shared contract that routes scheduled job CRUD/operations through <see cref="YasGMP.Services.DatabaseService"/>
+/// and the MAUI audit infrastructure.
 /// </summary>
+/// <remarks>
+/// Module view models invoke these members on the dispatcher thread; adapters execute the work against
+/// <see cref="YasGMP.Services.DatabaseService"/> so the MAUI app and WPF shell share persistence and audit history surfaced by
+/// <see cref="YasGMP.Services.AuditService"/>. Callers should marshal UI updates via <see cref="WpfUiDispatcher"/> after
+/// awaiting the returned tasks. Implementations must populate <see cref="CrudSaveResult"/> with identifiers, scheduling status,
+/// and signature context so the values can be localized with <see cref="LocalizationServiceExtensions"/> or
+/// <see cref="ILocalizationService"/> before operators see them.
+/// </remarks>
 public interface IScheduledJobCrudService
 {
     Task<ScheduledJob?> TryGetByIdAsync(int id);

--- a/YasGMP.Wpf/Services/ISupplierCrudService.cs
+++ b/YasGMP.Wpf/Services/ISupplierCrudService.cs
@@ -8,9 +8,16 @@ using YasGMP.Wpf.ViewModels.Dialogs;
 namespace YasGMP.Wpf.Services;
 
 /// <summary>
-/// Adapter-friendly abstraction exposing supplier CRUD to the WPF shell without
-/// binding directly to <see cref="YasGMP.Services.SupplierService"/>.
+/// Shared contract that drives supplier CRUD through <see cref="YasGMP.Services.SupplierService"/> and the MAUI audit stack.
 /// </summary>
+/// <remarks>
+/// Module view models call into this interface on the dispatcher thread; adapters forward the work to
+/// <see cref="YasGMP.Services.SupplierService"/> and <see cref="YasGMP.Services.DatabaseService"/> so MAUI and WPF persist and
+/// audit suppliers the same way. Await the asynchronous operations off the UI thread and dispatch UI updates via
+/// <see cref="WpfUiDispatcher"/>. <see cref="CrudSaveResult"/> instances must carry identifiers, status text, and signature metadata
+/// so localization can be applied through <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/> before
+/// the UI presents the values, and so <see cref="YasGMP.Services.AuditService"/> exposes complete context.
+/// </remarks>
 public interface ISupplierCrudService
 {
     Task<IReadOnlyList<Supplier>> GetAllAsync();

--- a/YasGMP.Wpf/Services/IUserCrudService.cs
+++ b/YasGMP.Wpf/Services/IUserCrudService.cs
@@ -7,9 +7,16 @@ using YasGMP.Wpf.ViewModels.Dialogs;
 namespace YasGMP.Wpf.Services
 {
     /// <summary>
-    /// Adapter-friendly abstraction that exposes user and role CRUD functionality to the WPF shell
-    /// without binding directly to <see cref="YasGMP.Services.UserService"/> or <see cref="YasGMP.Services.RBACService"/>.
+    /// Shared contract that orchestrates user and role workflows through
+    /// <see cref="YasGMP.Services.Interfaces.IUserService"/> and <see cref="YasGMP.Services.Interfaces.IRBACService"/> so MAUI and WPF share behavior.
     /// </summary>
+    /// <remarks>
+    /// Module view models call these members on the dispatcher thread. Implementations forward work to the shared MAUI
+    /// services (<see cref="YasGMP.Services.Interfaces.IUserService"/>, <see cref="YasGMP.Services.Interfaces.IRBACService"/>, and the downstream
+    /// <see cref="YasGMP.Services.AuditService"/>) while callers marshal UI updates via <see cref="WpfUiDispatcher"/> after awaiting the tasks.
+    /// Returned <see cref="CrudSaveResult"/> objects must include identifiers, signature context, and localization-ready status/notes so they can be translated with
+    /// <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/> and maintain parity with the MAUI shell.
+    /// </remarks>
     public interface IUserCrudService
     {
         Task<IReadOnlyList<User>> GetAllAsync();

--- a/YasGMP.Wpf/Services/IValidationCrudService.cs
+++ b/YasGMP.Wpf/Services/IValidationCrudService.cs
@@ -7,9 +7,14 @@ using YasGMP.Wpf.ViewModels.Dialogs;
 namespace YasGMP.Wpf.Services;
 
 /// <summary>
-/// Adapter abstraction over <see cref="YasGMP.Services.ValidationService"/> so the WPF shell can
-/// coordinate validation CRUD flows without binding directly to infrastructure types during tests.
+/// Shared contract that directs validation CRUD through <see cref="YasGMP.Services.ValidationService"/> and the MAUI audit pipeline.
 /// </summary>
+/// <remarks>
+/// Module view models invoke these members on the UI thread, implementations forward work to the shared
+/// <see cref="YasGMP.Services.ValidationService"/> and <see cref="YasGMP.Services.AuditService"/>, and UI consumers marshal updates via
+/// <see cref="WpfUiDispatcher"/> after awaiting tasks. <see cref="CrudSaveResult"/> must return identifiers, signature context, and localization-ready
+/// status text so <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/> can translate the values consistently with the MAUI shell.
+/// </remarks>
 public interface IValidationCrudService
 {
     Task<IReadOnlyList<Validation>> GetAllAsync();

--- a/YasGMP.Wpf/Services/IWarehouseCrudService.cs
+++ b/YasGMP.Wpf/Services/IWarehouseCrudService.cs
@@ -7,8 +7,17 @@ using YasGMP.Wpf.ViewModels.Dialogs;
 namespace YasGMP.Wpf.Services
 {
     /// <summary>
-    /// Abstraction around warehouse CRUD for the WPF shell.
+    /// Shared contract for routing warehouse CRUD/ledger operations through
+    /// <see cref="YasGMP.Services.DatabaseService"/> and the shared MAUI audit services.
     /// </summary>
+    /// <remarks>
+    /// Module view models call into this interface on the dispatcher thread; adapters forward the work to
+    /// <see cref="YasGMP.Services.DatabaseService"/> and <see cref="YasGMP.Services.AuditService"/> so warehouse persistence,
+    /// stock snapshots, and audit logs remain unified across MAUI and WPF. After awaiting, callers should marshal UI updates via
+    /// <see cref="WpfUiDispatcher"/>. Returned <see cref="CrudSaveResult"/> values carry identifiers, signature context, and
+    /// localization-ready status strings so <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/>
+    /// can translate them before presentation.
+    /// </remarks>
     public interface IWarehouseCrudService
     {
         Task<IReadOnlyList<Warehouse>> GetAllAsync();

--- a/YasGMP.Wpf/Services/IWorkOrderCrudService.cs
+++ b/YasGMP.Wpf/Services/IWorkOrderCrudService.cs
@@ -6,10 +6,17 @@ using YasGMP.Wpf.ViewModels.Dialogs;
 namespace YasGMP.Wpf.Services;
 
 /// <summary>
-/// Abstraction over the <see cref="YasGMP.Services.WorkOrderService"/> so the WPF shell
-/// can execute CRUD operations in a testable manner without connecting to the full
-/// database runtime.
+/// Shared contract consumed by the WPF shell and MAUI host to orchestrate Work Order persistence
+/// through <see cref="YasGMP.Services.WorkOrderService"/> and the shared audit infrastructure.
 /// </summary>
+/// <remarks>
+/// Module view models call these members on the dispatcher thread, adapters forward the work to
+/// <see cref="YasGMP.Services.WorkOrderService"/> and <see cref="YasGMP.Services.AuditService"/>, and callers must
+/// marshal UI updates back through <see cref="WpfUiDispatcher"/> after awaiting the result. Implementations are responsible
+/// for returning a <see cref="CrudSaveResult"/> containing identifiers, signature context, and localization-ready status text
+/// so MAUI and WPF shells emit identical audit logs and can localize notes through
+/// <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/>.
+/// </remarks>
 public interface IWorkOrderCrudService
 {
     Task<WorkOrder?> TryGetByIdAsync(int id);

--- a/YasGMP.Wpf/Services/IncidentCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/IncidentCrudServiceAdapter.cs
@@ -7,8 +7,16 @@ using YasGMP.Services;
 namespace YasGMP.Wpf.Services;
 
 /// <summary>
-/// Adapter that exposes <see cref="IncidentService"/> CRUD operations to the WPF shell.
+/// Bridges incident workflows from the WPF shell to the shared MAUI
+/// <see cref="YasGMP.Services.IncidentService"/> implementation.
 /// </summary>
+/// <remarks>
+/// Incident module view models call this adapter, which forwards the request to <see cref="YasGMP.Services.IncidentService"/>
+/// and the underlying <see cref="YasGMP.Services.AuditService"/> so persistence, localization, and audit logging match MAUI.
+/// Operations should be awaited off the dispatcher thread with UI updates marshalled via <see cref="WpfUiDispatcher"/>. The
+/// <see cref="CrudSaveResult"/> payload contains identifiers, status text, and signature metadata that callers localize using
+/// <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/> before rendering in the shell.
+/// </remarks>
 public sealed class IncidentCrudServiceAdapter : IIncidentCrudService
 {
     private readonly IncidentService _service;

--- a/YasGMP.Wpf/Services/MachineCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/MachineCrudServiceAdapter.cs
@@ -8,9 +8,17 @@ using YasGMP.Services;
 namespace YasGMP.Wpf.Services
 {
     /// <summary>
-    /// Default <see cref="IMachineCrudService"/> implementation that forwards calls to
-    /// the shared <see cref="MachineService"/> from <c>YasGMP.AppCore</c>.
+    /// Routes Machine module requests from the WPF shell into the shared MAUI
+    /// <see cref="YasGMP.Services.MachineService"/> pipeline.
     /// </summary>
+    /// <remarks>
+    /// Module view models issue CRUD commands through this adapter, which immediately forwards to
+    /// <see cref="YasGMP.Services.MachineService"/> and the shared <see cref="YasGMP.Services.AuditService"/> so MAUI and WPF
+    /// stay aligned. Operations should be awaited off the dispatcher thread with UI updates dispatched via
+    /// <see cref="WpfUiDispatcher"/>. The <see cref="CrudSaveResult"/> contains identifiers, signature metadata, and status/note
+    /// text that callers translate using <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/> before
+    /// presenting them in the shell.
+    /// </remarks>
     public sealed class MachineCrudServiceAdapter : IMachineCrudService
     {
         private readonly MachineService _inner;

--- a/YasGMP.Wpf/Services/PartCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/PartCrudServiceAdapter.cs
@@ -11,9 +11,21 @@ using YasGMP.Services.Interfaces;
 namespace YasGMP.Wpf.Services
 {
     /// <summary>
-    /// Concrete adapter that routes CRUD requests from the WPF shell to the
-    /// shared <see cref="PartService"/> and <see cref="DatabaseService"/>.
+    /// Bridges the Parts module view models in the WPF shell to the shared MAUI
+    /// <see cref="YasGMP.Services.PartService"/> pipeline and related infrastructure.
     /// </summary>
+    /// <remarks>
+    /// Requests originate from module view models (for example the docked Parts editor),
+    /// travel through this adapter, and end at the shared <see cref="YasGMP.Services.PartService"/>
+    /// and <see cref="YasGMP.Services.DatabaseService"/> just as they do in the MAUI shell.
+    /// Callers should await the asynchronous operations off the UI thread and marshal UI updates
+    /// back to the dispatcher via <see cref="WpfUiDispatcher"/>. The <see cref="CrudSaveResult"/>
+    /// returned by create/update operations includes the persisted identifier together with status,
+    /// signature, and session metadata that must be localized with <see cref="LocalizationServiceExtensions"/>
+    /// (or an <see cref="ILocalizationService"/>) before presenting any status or note text.
+    /// Audit trails are recorded through the shared <see cref="YasGMP.Services.AuditService"/>, ensuring
+    /// WPF operations remain visible to the cross-platform MAUI auditing experiences.
+    /// </remarks>
     public sealed class PartCrudServiceAdapter : IPartCrudService
     {
         private readonly PartService _partService;

--- a/YasGMP.Wpf/Services/ScheduledJobCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/ScheduledJobCrudServiceAdapter.cs
@@ -11,8 +11,17 @@ using YasGMP.Services;
 namespace YasGMP.Wpf.Services;
 
 /// <summary>
-/// Adapter that bridges the WPF shell to <see cref="DatabaseService"/> for scheduled jobs.
+/// Connects the WPF Scheduled Job module to the shared database-backed MAUI services exposed through
+/// <see cref="YasGMP.Services.DatabaseService"/>.
 /// </summary>
+/// <remarks>
+/// Module view models invoke this adapter which executes the same SQL routines as the MAUI app via
+/// <see cref="YasGMP.Services.DatabaseService"/> and surfaces audit metadata that ultimately feeds
+/// <see cref="YasGMP.Services.AuditService"/>. Calls should be awaited off the UI thread with UI updates marshalled via
+/// <see cref="WpfUiDispatcher"/>. <see cref="CrudSaveResult"/> values carry identifiers, scheduling status, and signature data;
+/// callers are responsible for localizing the status/comment text using <see cref="LocalizationServiceExtensions"/> or
+/// <see cref="ILocalizationService"/> before displaying it to operators.
+/// </remarks>
 public sealed class ScheduledJobCrudServiceAdapter : IScheduledJobCrudService
 {
     private readonly DatabaseService _database;

--- a/YasGMP.Wpf/Services/SupplierCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/SupplierCrudServiceAdapter.cs
@@ -10,9 +10,18 @@ using YasGMP.Services;
 namespace YasGMP.Wpf.Services;
 
 /// <summary>
-/// Adapter that allows the WPF shell to reuse the shared <see cref="SupplierService"/>
-/// while capturing the extra audit metadata required by desktop saves.
+/// Bridges supplier workflows in the WPF shell to the shared MAUI
+/// <see cref="YasGMP.Services.SupplierService"/> and supporting persistence services.
 /// </summary>
+/// <remarks>
+/// Supplier module view models issue CRUD commands through this adapter; requests are then forwarded to
+/// <see cref="YasGMP.Services.SupplierService"/> and <see cref="YasGMP.Services.DatabaseService"/> so both shells share the
+/// same persistence and audit story. Await operations off the UI thread and dispatch UI updates via
+/// <see cref="WpfUiDispatcher"/>. The returned <see cref="CrudSaveResult"/> contains identifiers, status, and signature data that
+/// callers must localize with <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/> before
+/// presenting to operators. Audit information is written through <see cref="YasGMP.Services.DatabaseServiceSuppliersExtensions.LogSupplierAuditAsync(YasGMP.Services.DatabaseService,int,string,int,string?,string,string,string?,System.Threading.CancellationToken)"/>,
+/// which feeds the shared <see cref="YasGMP.Services.AuditService"/> surfaced inside MAUI.
+/// </remarks>
 public sealed class SupplierCrudServiceAdapter : ISupplierCrudService
 {
     private readonly SupplierService _supplierService;

--- a/YasGMP.Wpf/Services/UserCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/UserCrudServiceAdapter.cs
@@ -9,10 +9,16 @@ using YasGMP.Services.Interfaces;
 namespace YasGMP.Wpf.Services
 {
     /// <summary>
-    /// Default <see cref="IUserCrudService"/> implementation that forwards calls to the shared
-    /// <see cref="UserService"/> and <see cref="IRBACService"/> infrastructure while keeping the WPF shell
-    /// decoupled for unit testing.
+    /// Routes WPF user-management workflows through the shared MAUI services
+    /// <see cref="YasGMP.Services.Interfaces.IUserService"/> and <see cref="YasGMP.Services.Interfaces.IRBACService"/>.
     /// </summary>
+    /// <remarks>
+    /// Module view models dispatch CRUD/role operations to this adapter, which forwards them to the shared user and RBAC
+    /// services so behavior matches the MAUI shell (including downstream auditing via <see cref="YasGMP.Services.AuditService"/>).
+    /// Await calls off the dispatcher thread and use <see cref="WpfUiDispatcher"/> for UI updates. Returned
+    /// <see cref="CrudSaveResult"/> instances must include identifiers, signature context, and localization-ready status/notes
+    /// for processing via <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/> before surfacing.
+    /// </remarks>
     public sealed class UserCrudServiceAdapter : IUserCrudService
     {
         private readonly IUserService _userService;

--- a/YasGMP.Wpf/Services/ValidationCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/ValidationCrudServiceAdapter.cs
@@ -8,9 +8,16 @@ using YasGMP.Services;
 namespace YasGMP.Wpf.Services;
 
 /// <summary>
-/// Default <see cref="IValidationCrudService"/> implementation backed by the shared
-/// <see cref="ValidationService"/>.
+/// Forwards validation module requests from the WPF shell into the shared MAUI
+/// <see cref="YasGMP.Services.ValidationService"/> implementation.
 /// </summary>
+/// <remarks>
+/// Validation view models invoke this adapter, which delegates to <see cref="YasGMP.Services.ValidationService"/> and the
+/// shared <see cref="YasGMP.Services.AuditService"/> so persistence and audit behavior mirrors the MAUI experience. Await the
+/// asynchronous operations away from the UI thread and marshal UI updates through <see cref="WpfUiDispatcher"/>. The
+/// <see cref="CrudSaveResult"/> payload carries identifiers, status text, and signature metadata that require localization via
+/// <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/> before they are surfaced in the shell.
+/// </remarks>
 public sealed class ValidationCrudServiceAdapter : IValidationCrudService
 {
     private readonly ValidationService _inner;

--- a/YasGMP.Wpf/Services/WarehouseCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/WarehouseCrudServiceAdapter.cs
@@ -12,9 +12,16 @@ using YasGMP.Services.Interfaces;
 namespace YasGMP.Wpf.Services
 {
     /// <summary>
-    /// Adapter that exposes warehouse CRUD operations to the WPF shell while
-    /// delegating to the shared database service for persistence.
+    /// Connects WPF warehouse view models to the shared MAUI persistence stack provided by
+    /// <see cref="YasGMP.Services.DatabaseService"/> and <see cref="YasGMP.Services.AuditService"/>.
     /// </summary>
+    /// <remarks>
+    /// Warehouse module view models call into this adapter, which relays operations to the same database routines and audit
+    /// pipeline used by MAUI so ledgers stay in sync across shells. Asynchronous calls should execute off the dispatcher thread,
+    /// with UI updates marshalled via <see cref="WpfUiDispatcher"/>. The <see cref="CrudSaveResult"/> payload carries identifiers,
+    /// status text, and signature metadata that callers localize using <see cref="LocalizationServiceExtensions"/> or
+    /// <see cref="ILocalizationService"/> before surfacing to users.
+    /// </remarks>
     public sealed class WarehouseCrudServiceAdapter : IWarehouseCrudService
     {
         private readonly DatabaseService _database;

--- a/YasGMP.Wpf/Services/WorkOrderCrudServiceAdapter.cs
+++ b/YasGMP.Wpf/Services/WorkOrderCrudServiceAdapter.cs
@@ -7,8 +7,17 @@ using YasGMP.Services;
 namespace YasGMP.Wpf.Services;
 
 /// <summary>
-/// Adapter that bridges the WPF shell to the domain <see cref="WorkOrderService"/>.
+/// Bridges Work Order module view models in the WPF shell to the shared MAUI
+/// <see cref="YasGMP.Services.WorkOrderService"/> and related infrastructure.
 /// </summary>
+/// <remarks>
+/// The WPF module view models call this adapter, which then invokes
+/// <see cref="YasGMP.Services.WorkOrderService"/> and the shared <see cref="YasGMP.Services.AuditService"/>
+/// so the persisted data and audit trail match the MAUI implementation. Operations should be awaited off the
+/// dispatcher thread, with UI updates marshalled through <see cref="WpfUiDispatcher"/>. The <see cref="CrudSaveResult"/>
+/// returned by save operations must propagate identifiers, status text, and signature metadata which callers localize through
+/// <see cref="LocalizationServiceExtensions"/> or <see cref="ILocalizationService"/> before surfacing to operators.
+/// </remarks>
 public sealed class WorkOrderCrudServiceAdapter : IWorkOrderCrudService
 {
     private readonly WorkOrderService _service;

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -52,6 +52,7 @@
   - 2025-09-24: Batch 0 rerun inside container confirmed `.NET 9` CLI is still missing; all `dotnet` commands fail immediately. Remains a prerequisite before module CRUD refactors can progress.
 
 ## Notes
+- 2025-10-07: Refreshed CRUD service adapter/interface XML documentation to spell out WPF module → adapter → MAUI service flow, dispatcher marshalling, localization responsibilities, and shared audit plumbing; `dotnet restore`/`dotnet build`/smoke reruns still fail because the `dotnet` CLI is unavailable in this container.
 - 2026-01-28: Expanded CFL dialog service XML documentation so Golden Arrow callers understand dispatcher invocation, owner wiring, localization sourcing, and how to feed selections into the audit appenders while dotnet restore/build/smoke remain blocked by the missing CLI.
 - 2026-01-29: Expanded shell interaction/navigation service XML docs covering ribbon & Golden Arrow usage patterns, dispatcher marshalling, and how <code>IModuleRegistry</code> metadata drives inspector/audit wiring while dotnet restore/build/smoke remain blocked by the missing CLI.
 - 2026-01-30: Documented WPF electronic signature dialog interface/service XML remarks covering shell entry points, dispatcher requirements, localization hooks, and audit/cancellation parity guidance while dotnet restore/build/smoke remain blocked by the missing CLI.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -44,7 +44,8 @@
       "2026-01-11: dotnet restore/build retried for yasgmp.sln and platform-specific targets; CLI remains unavailable in the container so each command fails with \"command not found\".",
       "2026-01-12: dotnet restore/build/test attempted for yasgmp.sln, YasGMP.Wpf, and MAUI net9.0-windows targets; CLI still missing so every command exits with 'command not found'.",
       "2026-01-13: dotnet restore retried for yasgmp.sln after API audit filter refresh updates; CLI remains unavailable so the command exits with 'command not found'.",
-      "2026-01-28: dotnet restore yasgmp.sln retried; CLI remains unavailable in the container so the command exits with 'command not found'."
+      "2026-01-28: dotnet restore yasgmp.sln retried; CLI remains unavailable in the container so the command exits with 'command not found'.",
+      "2025-10-07: dotnet restore yasgmp.sln retried for CRUD adapter documentation; CLI remains unavailable so the command exits with 'command not found'."
     ]
   },
   "batches": [
@@ -78,7 +79,8 @@
         "Test signature dialog now records capture results and persist calls, CRUD fakes expose configurable signature id providers, and module regression tests assert adapter-assigned ids skip redundant persistence while CLI validation remains blocked.",
         "2026-01-28: CFL dialog service XML docs now instruct modules on dispatcher usage, localization sourcing, and audit appenders so Golden Arrow flows capture selections even while CLI access is blocked.",
         "2026-01-29: Shell interaction/navigation service XML documentation now outlines ribbon/Golden Arrow usage, dispatcher marshalling expectations, and cross-references IModuleRegistry metadata so audit and inspector updates stay aligned while CLI access remains blocked.",
-        "2026-01-30: Electronic signature dialog service/interface XML documentation now details dispatcher usage, localization hooks, audit de-duplication, and cancellation guidance so WPF stays aligned with MAUI while CLI access remains blocked."
+        "2026-01-30: Electronic signature dialog service/interface XML documentation now details dispatcher usage, localization hooks, audit de-duplication, and cancellation guidance so WPF stays aligned with MAUI while CLI access remains blocked.",
+        "2025-10-07: CRUD service adapters/interfaces now document WPF module to MAUI service call flow, dispatcher marshalling, localization, and audit expectations; dotnet CLI remains missing so validation is limited to static analysis."
       ]
     },
     {
@@ -110,7 +112,7 @@
     "Reports": "pending",
     "SettingsAdmin": "pending"
   },
-  "lastCommitSummary": "fix: auto-refresh API audit filters",
+  "lastCommitSummary": "docs: expand CRUD adapter XML guidance",
   "notes": [
     "2025-10-02: WPF AuditDashboardDocument view mirrors the MAUI filters/exports with busy overlay + App.xaml DataTemplate wiring while dotnet restore/build remain blocked by the missing CLI.",
     "2026-01-22: ModuleToolbarCommand XML documentation now captures localization-driven captions/tooltips/automation metadata, SAP B1 form mode enablement, and Golden Arrow identifiers while dotnet restore/build/smoke remain blocked by the missing CLI.",


### PR DESCRIPTION
## Summary
- Documented each WPF CRUD service adapter to explain the module → adapter → shared MAUI service flow along with dispatcher, localization, and audit expectations.
- Updated the corresponding I*CrudService contracts so MAUI/WPF consumers understand the shared metadata, CrudSaveResult payloads, and localization/dispatcher responsibilities.
- Recorded the XML documentation batch and the continuing `dotnet` CLI blocker in codex plan/progress artifacts.

## Testing
- `dotnet restore yasgmp.sln` *(fails: `dotnet` command not available in container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence).
- [ ] MAUI builds/runs unaffected.
- [ ] Shared AppCore extraction complete where required; adapters compiled.
- [ ] ModulesPane lists every module and opens feature-parity editors.
- [ ] B1 FormModes & command enablement wired across editors.
- [ ] CFL pickers + Golden Arrow navigation working.
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end.
- [ ] Warehouse ledger with running balance and alerts.
- [ ] Audit surfacing + e-signature prompts on critical saves.
- [ ] Attachments DB-backed with upload/preview/download.
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented.
- [ ] Smoke tests succeed and log output.
- [ ] `README_WPF_SHELL.md` and `/docs/WPF_MAPPING.md` kept current.

------
https://chatgpt.com/codex/tasks/task_e_68e4e03c4cac8331acd597d414e1e2d3