### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/YasGMP.Wpf/Shell/ModulesPane.xaml
+++ b/YasGMP.Wpf/Shell/ModulesPane.xaml
@@ -11,6 +11,9 @@
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
                     <Expander Header="{Binding Header}"
+                              ToolTip="{Binding ToolTip}"
+                              AutomationProperties.Name="{Binding AutomationName}"
+                              AutomationProperties.AutomationId="{Binding AutomationId}"
                               Margin="0,0,0,8"
                               IsExpanded="True">
                         <ItemsControl ItemsSource="{Binding Modules}">
@@ -21,7 +24,9 @@
                                             CommandParameter="{Binding}"
                                             Margin="12,4,0,4"
                                             HorizontalContentAlignment="Left"
-                                            ToolTip="{Binding ToolTip}" />
+                                            ToolTip="{Binding ToolTip}"
+                                            AutomationProperties.Name="{Binding AutomationName}"
+                                            AutomationProperties.AutomationId="{Binding AutomationId}" />
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -21,6 +21,7 @@
 - **B1 — Shell foundation** (Ribbon, Docking, StatusBar, FormMode state machine) — [ ] todo
   - 2026-01-25: Documented B1FormDocumentViewModel command/state surface so derived modules inherit SAP B1 toolbar, audit, and busy-state guidance.
   - 2026-02-10: Modules pane groups/links now source localized headers, tooltips, automation names/ids through ILocalizationService subscriptions so culture switches update without rebuilding the tree; awaiting SDK install to validate via build/smoke.
+  - 2026-02-11: ModulesPane XAML now binds group expanders and module buttons to the localized headers/tooltips/automation metadata exposed by their view-models so accessibility/name/id updates propagate directly through the UI tree.
 - **B2 — Cross-cutting** (Attachments DB, E-Signature, Audit) — [~] in-progress *(e-sign capture now spans Assets, Components, Warehouses, Incidents, CAPA, Change Control, Validations, Scheduled Jobs, Suppliers, External Servicers, Users, and Work Orders; WPF adapters and AppCore services propagate optional signature metadata through to the database, falling back to the legacy hash generator only when metadata is missing; the WPF dialog service now emits audit events on capture/persist while broader audit surfacing remains gated on SDK access)*
 - **B3 — Editor framework** (templates, host, unsaved-guard) — [ ] todo
 - **B4+ — Module rollout:**

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -73,7 +73,8 @@
         "2026-02-05: Shell layout reset now clears persisted database snapshot via DockLayoutPersistenceService.ResetAsync before saving defaults; awaiting dotnet CLI to validate via build/smoke.",
         "2026-02-08: Status bar control now renders company/environment/server/database/user/UTC metadata with localized captions, tooltips, and automation names bound to the view-model while dotnet CLI access remains blocked.",
         "2026-02-09: MainWindowViewModel now applies session/configuration metadata to the status bar via injected IUserSession/DatabaseOptions and new WPF tests cover EN↔HR localization/tooltips while dotnet CLI remains unavailable.",
-        "2026-02-10: Modules pane groups and links now surface localized headers, tooltips, automation names, and automation ids through ILocalizationService subscriptions so culture switches update dynamically; build/smoke pending SDK install."
+        "2026-02-10: Modules pane groups and links now surface localized headers, tooltips, automation names, and automation ids through ILocalizationService subscriptions so culture switches update dynamically; build/smoke pending SDK install.",
+        "2026-02-11: ModulesPane XAML bindings now forward the localized headers/tooltips/automation names/ids from ModuleGroupViewModel and ModuleLinkViewModel onto the expanders/buttons so Accessibility Insights/FlaUI can read the updated metadata immediately."
       ]
     },
     {


### PR DESCRIPTION
## Summary
- bind module group expanders and module buttons to the new localized header, tooltip, and automation metadata so language switches update UIA data
- refresh codex plan/progress artifacts to capture the modules pane binding work

## Testing
- `dotnet restore yasgmp.sln` *(fails: `dotnet` CLI not available in container)*
- `dotnet build YasGMP.Wpf/YasGMP.Wpf.csproj` *(fails: `dotnet` CLI not available in container)*
- WPF smoke harness *(blocked: .NET tooling not installed in container)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence).
- [ ] MAUI builds/runs unaffected.
- [ ] Shared AppCore extraction complete where required; adapters compiled.
- [ ] ModulesPane lists every module and opens feature-parity editors.
- [ ] B1 FormModes & command enablement wired across editors.
- [ ] CFL pickers + Golden Arrow navigation working.
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end.
- [ ] Warehouse ledger with running balance and alerts.
- [ ] Audit surfacing + e-signature prompts on critical saves.
- [ ] Attachments DB-backed with upload/preview/download.
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented.
- [ ] Smoke tests succeed and log output.
- [ ] `README_WPF_SHELL.md` and `/docs/WPF_MAPPING.md` kept current.


------
https://chatgpt.com/codex/tasks/task_e_68e5fa7953288331979bbad12fbc7ba4