### PR TITLE
WPF Shell (.NET 9) + Full YasGMP Integration (B1-style Docking/Ribbon)

### DIFF
--- a/.github/workflows/wpf-tests.yml
+++ b/.github/workflows/wpf-tests.yml
@@ -1,0 +1,53 @@
+name: WPF Smoke Tests
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+
+jobs:
+  build-and-test:
+    name: Build WPF shell and run smoke suite
+    runs-on: windows-latest
+    env:
+      DOTNET_NOLOGO: true
+      YASGMP_SMOKE: "1"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 9 SDK
+        id: setup_dotnet_9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+        continue-on-error: true
+
+      - name: Setup .NET 8 SDK (fallback)
+        if: steps.setup_dotnet_9.outcome == 'failure'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore solution
+        run: dotnet restore yasgmp.sln
+
+      - name: Build solution (Release)
+        run: dotnet build yasgmp.sln -c Release --no-restore
+
+      - name: Run WPF smoke tests
+        run: >-
+          dotnet test YasGMP.Wpf.Smoke/YasGMP.Wpf.Smoke.csproj
+          -c Release
+          --no-build
+          --logger "trx;LogFileName=wpf-smoke.trx"
+          --results-directory "${{ github.workspace }}\\artifacts\\test-results"
+
+      - name: Upload smoke test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wpf-smoke-test-results
+          path: artifacts/test-results
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ dotnet build
 
 Refer to platform-specific documentation for signing, deployment, and device setup.
 
+### Test matrix
+
+All contributors should execute the full regression suite before opening a pull request:
+
+```bash
+dotnet test YasGMP.Wpf.Smoke/YasGMP.Wpf.Smoke.csproj -c Release --logger trx
+```
+
+The smoke harness launches the WPF shell, drives the FlaUI automation flows, and emits a `.trx` log that can be attached to PRs
+and inspected in CI artifacts. Set `YASGMP_SMOKE=0` only when diagnosing local infrastructure issues that prevent UI automation
+from launching.
+
 ## WPF desktop shell
 
 `YasGMP.Wpf` targets `net9.0-windows10.0.19041.0` (see `YasGMP.Wpf/YasGMP.Wpf.csproj`) and serves as the Windows-only desktop shell. Its `App.xaml.cs` bootstraps the same generic host, configuration, and DI container as the MAUI client, reusing the shared services that now live in the `YasGMP.AppCore` library. Refer to [README_WPF_SHELL.md](README_WPF_SHELL.md) for detailed setup, layout management, and docking workflows. Shared services together with the dock layout persistence service (`YasGMP.Wpf/Services/DockLayoutPersistenceService.cs`) ensure that saved layouts travel between the WPF shell and the MAUI app so both environments stay aligned.

--- a/docs/codex_plan.md
+++ b/docs/codex_plan.md
@@ -19,6 +19,7 @@
 ## Batches
 - **B0 — Environment stabilization** (SDKs, NuGets, XAML namespaces) — **blocked** *(no `dotnet` CLI)*
   - 2025-10-07: Reconfirmed CLI absence this run; planning next increment around static analysis, documentation refresh, and schema review until installation is possible.
+  - 2025-10-08: Authored `WPF Smoke Tests` GitHub Actions workflow to run restore/build/FlaUI smoke automation on `windows-latest` using .NET 9 when available (falls back to .NET 8). Local validation remains blocked because `dotnet --info` still reports `command not found`.
 - **B1 — Shell foundation** (Ribbon, Docking, StatusBar, FormMode state machine) — [ ] todo
   - 2026-01-25: Documented B1FormDocumentViewModel command/state surface so derived modules inherit SAP B1 toolbar, audit, and busy-state guidance.
   - 2026-02-10: Modules pane groups/links now source localized headers, tooltips, automation names/ids through ILocalizationService subscriptions so culture switches update without rebuilding the tree; awaiting SDK install to validate via build/smoke.

--- a/docs/codex_progress.json
+++ b/docs/codex_progress.json
@@ -144,6 +144,7 @@
   "lastCommitSummary": "docs: expand CRUD adapter XML guidance",
   "notes": [
     "2026-02-06: Added regression tests for DatabaseService layout helpers, DockLayoutPersistenceService forwarding, and ShellLayoutController reset sequencing so SQL payloads stay covered while dotnet tooling remains unavailable.",
+    "2025-10-08: Authored GitHub Actions workflow 'WPF Smoke Tests' to run restore/build/FlaUI smoke automation on windows-latest using .NET 9 when available (falls back to .NET 8). Local CLI validation still blocked because dotnet --info returns 'command not found'.",
     "2026-02-08: Shell status bar layout/localization update surfaces metadata fields with accessibility bindings while dotnet CLI access is still missing.",
     "2026-02-03: DatabaseService now exposes layout persistence helpers so the WPF shell can store per-user dock/ribbon arrangements even though dotnet restore/build remain blocked by the missing CLI.",
     "2025-10-02: WPF AuditDashboardDocument view mirrors the MAUI filters/exports with busy overlay + App.xaml DataTemplate wiring while dotnet restore/build remain blocked by the missing CLI.",


### PR DESCRIPTION
## Summary
- add a Windows-based GitHub Actions workflow that restores, builds, and runs the WPF FlaUI smoke automation with .NET 9 (falling back to .NET 8 when unavailable)
- surface the WPF smoke harness in the contributor test matrix and document the desktop automation prerequisites for CI and self-hosted agents
- log the CI workflow addition in the Codex plan/progress artifacts to preserve batch history

## Testing
- `dotnet --info` *(fails: command not found in container; .NET SDK unavailable here)*

## Acceptance Checklist
- [ ] WPF project builds/runs (Ribbon + AvalonDock + layout persistence)
- [ ] MAUI builds/runs unaffected
- [ ] Shared AppCore extraction complete where required; adapters compiled
- [ ] ModulesPane lists every module and opens feature-parity editors
- [ ] B1 FormModes & command enablement wired across editors
- [ ] CFL pickers + Golden Arrow navigation working
- [ ] Work Orders, Calibration, and Quality workflows usable end-to-end
- [ ] Warehouse ledger with running balance and alerts
- [ ] Audit surfacing + e-signature prompts on critical saves
- [ ] Attachments DB-backed with upload/preview/download
- [ ] Scheduled Jobs, Users/Roles (RBAC), Dashboard KPIs, Reports TODOs documented
- [ ] Smoke tests succeed and log output
- [ ] `README_WPF_SHELL.md` and `/docs/WPF_MAPPING.md` kept current

------
https://chatgpt.com/codex/tasks/task_e_68e6366d229883319c3d77ddc7605de1