### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Tests/DatabaseServiceLayoutsExtensionsTests.cs
+++ b/YasGMP.Tests/DatabaseServiceLayoutsExtensionsTests.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using MySqlConnector;
+using Xunit;
+using YasGMP.Services;
+
+namespace YasGMP.Tests;
+
+public class DatabaseServiceLayoutsExtensionsTests
+{
+    private const string ConnectionString = "Server=localhost;User Id=test;Password=test;Database=test;";
+
+    [Fact]
+    public async Task GetUserWindowLayoutAsync_EmitsExpectedSql_AndMapsNullableGeometry()
+    {
+        var db = new DatabaseService(ConnectionString);
+        string? capturedSql = null;
+        MySqlParameter[]? capturedParameters = null;
+        var now = DateTime.UtcNow;
+
+        var table = new DataTable();
+        table.Columns.Add("layout_xml", typeof(string));
+        table.Columns.Add("pos_x", typeof(double));
+        table.Columns.Add("pos_y", typeof(double));
+        table.Columns.Add("width", typeof(double));
+        table.Columns.Add("height", typeof(double));
+        table.Columns.Add("saved_at", typeof(DateTime));
+        table.Columns.Add("created_at", typeof(DateTime));
+        table.Columns.Add("updated_at", typeof(DateTime));
+        table.Rows.Add(DBNull.Value, 15.5, DBNull.Value, 800.0, DBNull.Value, now, now.AddDays(-1), now.AddMinutes(-30));
+
+        db.ExecuteSelectOverride = (sql, parameters, _) =>
+        {
+            capturedSql = sql;
+            capturedParameters = parameters?.OfType<MySqlParameter>().ToArray();
+            return Task.FromResult(table);
+        };
+
+        try
+        {
+            var snapshot = await db.GetUserWindowLayoutAsync(7, "YasGmp.Wpf.Shell").ConfigureAwait(false);
+
+            Assert.Equal(
+                "SELECT layout_xml, pos_x, pos_y, width, height, saved_at, created_at, updated_at\nFROM user_window_layouts WHERE user_id=@u AND page_type=@p LIMIT 1;",
+                capturedSql);
+
+            Assert.NotNull(capturedParameters);
+            Assert.Collection(
+                capturedParameters!,
+                p =>
+                {
+                    Assert.Equal("@u", p.ParameterName);
+                    Assert.Equal(7, p.Value);
+                },
+                p =>
+                {
+                    Assert.Equal("@p", p.ParameterName);
+                    Assert.Equal("YasGmp.Wpf.Shell", p.Value);
+                });
+
+            Assert.NotNull(snapshot);
+            Assert.Null(snapshot!.Value.LayoutXml);
+            Assert.Equal(15.5, snapshot.Value.Geometry.Left);
+            Assert.Null(snapshot.Value.Geometry.Top);
+            Assert.Equal(800.0, snapshot.Value.Geometry.Width);
+            Assert.Null(snapshot.Value.Geometry.Height);
+            Assert.Equal(now, snapshot.Value.SavedAt);
+            Assert.Equal(now.AddDays(-1), snapshot.Value.CreatedAt);
+            Assert.Equal(now.AddMinutes(-30), snapshot.Value.UpdatedAt);
+        }
+        finally
+        {
+            db.ResetTestOverrides();
+        }
+    }
+
+    [Fact]
+    public async Task SaveUserWindowLayoutAsync_EmitsExpectedSql_AndParameters()
+    {
+        var db = new DatabaseService(ConnectionString);
+        string? capturedSql = null;
+        MySqlParameter[]? capturedParameters = null;
+
+        db.ExecuteNonQueryOverride = (sql, parameters, _) =>
+        {
+            capturedSql = sql;
+            capturedParameters = parameters?.OfType<MySqlParameter>().ToArray();
+            return Task.FromResult(1);
+        };
+
+        var geometry = new DatabaseServiceLayoutsExtensions.UserWindowLayoutGeometry(null, 20.0, null, 720.0);
+
+        try
+        {
+            await db.SaveUserWindowLayoutAsync(11, "Shell", null, geometry).ConfigureAwait(false);
+
+            const string expectedSql = "INSERT INTO user_window_layouts (user_id, page_type, layout_xml, pos_x, pos_y, width, height, saved_at, created_at, updated_at)\nVALUES (@u, @p, @layout, @x, @y, @w, @h, UTC_TIMESTAMP(), UTC_TIMESTAMP(), UTC_TIMESTAMP())\nON DUPLICATE KEY UPDATE\n    layout_xml = VALUES(layout_xml),\n    pos_x = VALUES(pos_x),\n    pos_y = VALUES(pos_y),\n    width = VALUES(width),\n    height = VALUES(height),\n    saved_at = UTC_TIMESTAMP(),\n    updated_at = UTC_TIMESTAMP(),\n    created_at = COALESCE(created_at, VALUES(created_at));";
+            Assert.Equal(expectedSql, capturedSql);
+
+            Assert.NotNull(capturedParameters);
+            Assert.Collection(
+                capturedParameters!,
+                p =>
+                {
+                    Assert.Equal("@u", p.ParameterName);
+                    Assert.Equal(11, p.Value);
+                },
+                p =>
+                {
+                    Assert.Equal("@p", p.ParameterName);
+                    Assert.Equal("Shell", p.Value);
+                },
+                p =>
+                {
+                    Assert.Equal("@layout", p.ParameterName);
+                    Assert.Equal(DBNull.Value, p.Value);
+                },
+                p =>
+                {
+                    Assert.Equal("@x", p.ParameterName);
+                    Assert.Equal(DBNull.Value, p.Value);
+                },
+                p =>
+                {
+                    Assert.Equal("@y", p.ParameterName);
+                    Assert.Equal(20.0, p.Value);
+                },
+                p =>
+                {
+                    Assert.Equal("@w", p.ParameterName);
+                    Assert.Equal(DBNull.Value, p.Value);
+                },
+                p =>
+                {
+                    Assert.Equal("@h", p.ParameterName);
+                    Assert.Equal(720.0, p.Value);
+                });
+        }
+        finally
+        {
+            db.ResetTestOverrides();
+        }
+    }
+
+    [Fact]
+    public async Task DeleteUserWindowLayoutAsync_EmitsExpectedSql_AndParameters()
+    {
+        var db = new DatabaseService(ConnectionString);
+        string? capturedSql = null;
+        MySqlParameter[]? capturedParameters = null;
+
+        db.ExecuteNonQueryOverride = (sql, parameters, _) =>
+        {
+            capturedSql = sql;
+            capturedParameters = parameters?.OfType<MySqlParameter>().ToArray();
+            return Task.FromResult(1);
+        };
+
+        try
+        {
+            await db.DeleteUserWindowLayoutAsync(3, "Reset.Key").ConfigureAwait(false);
+
+            Assert.Equal("DELETE FROM user_window_layouts WHERE user_id=@u AND page_type=@p;", capturedSql);
+            Assert.NotNull(capturedParameters);
+            Assert.Collection(
+                capturedParameters!,
+                p =>
+                {
+                    Assert.Equal("@u", p.ParameterName);
+                    Assert.Equal(3, p.Value);
+                },
+                p =>
+                {
+                    Assert.Equal("@p", p.ParameterName);
+                    Assert.Equal("Reset.Key", p.Value);
+                });
+        }
+        finally
+        {
+            db.ResetTestOverrides();
+        }
+    }
+}

