### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf/Controls/ShellStatusBar.xaml
+++ b/YasGMP.Wpf/Controls/ShellStatusBar.xaml
@@ -6,12 +6,121 @@
              mc:Ignorable="d"
              d:DesignHeight="24"
              d:DesignWidth="800">
-    <Border Background="#2D2D30" Padding="8,2">
-        <DockPanel>
-            <TextBlock Text="{Binding StatusText}" Foreground="White" />
-            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
-                <TextBlock Text="Active:" Foreground="#AAAAAA" Margin="0,0,4,0" />
-                <TextBlock Text="{Binding ActiveModule}" Foreground="#CCCCCC" />
+    <Border Background="#2D2D30"
+            Padding="8,2"
+            ToolTipService.ToolTip="{DynamicResource Shell.StatusBar.Container.ToolTip}"
+            AutomationProperties.Name="{DynamicResource Shell.StatusBar.Container.AutomationName}"
+            AutomationProperties.AutomationId="{DynamicResource Shell.StatusBar.Container.AutomationId}">
+        <DockPanel LastChildFill="True">
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                <TextBlock Text="{DynamicResource Shell.StatusBar.Status.Label}"
+                           Foreground="#AAAAAA"
+                           Margin="0,0,4,0"
+                           VerticalAlignment="Center"
+                           ToolTipService.ToolTip="{DynamicResource Shell.StatusBar.Status.Label.ToolTip}"
+                           AutomationProperties.Name="{DynamicResource Shell.StatusBar.Status.Label.AutomationName}"
+                           AutomationProperties.AutomationId="{DynamicResource Shell.StatusBar.Status.Label.AutomationId}" />
+                <TextBlock Text="{Binding StatusText}"
+                           Foreground="White"
+                           VerticalAlignment="Center"
+                           ToolTipService.ToolTip="{DynamicResource Shell.StatusBar.Status.Value.ToolTip}"
+                           AutomationProperties.Name="{DynamicResource Shell.StatusBar.Status.Value.AutomationName}"
+                           AutomationProperties.AutomationId="{DynamicResource Shell.StatusBar.Status.Value.AutomationId}" />
+                <TextBlock Text="{DynamicResource Shell.StatusBar.ActiveModule.Label}"
+                           Foreground="#AAAAAA"
+                           Margin="16,0,4,0"
+                           VerticalAlignment="Center"
+                           ToolTipService.ToolTip="{DynamicResource Shell.StatusBar.ActiveModule.Label.ToolTip}"
+                           AutomationProperties.Name="{DynamicResource Shell.StatusBar.ActiveModule.Label.AutomationName}"
+                           AutomationProperties.AutomationId="{DynamicResource Shell.StatusBar.ActiveModule.Label.AutomationId}" />
+                <TextBlock Text="{Binding ActiveModule}"
+                           Foreground="#CCCCCC"
+                           VerticalAlignment="Center"
+                           ToolTipService.ToolTip="{DynamicResource Shell.StatusBar.ActiveModule.Value.ToolTip}"
+                           AutomationProperties.Name="{DynamicResource Shell.StatusBar.ActiveModule.Value.AutomationName}"
+                           AutomationProperties.AutomationId="{DynamicResource Shell.StatusBar.ActiveModule.Value.AutomationId}" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal"
+                        DockPanel.Dock="Right"
+                        VerticalAlignment="Center">
+                <TextBlock Text="{DynamicResource Shell.StatusBar.Company.Label}"
+                           Foreground="#AAAAAA"
+                           Margin="16,0,4,0"
+                           VerticalAlignment="Center"
+                           ToolTipService.ToolTip="{DynamicResource Shell.StatusBar.Company.Label.ToolTip}"
+                           AutomationProperties.Name="{DynamicResource Shell.StatusBar.Company.Label.AutomationName}"
+                           AutomationProperties.AutomationId="{DynamicResource Shell.StatusBar.Company.Label.AutomationId}" />
+                <TextBlock Text="{Binding Company}"
+                           Foreground="#CCCCCC"
+                           VerticalAlignment="Center"
+                           ToolTipService.ToolTip="{DynamicResource Shell.StatusBar.Company.Value.ToolTip}"
+                           AutomationProperties.Name="{DynamicResource Shell.StatusBar.Company.Value.AutomationName}"
+                           AutomationProperties.AutomationId="{DynamicResource Shell.StatusBar.Company.Value.AutomationId}" />
+                <TextBlock Text="{DynamicResource Shell.StatusBar.Environment.Label}"
+                           Foreground="#AAAAAA"
+                           Margin="16,0,4,0"
+                           VerticalAlignment="Center"
+                           ToolTipService.ToolTip="{DynamicResource Shell.StatusBar.Environment.Label.ToolTip}"
+                           AutomationProperties.Name="{DynamicResource Shell.StatusBar.Environment.Label.AutomationName}"
+                           AutomationProperties.AutomationId="{DynamicResource Shell.StatusBar.Environment.Label.AutomationId}" />
+                <TextBlock Text="{Binding Environment}"
+                           Foreground="#CCCCCC"
+                           VerticalAlignment="Center"
+                           ToolTipService.ToolTip="{DynamicResource Shell.StatusBar.Environment.Value.ToolTip}"
+                           AutomationProperties.Name="{DynamicResource Shell.StatusBar.Environment.Value.AutomationName}"
+                           AutomationProperties.AutomationId="{DynamicResource Shell.StatusBar.Environment.Value.AutomationId}" />
+                <TextBlock Text="{DynamicResource Shell.StatusBar.Server.Label}"
+                           Foreground="#AAAAAA"
+                           Margin="16,0,4,0"
+                           VerticalAlignment="Center"
+                           ToolTipService.ToolTip="{DynamicResource Shell.StatusBar.Server.Label.ToolTip}"
+                           AutomationProperties.Name="{DynamicResource Shell.StatusBar.Server.Label.AutomationName}"
+                           AutomationProperties.AutomationId="{DynamicResource Shell.StatusBar.Server.Label.AutomationId}" />
+                <TextBlock Text="{Binding Server}"
+                           Foreground="#CCCCCC"
+                           VerticalAlignment="Center"
+                           ToolTipService.ToolTip="{DynamicResource Shell.StatusBar.Server.Value.ToolTip}"
+                           AutomationProperties.Name="{DynamicResource Shell.StatusBar.Server.Value.AutomationName}"
+                           AutomationProperties.AutomationId="{DynamicResource Shell.StatusBar.Server.Value.AutomationId}" />
+                <TextBlock Text="{DynamicResource Shell.StatusBar.Database.Label}"
+                           Foreground="#AAAAAA"
+                           Margin="16,0,4,0"
+                           VerticalAlignment="Center"
+                           ToolTipService.ToolTip="{DynamicResource Shell.StatusBar.Database.Label.ToolTip}"
+                           AutomationProperties.Name="{DynamicResource Shell.StatusBar.Database.Label.AutomationName}"
+                           AutomationProperties.AutomationId="{DynamicResource Shell.StatusBar.Database.Label.AutomationId}" />
+                <TextBlock Text="{Binding Database}"
+                           Foreground="#CCCCCC"
+                           VerticalAlignment="Center"
+                           ToolTipService.ToolTip="{DynamicResource Shell.StatusBar.Database.Value.ToolTip}"
+                           AutomationProperties.Name="{DynamicResource Shell.StatusBar.Database.Value.AutomationName}"
+                           AutomationProperties.AutomationId="{DynamicResource Shell.StatusBar.Database.Value.AutomationId}" />
+                <TextBlock Text="{DynamicResource Shell.StatusBar.User.Label}"
+                           Foreground="#AAAAAA"
+                           Margin="16,0,4,0"
+                           VerticalAlignment="Center"
+                           ToolTipService.ToolTip="{DynamicResource Shell.StatusBar.User.Label.ToolTip}"
+                           AutomationProperties.Name="{DynamicResource Shell.StatusBar.User.Label.AutomationName}"
+                           AutomationProperties.AutomationId="{DynamicResource Shell.StatusBar.User.Label.AutomationId}" />
+                <TextBlock Text="{Binding User}"
+                           Foreground="#CCCCCC"
+                           VerticalAlignment="Center"
+                           ToolTipService.ToolTip="{DynamicResource Shell.StatusBar.User.Value.ToolTip}"
+                           AutomationProperties.Name="{DynamicResource Shell.StatusBar.User.Value.AutomationName}"
+                           AutomationProperties.AutomationId="{DynamicResource Shell.StatusBar.User.Value.AutomationId}" />
+                <TextBlock Text="{DynamicResource Shell.StatusBar.UtcTime.Label}"
+                           Foreground="#AAAAAA"
+                           Margin="16,0,4,0"
+                           VerticalAlignment="Center"
+                           ToolTipService.ToolTip="{DynamicResource Shell.StatusBar.UtcTime.Label.ToolTip}"
+                           AutomationProperties.Name="{DynamicResource Shell.StatusBar.UtcTime.Label.AutomationName}"
+                           AutomationProperties.AutomationId="{DynamicResource Shell.StatusBar.UtcTime.Label.AutomationId}" />
+                <TextBlock Text="{Binding UtcTime}"
+                           Foreground="#CCCCCC"
+                           VerticalAlignment="Center"
+                           ToolTipService.ToolTip="{DynamicResource Shell.StatusBar.UtcTime.Value.ToolTip}"
+                           AutomationProperties.Name="{DynamicResource Shell.StatusBar.UtcTime.Value.AutomationName}"
+                           AutomationProperties.AutomationId="{DynamicResource Shell.StatusBar.UtcTime.Value.AutomationId}" />
             </StackPanel>
         </DockPanel>
     </Border>

