### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.AppCore/Services/DatabaseService.Layouts.Extensions.cs
+++ b/YasGMP.AppCore/Services/DatabaseService.Layouts.Extensions.cs
@@ -1,0 +1,189 @@
+// ==============================================================================
+// File: Services/DatabaseService.Layouts.Extensions.cs
+// Purpose: User window layout persistence helpers for DatabaseService.
+// ==============================================================================
+
+#nullable enable
+
+using System;
+using System.Data;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using MySqlConnector;
+
+namespace YasGMP.Services
+{
+    /// <summary>
+    /// Extension helpers that persist user-specific window layouts through <see cref="DatabaseService"/>.
+    /// </summary>
+    public static class DatabaseServiceLayoutsExtensions
+    {
+        /// <summary>
+        /// Represents dock/window geometry persisted alongside a layout definition.
+        /// </summary>
+        /// <param name="Left">The left coordinate.</param>
+        /// <param name="Top">The top coordinate.</param>
+        /// <param name="Width">The width.</param>
+        /// <param name="Height">The height.</param>
+        public sealed record UserWindowLayoutGeometry(double? Left, double? Top, double? Width, double? Height);
+
+        /// <summary>
+        /// Represents a persisted layout snapshot.
+        /// </summary>
+        /// <param name="LayoutXml">The serialized layout XML.</param>
+        /// <param name="Geometry">The persisted geometry.</param>
+        /// <param name="SavedAt">Timestamp when the layout was last saved.</param>
+        /// <param name="CreatedAt">Timestamp when the record was created.</param>
+        /// <param name="UpdatedAt">Timestamp when the record was last updated.</param>
+        public sealed record UserWindowLayoutSnapshot(string? LayoutXml, UserWindowLayoutGeometry Geometry, DateTime? SavedAt, DateTime? CreatedAt, DateTime? UpdatedAt);
+
+        /// <summary>
+        /// Retrieves the persisted layout for the specified user and page type.
+        /// </summary>
+        /// <param name="db">The <see cref="DatabaseService"/> instance.</param>
+        /// <param name="userId">User identifier.</param>
+        /// <param name="pageType">Layout page type key.</param>
+        /// <param name="token">Cancellation token.</param>
+        /// <returns>The <see cref="UserWindowLayoutSnapshot"/> if found; otherwise <c>null</c>.</returns>
+        public static async Task<UserWindowLayoutSnapshot?> GetUserWindowLayoutAsync(
+            this DatabaseService db,
+            int userId,
+            string pageType,
+            CancellationToken token = default)
+        {
+            if (db == null) throw new ArgumentNullException(nameof(db));
+            if (string.IsNullOrWhiteSpace(pageType)) throw new ArgumentException("Value cannot be null or whitespace.", nameof(pageType));
+
+            const string sql = @"SELECT layout_xml, pos_x, pos_y, width, height, saved_at, created_at, updated_at
+FROM user_window_layouts WHERE user_id=@u AND page_type=@p LIMIT 1;";
+
+            var parameters = new[]
+            {
+                new MySqlParameter("@u", userId),
+                new MySqlParameter("@p", pageType)
+            };
+
+            var table = await db.ExecuteSelectAsync(sql, parameters, token).ConfigureAwait(false);
+            if (table.Rows.Count == 0)
+            {
+                return null;
+            }
+
+            DataRow row = table.Rows[0];
+            var geometry = new UserWindowLayoutGeometry(
+                ReadDouble(row, "pos_x"),
+                ReadDouble(row, "pos_y"),
+                ReadDouble(row, "width"),
+                ReadDouble(row, "height"));
+
+            string? layoutXml = row.Table.Columns.Contains("layout_xml") && row["layout_xml"] != DBNull.Value
+                ? row["layout_xml"].ToString()
+                : null;
+
+            DateTime? savedAt = row.Table.Columns.Contains("saved_at") && row["saved_at"] != DBNull.Value
+                ? Convert.ToDateTime(row["saved_at"], CultureInfo.InvariantCulture)
+                : null;
+            DateTime? createdAt = row.Table.Columns.Contains("created_at") && row["created_at"] != DBNull.Value
+                ? Convert.ToDateTime(row["created_at"], CultureInfo.InvariantCulture)
+                : null;
+            DateTime? updatedAt = row.Table.Columns.Contains("updated_at") && row["updated_at"] != DBNull.Value
+                ? Convert.ToDateTime(row["updated_at"], CultureInfo.InvariantCulture)
+                : null;
+
+            return new UserWindowLayoutSnapshot(layoutXml, geometry, savedAt, createdAt, updatedAt);
+        }
+
+        /// <summary>
+        /// Persists or updates the layout for the specified user/page combination.
+        /// </summary>
+        /// <param name="db">The <see cref="DatabaseService"/> instance.</param>
+        /// <param name="userId">User identifier.</param>
+        /// <param name="pageType">Layout page type key.</param>
+        /// <param name="layoutXml">Serialized layout XML.</param>
+        /// <param name="geometry">Persisted geometry values.</param>
+        /// <param name="token">Cancellation token.</param>
+        public static async Task SaveUserWindowLayoutAsync(
+            this DatabaseService db,
+            int userId,
+            string pageType,
+            string? layoutXml,
+            UserWindowLayoutGeometry geometry,
+            CancellationToken token = default)
+        {
+            if (db == null) throw new ArgumentNullException(nameof(db));
+            if (string.IsNullOrWhiteSpace(pageType)) throw new ArgumentException("Value cannot be null or whitespace.", nameof(pageType));
+            if (geometry == null) throw new ArgumentNullException(nameof(geometry));
+
+            const string sql = @"INSERT INTO user_window_layouts (user_id, page_type, layout_xml, pos_x, pos_y, width, height, saved_at, created_at, updated_at)
+VALUES (@u, @p, @layout, @x, @y, @w, @h, UTC_TIMESTAMP(), UTC_TIMESTAMP(), UTC_TIMESTAMP())
+ON DUPLICATE KEY UPDATE
+    layout_xml = VALUES(layout_xml),
+    pos_x = VALUES(pos_x),
+    pos_y = VALUES(pos_y),
+    width = VALUES(width),
+    height = VALUES(height),
+    saved_at = UTC_TIMESTAMP(),
+    updated_at = UTC_TIMESTAMP(),
+    created_at = COALESCE(created_at, VALUES(created_at));";
+
+            var parameters = new[]
+            {
+                new MySqlParameter("@u", userId),
+                new MySqlParameter("@p", pageType),
+                new MySqlParameter("@layout", string.IsNullOrWhiteSpace(layoutXml) ? DBNull.Value : layoutXml),
+                CreateNullableDoubleParameter("@x", geometry.Left),
+                CreateNullableDoubleParameter("@y", geometry.Top),
+                CreateNullableDoubleParameter("@w", geometry.Width),
+                CreateNullableDoubleParameter("@h", geometry.Height)
+            };
+
+            await db.ExecuteNonQueryAsync(sql, parameters, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Deletes the persisted layout for the specified user/page combination.
+        /// </summary>
+        /// <param name="db">The <see cref="DatabaseService"/> instance.</param>
+        /// <param name="userId">User identifier.</param>
+        /// <param name="pageType">Layout page type key.</param>
+        /// <param name="token">Cancellation token.</param>
+        public static Task DeleteUserWindowLayoutAsync(
+            this DatabaseService db,
+            int userId,
+            string pageType,
+            CancellationToken token = default)
+        {
+            if (db == null) throw new ArgumentNullException(nameof(db));
+            if (string.IsNullOrWhiteSpace(pageType)) throw new ArgumentException("Value cannot be null or whitespace.", nameof(pageType));
+
+            const string sql = "DELETE FROM user_window_layouts WHERE user_id=@u AND page_type=@p;";
+            var parameters = new[]
+            {
+                new MySqlParameter("@u", userId),
+                new MySqlParameter("@p", pageType)
+            };
+
+            return db.ExecuteNonQueryAsync(sql, parameters, token);
+        }
+
+        private static double? ReadDouble(DataRow row, string column)
+        {
+            if (!row.Table.Columns.Contains(column) || row[column] == DBNull.Value)
+            {
+                return null;
+            }
+
+            return Convert.ToDouble(row[column], CultureInfo.InvariantCulture);
+        }
+
+        private static MySqlParameter CreateNullableDoubleParameter(string name, double? value)
+        {
+            var parameter = new MySqlParameter(name, MySqlDbType.Double)
+            {
+                Value = value.HasValue ? value.Value : DBNull.Value
+            };
+            return parameter;
+        }
+    }
+}

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -54,6 +54,7 @@
   - 2025-09-24: Batch 0 rerun inside container confirmed `.NET 9` CLI is still missing; all `dotnet` commands fail immediately. Remains a prerequisite before module CRUD refactors can progress.
 
 ## Notes
+- 2026-02-03: Added DatabaseService layout persistence extensions so WPF shell sessions can round-trip ribbon/dock arrangements even while .NET tooling remains unavailable in the container; tests remain blocked pending SDK installation.
 - 2025-10-07: Refreshed CRUD service adapter/interface XML documentation to spell out WPF module → adapter → MAUI service flow, dispatcher marshalling, localization responsibilities, and shared audit plumbing; `dotnet restore`/`dotnet build`/smoke reruns still fail because the `dotnet` CLI is unavailable in this container.
 - 2025-10-07: Re-enabled CS1591 warnings by removing the repo-wide suppression, added XML documentation across AppCore data models and MAUI shell session properties, and recorded the continued `dotnet restore`/`dotnet build` failures due to the missing CLI.
 - 2025-10-07: Elevated documentation enforcement by promoting CS1591 to a warnings-as-errors rule in `Directory.Build.props`; attempted `dotnet build` still fails with `command not found` until the .NET CLI is installed.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -119,6 +119,7 @@
   },
   "lastCommitSummary": "docs: expand CRUD adapter XML guidance",
   "notes": [
+    "2026-02-03: DatabaseService now exposes layout persistence helpers so the WPF shell can store per-user dock/ribbon arrangements even though dotnet restore/build remain blocked by the missing CLI.",
     "2025-10-02: WPF AuditDashboardDocument view mirrors the MAUI filters/exports with busy overlay + App.xaml DataTemplate wiring while dotnet restore/build remain blocked by the missing CLI.",
     "2026-02-01: WPF dialog, file picker, platform, and dispatcher services now document MAUI parity limits, localization responsibilities, and migration guidance; dotnet restore/build/smoke still blocked without the CLI.",
     "2026-01-22: ModuleToolbarCommand XML documentation now captures localization-driven captions/tooltips/automation metadata, SAP B1 form mode enablement, and Golden Arrow identifiers while dotnet restore/build/smoke remain blocked by the missing CLI.",


### PR DESCRIPTION
## Summary
- add DatabaseService layouts extension helpers for retrieving, saving, and deleting per-user window layouts
- capture the layout persistence work in codex planning/progress documentation while .NET tooling remains unavailable

## Testing
- dotnet restore *(fails: command not found – .NET SDK unavailable in container)*
- dotnet build yasgmp.sln *(fails: command not found – .NET SDK unavailable in container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence) *(blocked: dotnet CLI unavailable in container)*
- [ ] MAUI builds/runs unaffected *(blocked: dotnet CLI unavailable in container)*
- [ ] Shared AppCore extraction complete where required; adapters compiled *(unchanged this batch)*
- [ ] ModulesPane lists every module and opens feature-parity editors *(unchanged this batch)*
- [ ] B1 FormModes & command enablement wired across editors *(unchanged this batch)*
- [ ] CFL pickers + Golden Arrow navigation working *(unchanged this batch)*
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end *(unchanged this batch)*
- [ ] Warehouse ledger with running balance and alerts *(unchanged this batch)*
- [ ] Audit surfacing + e-signature prompts on critical saves *(unchanged this batch)*
- [ ] Attachments DB-backed with upload/preview/download *(unchanged this batch)*
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented *(unchanged this batch)*
- [ ] Smoke tests succeed and log output *(blocked pending CLI/smoke harness tooling)*
- [ ] README_WPF_SHELL.md and /docs/WPF_MAPPING.md kept current *(unchanged this batch)*

------
https://chatgpt.com/codex/tasks/task_e_68e4fddfaa748331a427756f99cdf2a6