--- a/YasGMP.Wpf.Tests/DockLayoutPersistenceServiceTests.cs
+++ b/YasGMP.Wpf.Tests/DockLayoutPersistenceServiceTests.cs
@@ -1,0 +1,332 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Threading;
+using AvalonDock;
+using AvalonDock.Layout;
+using AvalonDock.Layout.Serialization;
+using MySqlConnector;
+using Xunit;
+using YasGMP.Models;
+using YasGMP.Services;
+using YasGMP.Wpf.Services;
+
+namespace YasGMP.Wpf.Tests;
+
+public class DockLayoutPersistenceServiceTests
+{
+    private const string ConnectionString = "Server=localhost;Database=test;Uid=test;Pwd=test;";
+
+    [Fact]
+    public async Task LoadAsync_DelegatesToDatabaseService()
+    {
+        var database = new DatabaseService(ConnectionString);
+        var session = new StubUserSession(42);
+        string? capturedSql = null;
+        MySqlParameter[]? capturedParameters = null;
+
+        SetExecuteSelectOverride(database, (sql, parameters, _) =>
+        {
+            capturedSql = sql;
+            capturedParameters = parameters?.OfType<MySqlParameter>().ToArray();
+
+            var table = new DataTable();
+            table.Columns.Add("layout_xml", typeof(string));
+            table.Columns.Add("pos_x", typeof(double));
+            table.Columns.Add("pos_y", typeof(double));
+            table.Columns.Add("width", typeof(double));
+            table.Columns.Add("height", typeof(double));
+            table.Columns.Add("saved_at", typeof(DateTime));
+            table.Columns.Add("created_at", typeof(DateTime));
+            table.Columns.Add("updated_at", typeof(DateTime));
+            table.Rows.Add("<layout />", 10.0, 20.0, 1024.0, 768.0, DateTime.UtcNow, DateTime.UtcNow.AddDays(-1), DateTime.UtcNow);
+            return Task.FromResult(table);
+        });
+
+        try
+        {
+            var service = new DockLayoutPersistenceService(database, session);
+            var snapshot = await service.LoadAsync("Shell", CancellationToken.None).ConfigureAwait(false);
+
+            Assert.NotNull(snapshot);
+            Assert.Equal("<layout />", snapshot!.Value.LayoutXml);
+            Assert.Equal(10.0, snapshot.Value.Left);
+            Assert.Equal(20.0, snapshot.Value.Top);
+            Assert.Equal(1024.0, snapshot.Value.Width);
+            Assert.Equal(768.0, snapshot.Value.Height);
+
+            Assert.Equal(
+                "SELECT layout_xml, pos_x, pos_y, width, height, saved_at, created_at, updated_at\nFROM user_window_layouts WHERE user_id=@u AND page_type=@p LIMIT 1;",
+                capturedSql);
+            Assert.Collection(
+                capturedParameters ?? Array.Empty<MySqlParameter>(),
+                p =>
+                {
+                    Assert.Equal("@u", p.ParameterName);
+                    Assert.Equal(42, p.Value);
+                },
+                p =>
+                {
+                    Assert.Equal("@p", p.ParameterName);
+                    Assert.Equal("Shell", p.Value);
+                });
+        }
+        finally
+        {
+            ResetOverrides(database);
+        }
+    }
+
+    [Fact]
+    public async Task SaveAsync_DelegatesToDatabaseService_WithNullableGeometry()
+    {
+        var database = new DatabaseService(ConnectionString);
+        var session = new StubUserSession(77);
+        string? capturedSql = null;
+        MySqlParameter[]? capturedParameters = null;
+
+        SetExecuteNonQueryOverride(database, (sql, parameters, _) =>
+        {
+            capturedSql = sql;
+            capturedParameters = parameters?.OfType<MySqlParameter>().ToArray();
+            return Task.FromResult(1);
+        });
+
+        try
+        {
+            var service = new DockLayoutPersistenceService(database, session);
+            var geometry = new WindowGeometry(null, 64.0, 1400.0, null);
+            await service.SaveAsync("Shell", "<layoutXml />", geometry, CancellationToken.None).ConfigureAwait(false);
+
+            const string expectedSql = "INSERT INTO user_window_layouts (user_id, page_type, layout_xml, pos_x, pos_y, width, height, saved_at, created_at, updated_at)\nVALUES (@u, @p, @layout, @x, @y, @w, @h, UTC_TIMESTAMP(), UTC_TIMESTAMP(), UTC_TIMESTAMP())\nON DUPLICATE KEY UPDATE\n    layout_xml = VALUES(layout_xml),\n    pos_x = VALUES(pos_x),\n    pos_y = VALUES(pos_y),\n    width = VALUES(width),\n    height = VALUES(height),\n    saved_at = UTC_TIMESTAMP(),\n    updated_at = UTC_TIMESTAMP(),\n    created_at = COALESCE(created_at, VALUES(created_at));";
+            Assert.Equal(expectedSql, capturedSql);
+            Assert.Collection(
+                capturedParameters ?? Array.Empty<MySqlParameter>(),
+                p =>
+                {
+                    Assert.Equal("@u", p.ParameterName);
+                    Assert.Equal(77, p.Value);
+                },
+                p =>
+                {
+                    Assert.Equal("@p", p.ParameterName);
+                    Assert.Equal("Shell", p.Value);
+                },
+                p =>
+                {
+                    Assert.Equal("@layout", p.ParameterName);
+                    Assert.Equal("<layoutXml />", p.Value);
+                },
+                p =>
+                {
+                    Assert.Equal("@x", p.ParameterName);
+                    Assert.Equal(DBNull.Value, p.Value);
+                },
+                p =>
+                {
+                    Assert.Equal("@y", p.ParameterName);
+                    Assert.Equal(64.0, p.Value);
+                },
+                p =>
+                {
+                    Assert.Equal("@w", p.ParameterName);
+                    Assert.Equal(1400.0, p.Value);
+                },
+                p =>
+                {
+                    Assert.Equal("@h", p.ParameterName);
+                    Assert.Equal(DBNull.Value, p.Value);
+                });
+        }
+        finally
+        {
+            ResetOverrides(database);
+        }
+    }
+
+    [Fact]
+    public async Task ResetAsync_DelegatesToDatabaseService()
+    {
+        var database = new DatabaseService(ConnectionString);
+        var session = new StubUserSession(91);
+        string? capturedSql = null;
+        MySqlParameter[]? capturedParameters = null;
+
+        SetExecuteNonQueryOverride(database, (sql, parameters, _) =>
+        {
+            capturedSql = sql;
+            capturedParameters = parameters?.OfType<MySqlParameter>().ToArray();
+            return Task.FromResult(1);
+        });
+
+        try
+        {
+            var service = new DockLayoutPersistenceService(database, session);
+            await service.ResetAsync("Shell", CancellationToken.None).ConfigureAwait(false);
+
+            Assert.Equal("DELETE FROM user_window_layouts WHERE user_id=@u AND page_type=@p;", capturedSql);
+            Assert.Collection(
+                capturedParameters ?? Array.Empty<MySqlParameter>(),
+                p =>
+                {
+                    Assert.Equal("@u", p.ParameterName);
+                    Assert.Equal(91, p.Value);
+                },
+                p =>
+                {
+                    Assert.Equal("@p", p.ParameterName);
+                    Assert.Equal("Shell", p.Value);
+                });
+        }
+        finally
+        {
+            ResetOverrides(database);
+        }
+    }
+
+    [Fact]
+    public async Task ShellLayoutController_ResetLayoutAsync_InvokesResetBeforeSave()
+    {
+        await RunOnStaThread(async () =>
+        {
+            var database = new DatabaseService(ConnectionString);
+            var session = new StubUserSession(101);
+            var persistence = new DockLayoutPersistenceService(database, session);
+            var controller = new ShellLayoutController(persistence);
+
+            var dockManager = new DockingManager();
+            var layoutRoot = new LayoutRoot();
+            var layoutPanel = new LayoutPanel();
+            layoutPanel.Children.Add(new LayoutDocumentPane());
+            layoutRoot.RootPanel = layoutPanel;
+            dockManager.Layout = layoutRoot;
+
+            var serializer = new XmlLayoutSerializer(dockManager);
+            string defaultLayout;
+            using (var writer = new System.IO.StringWriter())
+            {
+                serializer.Serialize(writer);
+                defaultLayout = writer.ToString();
+            }
+
+            SetPrivateField(controller, "_dockManager", dockManager);
+            SetPrivateField(controller, "_defaultLayout", defaultLayout);
+
+            var window = new Window
+            {
+                Width = 1280,
+                Height = 720,
+                Left = 100,
+                Top = 100
+            };
+
+            var sqlCalls = new List<string>();
+            SetExecuteNonQueryOverride(database, (sql, parameters, _) =>
+            {
+                sqlCalls.Add(sql);
+                return Task.FromResult(1);
+            });
+
+            try
+            {
+                await controller.ResetLayoutAsync(window, CancellationToken.None).ConfigureAwait(false);
+                Assert.Equal(2, sqlCalls.Count);
+                Assert.Equal("DELETE FROM user_window_layouts WHERE user_id=@u AND page_type=@p;", sqlCalls[0]);
+                Assert.StartsWith("INSERT INTO user_window_layouts", sqlCalls[1], StringComparison.Ordinal);
+            }
+            finally
+            {
+                window.Close();
+                ResetOverrides(database);
+            }
+        });
+    }
+
+    private static Task RunOnStaThread(Func<Task> action)
+    {
+        var tcs = new TaskCompletionSource<object?>();
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                SynchronizationContext.SetSynchronizationContext(new DispatcherSynchronizationContext());
+                var dispatcher = Dispatcher.CurrentDispatcher;
+                dispatcher.InvokeAsync(async () =>
+                {
+                    try
+                    {
+                        await action().ConfigureAwait(true);
+                        tcs.SetResult(null);
+                    }
+                    catch (Exception ex)
+                    {
+                        tcs.SetException(ex);
+                    }
+                    finally
+                    {
+                        dispatcher.BeginInvokeShutdown(DispatcherPriority.Background);
+                    }
+                });
+                Dispatcher.Run();
+            }
+            catch (Exception ex)
+            {
+                tcs.TrySetException(ex);
+            }
+        })
+        {
+            IsBackground = true
+        };
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        return tcs.Task;
+    }
+
+    private static void SetExecuteSelectOverride(DatabaseService database, Func<string, IEnumerable<MySqlParameter>?, CancellationToken, Task<DataTable>> factory)
+    {
+        var property = typeof(DatabaseService).GetProperty("ExecuteSelectOverride", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingMemberException(nameof(DatabaseService), "ExecuteSelectOverride");
+        property.SetValue(database, factory);
+    }
+
+    private static void SetExecuteNonQueryOverride(DatabaseService database, Func<string, IEnumerable<MySqlParameter>?, CancellationToken, Task<int>> factory)
+    {
+        var property = typeof(DatabaseService).GetProperty("ExecuteNonQueryOverride", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingMemberException(nameof(DatabaseService), "ExecuteNonQueryOverride");
+        property.SetValue(database, factory);
+    }
+
+    private static void ResetOverrides(DatabaseService database)
+    {
+        var method = typeof(DatabaseService).GetMethod("ResetTestOverrides", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingMemberException(nameof(DatabaseService), "ResetTestOverrides");
+        method.Invoke(database, null);
+    }
+
+    private static void SetPrivateField(object target, string fieldName, object? value)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingMemberException(target.GetType().Name, fieldName);
+        field.SetValue(target, value);
+    }
+
+    private sealed class StubUserSession : IUserSession
+    {
+        public StubUserSession(int userId)
+        {
+            UserId = userId;
+            SessionId = Guid.NewGuid().ToString("N");
+        }
+
+        public User? CurrentUser => null;
+        public int? UserId { get; }
+        public string? Username => "test";
+        public string? FullName => "Test User";
+        public string SessionId { get; }
+    }
+}

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -54,6 +54,7 @@
   - 2025-09-24: Batch 0 rerun inside container confirmed `.NET 9` CLI is still missing; all `dotnet` commands fail immediately. Remains a prerequisite before module CRUD refactors can progress.
 
 ## Notes
+- 2026-02-06: Added layout persistence regression tests covering DatabaseService helpers, DockLayoutPersistenceService forwarding, and ShellLayoutController reset ordering so SQL payloads and reset/save sequencing stay exercised even while the dotnet CLI is unavailable in this container.
 - 2026-02-05: Shell layout reset now clears the persisted snapshot via DockLayoutPersistenceService.ResetAsync before saving the default layout so the database state stays aligned with the restored UI; dotnet CLI remains unavailable for restore/build validation in this container.
 - 2025-10-07: Retired the redundant DatabaseOptions wrapper and host registration so DockLayoutPersistenceService continues to resolve the shared DatabaseService singleton directly for layout persistence while dotnet tooling remains unavailable in the container.
 - 2026-02-03: Added DatabaseService layout persistence extensions so WPF shell sessions can round-trip ribbon/dock arrangements even while .NET tooling remains unavailable in the container; tests remain blocked pending SDK installation.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -50,6 +50,7 @@
       "2025-10-07: dotnet restore yasgmp.sln retried for CRUD adapter documentation; CLI remains unavailable so the command exits with 'command not found'.",
       "2026-02-02: dotnet restore/build retried for yasgmp.sln, YasGMP.Wpf.csproj, and MAUI net8.0-windows10.0.19041.0; CLI remains unavailable so each command exits with 'command not found'.",
       "2026-02-05: dotnet restore yasgmp.sln retried after Shell layout reset adjustments; CLI remains unavailable so the command exits with 'command not found'.",
+      "2026-02-06: dotnet --info and dotnet restore yasgmp.sln retried while adding layout persistence tests; CLI still missing so both commands exit with 'command not found'.",
       "2025-10-07T11:06Z: Latest container session reconfirmed 'command not found' for dotnet --info; continuing documentation-only cadence until SDK installation.",
     ]
   },