--- a/YasGMP.Wpf/Resources/ShellStrings.en.resx
+++ b/YasGMP.Wpf/Resources/ShellStrings.en.resx
@@ -1884,4 +1884,130 @@
   <data name="Module.ExternalServicers.ToolTip.DigitalSignature" xml:space="preserve">
     <value>Digital signatures are captured via the e-signature workflow.</value>
   </data>
+  <data name="Shell.StatusBar.Container.ToolTip" xml:space="preserve">
+    <value>Displays YasGMP connection and session metadata.</value>
+  </data>
+  <data name="Shell.StatusBar.Container.AutomationName" xml:space="preserve">
+    <value>Shell status bar</value>
+  </data>
+  <data name="Shell.StatusBar.Status.Label" xml:space="preserve">
+    <value>Status:</value>
+  </data>
+  <data name="Shell.StatusBar.Status.Label.ToolTip" xml:space="preserve">
+    <value>Describes the current shell operation status.</value>
+  </data>
+  <data name="Shell.StatusBar.Status.Label.AutomationName" xml:space="preserve">
+    <value>Status label</value>
+  </data>
+  <data name="Shell.StatusBar.Status.Value.ToolTip" xml:space="preserve">
+    <value>Displays the current shell status message.</value>
+  </data>
+  <data name="Shell.StatusBar.Status.Value.AutomationName" xml:space="preserve">
+    <value>Status value</value>
+  </data>
+  <data name="Shell.StatusBar.ActiveModule.Label" xml:space="preserve">
+    <value>Active module:</value>
+  </data>
+  <data name="Shell.StatusBar.ActiveModule.Label.ToolTip" xml:space="preserve">
+    <value>Indicates which module currently has focus.</value>
+  </data>
+  <data name="Shell.StatusBar.ActiveModule.Label.AutomationName" xml:space="preserve">
+    <value>Active module label</value>
+  </data>
+  <data name="Shell.StatusBar.ActiveModule.Value.ToolTip" xml:space="preserve">
+    <value>Displays the name of the active module.</value>
+  </data>
+  <data name="Shell.StatusBar.ActiveModule.Value.AutomationName" xml:space="preserve">
+    <value>Active module value</value>
+  </data>
+  <data name="Shell.StatusBar.Company.Label" xml:space="preserve">
+    <value>Company:</value>
+  </data>
+  <data name="Shell.StatusBar.Company.Label.ToolTip" xml:space="preserve">
+    <value>Shows the connected company context.</value>
+  </data>
+  <data name="Shell.StatusBar.Company.Label.AutomationName" xml:space="preserve">
+    <value>Company label</value>
+  </data>
+  <data name="Shell.StatusBar.Company.Value.ToolTip" xml:space="preserve">
+    <value>Displays the connected company.</value>
+  </data>
+  <data name="Shell.StatusBar.Company.Value.AutomationName" xml:space="preserve">
+    <value>Company value</value>
+  </data>
+  <data name="Shell.StatusBar.Environment.Label" xml:space="preserve">
+    <value>Environment:</value>
+  </data>
+  <data name="Shell.StatusBar.Environment.Label.ToolTip" xml:space="preserve">
+    <value>Shows the current runtime environment.</value>
+  </data>
+  <data name="Shell.StatusBar.Environment.Label.AutomationName" xml:space="preserve">
+    <value>Environment label</value>
+  </data>
+  <data name="Shell.StatusBar.Environment.Value.ToolTip" xml:space="preserve">
+    <value>Displays the active runtime environment.</value>
+  </data>
+  <data name="Shell.StatusBar.Environment.Value.AutomationName" xml:space="preserve">
+    <value>Environment value</value>
+  </data>
+  <data name="Shell.StatusBar.Server.Label" xml:space="preserve">
+    <value>Server:</value>
+  </data>
+  <data name="Shell.StatusBar.Server.Label.ToolTip" xml:space="preserve">
+    <value>Identifies the database server host.</value>
+  </data>
+  <data name="Shell.StatusBar.Server.Label.AutomationName" xml:space="preserve">
+    <value>Server label</value>
+  </data>
+  <data name="Shell.StatusBar.Server.Value.ToolTip" xml:space="preserve">
+    <value>Displays the connected database server.</value>
+  </data>
+  <data name="Shell.StatusBar.Server.Value.AutomationName" xml:space="preserve">
+    <value>Server value</value>
+  </data>
+  <data name="Shell.StatusBar.Database.Label" xml:space="preserve">
+    <value>Database:</value>
+  </data>
+  <data name="Shell.StatusBar.Database.Label.ToolTip" xml:space="preserve">
+    <value>Identifies the database name in use.</value>
+  </data>
+  <data name="Shell.StatusBar.Database.Label.AutomationName" xml:space="preserve">
+    <value>Database label</value>
+  </data>
+  <data name="Shell.StatusBar.Database.Value.ToolTip" xml:space="preserve">
+    <value>Displays the connected database name.</value>
+  </data>
+  <data name="Shell.StatusBar.Database.Value.AutomationName" xml:space="preserve">
+    <value>Database value</value>
+  </data>
+  <data name="Shell.StatusBar.User.Label" xml:space="preserve">
+    <value>User:</value>
+  </data>
+  <data name="Shell.StatusBar.User.Label.ToolTip" xml:space="preserve">
+    <value>Identifies the authenticated user.</value>
+  </data>
+  <data name="Shell.StatusBar.User.Label.AutomationName" xml:space="preserve">
+    <value>User label</value>
+  </data>
+  <data name="Shell.StatusBar.User.Value.ToolTip" xml:space="preserve">
+    <value>Displays the authenticated user.</value>
+  </data>
+  <data name="Shell.StatusBar.User.Value.AutomationName" xml:space="preserve">
+    <value>User value</value>
+  </data>
+  <data name="Shell.StatusBar.UtcTime.Label" xml:space="preserve">
+    <value>UTC time:</value>
+  </data>
+  <data name="Shell.StatusBar.UtcTime.Label.ToolTip" xml:space="preserve">
+    <value>Shows the coordinated universal time.</value>
+  </data>
+  <data name="Shell.StatusBar.UtcTime.Label.AutomationName" xml:space="preserve">
+    <value>UTC time label</value>
+  </data>
+  <data name="Shell.StatusBar.UtcTime.Value.ToolTip" xml:space="preserve">
+    <value>Displays the current coordinated universal time.</value>
+  </data>
+  <data name="Shell.StatusBar.UtcTime.Value.AutomationName" xml:space="preserve">
+    <value>UTC time value</value>
+  </data>
 </root>