@@ -125,6 +126,7 @@
   },
   "lastCommitSummary": "docs: expand CRUD adapter XML guidance",
   "notes": [
+    "2026-02-06: Added regression tests for DatabaseService layout helpers, DockLayoutPersistenceService forwarding, and ShellLayoutController reset sequencing so SQL payloads stay covered while dotnet tooling remains unavailable.",
     "2026-02-03: DatabaseService now exposes layout persistence helpers so the WPF shell can store per-user dock/ribbon arrangements even though dotnet restore/build remain blocked by the missing CLI.",
     "2025-10-02: WPF AuditDashboardDocument view mirrors the MAUI filters/exports with busy overlay + App.xaml DataTemplate wiring while dotnet restore/build remain blocked by the missing CLI.",
     "2026-02-01: WPF dialog, file picker, platform, and dispatcher services now document MAUI parity limits, localization responsibilities, and migration guidance; dotnet restore/build/smoke still blocked without the CLI.",


### PR DESCRIPTION
## Summary
- add focused DatabaseService layout helper tests to assert SQL text, parameters, and nullable geometry handling
- cover DockLayoutPersistenceService load/save/reset flows plus ShellLayoutController reset sequencing with STA-safe fakes
- document the new regression coverage and repeated CLI blocker in codex_plan/codex_progress

## Testing
- `dotnet --info` *(fails: command not found in container)*
- `dotnet restore yasgmp.sln` *(fails: command not found in container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence).
- [ ] MAUI builds/runs unaffected.
- [ ] Shared AppCore extraction complete where required; adapters compiled.
- [ ] ModulesPane lists every module and opens feature-parity editors.
- [ ] B1 FormModes & command enablement wired across editors.
- [ ] CFL pickers + Golden Arrow navigation working.
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end.
- [ ] Warehouse ledger with running balance and alerts.
- [ ] Audit surfacing + e-signature prompts on critical saves.
- [ ] Attachments DB-backed with upload/preview/download.
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented.
- [ ] Smoke tests succeed and log output.
- [ ] `README_WPF_SHELL.md` and `/docs/WPF_MAPPING.md` kept current.

------
https://chatgpt.com/codex/tasks/task_e_68e50431ffdc83318156bdf082df5dc8