--- a/YasGMP.Wpf/Resources/ShellStrings.hr.resx
+++ b/YasGMP.Wpf/Resources/ShellStrings.hr.resx
@@ -1887,4 +1887,130 @@
   <data name="Module.ExternalServicers.ToolTip.DigitalSignature" xml:space="preserve">
     <value>Digital signatures are captured via the e-signature workflow.</value>
   </data>
+  <data name="Shell.StatusBar.Container.ToolTip" xml:space="preserve">
+    <value>Prikazuje YasGMP metapodatke veze i sesije.</value>
+  </data>
+  <data name="Shell.StatusBar.Container.AutomationName" xml:space="preserve">
+    <value>Statusna traka ljuske</value>
+  </data>
+  <data name="Shell.StatusBar.Status.Label" xml:space="preserve">
+    <value>Status:</value>
+  </data>
+  <data name="Shell.StatusBar.Status.Label.ToolTip" xml:space="preserve">
+    <value>Opisuje trenutačno stanje ljuske.</value>
+  </data>
+  <data name="Shell.StatusBar.Status.Label.AutomationName" xml:space="preserve">
+    <value>Oznaka statusa</value>
+  </data>
+  <data name="Shell.StatusBar.Status.Value.ToolTip" xml:space="preserve">
+    <value>Prikazuje trenutačnu statusnu poruku ljuske.</value>
+  </data>
+  <data name="Shell.StatusBar.Status.Value.AutomationName" xml:space="preserve">
+    <value>Vrijednost statusa</value>
+  </data>
+  <data name="Shell.StatusBar.ActiveModule.Label" xml:space="preserve">
+    <value>Aktivni modul:</value>
+  </data>
+  <data name="Shell.StatusBar.ActiveModule.Label.ToolTip" xml:space="preserve">
+    <value>Označava koji modul je trenutačno u fokusu.</value>
+  </data>
+  <data name="Shell.StatusBar.ActiveModule.Label.AutomationName" xml:space="preserve">
+    <value>Oznaka aktivnog modula</value>
+  </data>
+  <data name="Shell.StatusBar.ActiveModule.Value.ToolTip" xml:space="preserve">
+    <value>Prikazuje naziv aktivnog modula.</value>
+  </data>
+  <data name="Shell.StatusBar.ActiveModule.Value.AutomationName" xml:space="preserve">
+    <value>Vrijednost aktivnog modula</value>
+  </data>
+  <data name="Shell.StatusBar.Company.Label" xml:space="preserve">
+    <value>Tvrtka:</value>
+  </data>
+  <data name="Shell.StatusBar.Company.Label.ToolTip" xml:space="preserve">
+    <value>Prikazuje povezani kontekst tvrtke.</value>
+  </data>
+  <data name="Shell.StatusBar.Company.Label.AutomationName" xml:space="preserve">
+    <value>Oznaka tvrtke</value>
+  </data>
+  <data name="Shell.StatusBar.Company.Value.ToolTip" xml:space="preserve">
+    <value>Prikazuje povezanu tvrtku.</value>
+  </data>
+  <data name="Shell.StatusBar.Company.Value.AutomationName" xml:space="preserve">
+    <value>Vrijednost tvrtke</value>
+  </data>
+  <data name="Shell.StatusBar.Environment.Label" xml:space="preserve">
+    <value>Okruženje:</value>
+  </data>
+  <data name="Shell.StatusBar.Environment.Label.ToolTip" xml:space="preserve">
+    <value>Prikazuje trenutačno radno okruženje.</value>
+  </data>
+  <data name="Shell.StatusBar.Environment.Label.AutomationName" xml:space="preserve">
+    <value>Oznaka okruženja</value>
+  </data>
+  <data name="Shell.StatusBar.Environment.Value.ToolTip" xml:space="preserve">
+    <value>Prikazuje aktivno radno okruženje.</value>
+  </data>
+  <data name="Shell.StatusBar.Environment.Value.AutomationName" xml:space="preserve">
+    <value>Vrijednost okruženja</value>
+  </data>
+  <data name="Shell.StatusBar.Server.Label" xml:space="preserve">
+    <value>Poslužitelj:</value>
+  </data>
+  <data name="Shell.StatusBar.Server.Label.ToolTip" xml:space="preserve">
+    <value>Identificira poslužitelja baze podataka.</value>
+  </data>
+  <data name="Shell.StatusBar.Server.Label.AutomationName" xml:space="preserve">
+    <value>Oznaka poslužitelja</value>
+  </data>
+  <data name="Shell.StatusBar.Server.Value.ToolTip" xml:space="preserve">
+    <value>Prikazuje povezani poslužitelj baze podataka.</value>
+  </data>
+  <data name="Shell.StatusBar.Server.Value.AutomationName" xml:space="preserve">
+    <value>Vrijednost poslužitelja</value>
+  </data>
+  <data name="Shell.StatusBar.Database.Label" xml:space="preserve">
+    <value>Baza podataka:</value>
+  </data>
+  <data name="Shell.StatusBar.Database.Label.ToolTip" xml:space="preserve">
+    <value>Identificira korištenu bazu podataka.</value>
+  </data>
+  <data name="Shell.StatusBar.Database.Label.AutomationName" xml:space="preserve">
+    <value>Oznaka baze podataka</value>
+  </data>
+  <data name="Shell.StatusBar.Database.Value.ToolTip" xml:space="preserve">
+    <value>Prikazuje naziv povezane baze podataka.</value>
+  </data>
+  <data name="Shell.StatusBar.Database.Value.AutomationName" xml:space="preserve">
+    <value>Vrijednost baze podataka</value>
+  </data>
+  <data name="Shell.StatusBar.User.Label" xml:space="preserve">
+    <value>Korisnik:</value>
+  </data>
+  <data name="Shell.StatusBar.User.Label.ToolTip" xml:space="preserve">
+    <value>Identificira prijavljenog korisnika.</value>
+  </data>
+  <data name="Shell.StatusBar.User.Label.AutomationName" xml:space="preserve">
+    <value>Oznaka korisnika</value>
+  </data>
+  <data name="Shell.StatusBar.User.Value.ToolTip" xml:space="preserve">
+    <value>Prikazuje prijavljenog korisnika.</value>
+  </data>
+  <data name="Shell.StatusBar.User.Value.AutomationName" xml:space="preserve">
+    <value>Vrijednost korisnika</value>
+  </data>
+  <data name="Shell.StatusBar.UtcTime.Label" xml:space="preserve">
+    <value>UTC vrijeme:</value>
+  </data>
+  <data name="Shell.StatusBar.UtcTime.Label.ToolTip" xml:space="preserve">
+    <value>Prikazuje koordinirano univerzalno vrijeme.</value>
+  </data>
+  <data name="Shell.StatusBar.UtcTime.Label.AutomationName" xml:space="preserve">
+    <value>Oznaka UTC vremena</value>
+  </data>
+  <data name="Shell.StatusBar.UtcTime.Value.ToolTip" xml:space="preserve">
+    <value>Prikazuje trenutačno koordinirano univerzalno vrijeme.</value>
+  </data>
+  <data name="Shell.StatusBar.UtcTime.Value.AutomationName" xml:space="preserve">
+    <value>Vrijednost UTC vremena</value>
+  </data>
 </root>

--- a/YasGMP.Wpf/Resources/Strings.xaml
+++ b/YasGMP.Wpf/Resources/Strings.xaml
@@ -106,4 +106,22 @@
     <sys:String x:Key="Module.Attachments.Button.PickFiles.AutomationId">Attachments.Toolbar.PickFiles</sys:String>
     <sys:String x:Key="Module.Scheduling.Button.ExecuteNow.AutomationId">Scheduling.Toolbar.ExecuteNow</sys:String>
     <sys:String x:Key="Module.Scheduling.Button.Acknowledge.AutomationId">Scheduling.Toolbar.Acknowledge</sys:String>
+
+    <sys:String x:Key="Shell.StatusBar.Container.AutomationId">StatusBar.Container</sys:String>
+    <sys:String x:Key="Shell.StatusBar.Status.Label.AutomationId">StatusBar.Status.Label</sys:String>
+    <sys:String x:Key="Shell.StatusBar.Status.Value.AutomationId">StatusBar.Status.Value</sys:String>
+    <sys:String x:Key="Shell.StatusBar.ActiveModule.Label.AutomationId">StatusBar.ActiveModule.Label</sys:String>
+    <sys:String x:Key="Shell.StatusBar.ActiveModule.Value.AutomationId">StatusBar.ActiveModule.Value</sys:String>
+    <sys:String x:Key="Shell.StatusBar.Company.Label.AutomationId">StatusBar.Company.Label</sys:String>
+    <sys:String x:Key="Shell.StatusBar.Company.Value.AutomationId">StatusBar.Company.Value</sys:String>
+    <sys:String x:Key="Shell.StatusBar.Environment.Label.AutomationId">StatusBar.Environment.Label</sys:String>
+    <sys:String x:Key="Shell.StatusBar.Environment.Value.AutomationId">StatusBar.Environment.Value</sys:String>
+    <sys:String x:Key="Shell.StatusBar.Server.Label.AutomationId">StatusBar.Server.Label</sys:String>
+    <sys:String x:Key="Shell.StatusBar.Server.Value.AutomationId">StatusBar.Server.Value</sys:String>
+    <sys:String x:Key="Shell.StatusBar.Database.Label.AutomationId">StatusBar.Database.Label</sys:String>
+    <sys:String x:Key="Shell.StatusBar.Database.Value.AutomationId">StatusBar.Database.Value</sys:String>
+    <sys:String x:Key="Shell.StatusBar.User.Label.AutomationId">StatusBar.User.Label</sys:String>
+    <sys:String x:Key="Shell.StatusBar.User.Value.AutomationId">StatusBar.User.Value</sys:String>
+    <sys:String x:Key="Shell.StatusBar.UtcTime.Label.AutomationId">StatusBar.UtcTime.Label</sys:String>
+    <sys:String x:Key="Shell.StatusBar.UtcTime.Value.AutomationId">StatusBar.UtcTime.Value</sys:String>
 </ResourceDictionary>

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -54,6 +54,7 @@
   - 2025-09-24: Batch 0 rerun inside container confirmed `.NET 9` CLI is still missing; all `dotnet` commands fail immediately. Remains a prerequisite before module CRUD refactors can progress.
 
 ## Notes
+- 2026-02-08: Shell status bar layout now localizes labels/tooltips/automation metadata for company, environment, server, database, user, and UTC timestamp fields, surfacing the bindings through the redesigned control while dotnet restore/build/smoke remain blocked by the missing CLI.
 - 2026-02-07: Shell status bar now resolves company, environment, database, server, user, and UTC clock metadata via revived DatabaseOptions + configuration bindings and a dispatcher-driven timer while dotnet restore/build/smoke remain blocked by the missing CLI.
 - 2026-02-06: Added layout persistence regression tests covering DatabaseService helpers, DockLayoutPersistenceService forwarding, and ShellLayoutController reset ordering so SQL payloads and reset/save sequencing stay exercised even while the dotnet CLI is unavailable in this container.
 - 2026-02-05: Shell layout reset now clears the persisted snapshot via DockLayoutPersistenceService.ResetAsync before saving the default layout so the database state stays aligned with the restored UI; dotnet CLI remains unavailable for restore/build validation in this container.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -68,7 +68,8 @@
       "name": "Shell foundation",
       "status": "pending",
       "notes": [
-        "2026-02-05: Shell layout reset now clears persisted database snapshot via DockLayoutPersistenceService.ResetAsync before saving defaults; awaiting dotnet CLI to validate via build/smoke."
+        "2026-02-05: Shell layout reset now clears persisted database snapshot via DockLayoutPersistenceService.ResetAsync before saving defaults; awaiting dotnet CLI to validate via build/smoke.",
+        "2026-02-08: Status bar control now renders company/environment/server/database/user/UTC metadata with localized captions, tooltips, and automation names bound to the view-model while dotnet CLI access remains blocked."
       ]
     },
     {
@@ -127,6 +128,7 @@
   "lastCommitSummary": "docs: expand CRUD adapter XML guidance",
   "notes": [
     "2026-02-06: Added regression tests for DatabaseService layout helpers, DockLayoutPersistenceService forwarding, and ShellLayoutController reset sequencing so SQL payloads stay covered while dotnet tooling remains unavailable.",
+    "2026-02-08: Shell status bar layout/localization update surfaces metadata fields with accessibility bindings while dotnet CLI access is still missing.",
     "2026-02-03: DatabaseService now exposes layout persistence helpers so the WPF shell can store per-user dock/ribbon arrangements even though dotnet restore/build remain blocked by the missing CLI.",
     "2025-10-02: WPF AuditDashboardDocument view mirrors the MAUI filters/exports with busy overlay + App.xaml DataTemplate wiring while dotnet restore/build remain blocked by the missing CLI.",
     "2026-02-01: WPF dialog, file picker, platform, and dispatcher services now document MAUI parity limits, localization responsibilities, and migration guidance; dotnet restore/build/smoke still blocked without the CLI.",


### PR DESCRIPTION
## Summary
- Redesigned the shell status bar layout to surface status, module, and session metadata with localized captions, tooltips, and accessibility bindings.
- Added English and Croatian resource entries plus automation identifiers for the new status bar fields.
- Recorded the status bar localization work in the codex plan and progress logs.

## Testing
- `dotnet restore yasgmp.sln` *(fails: dotnet CLI unavailable in container)*
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj` *(fails: dotnet CLI unavailable in container)*
- `dotnet build yasgmp.csproj -f net9.0-windows10.0.19041.0` *(fails: dotnet CLI unavailable in container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence).
- [ ] MAUI builds/runs unaffected.
- [ ] Shared AppCore extraction complete where required; adapters compiled.
- [ ] ModulesPane lists every module and opens feature-parity editors.
- [ ] B1 FormModes & command enablement wired across editors.
- [ ] CFL pickers + Golden Arrow navigation working.
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end.
- [ ] Warehouse ledger with running balance and alerts.
- [ ] Audit surfacing + e-signature prompts on critical saves.
- [ ] Attachments DB-backed with upload/preview/download.
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented.
- [ ] Smoke tests succeed and log output.
- [ ] `README_WPF_SHELL.md` and `/docs/WPF_MAPPING.md` kept current.

------
https://chatgpt.com/codex/tasks/task_e_68e509dced948331b5b6d2d544c32a10